### PR TITLE
Enable ght parsing of countries other than US

### DIFF
--- a/src/acquisition/ght/ght_update.py
+++ b/src/acquisition/ght/ght_update.py
@@ -75,6 +75,7 @@ from apiclient.discovery import build
 
 # first party
 from .google_health_trends import GHT
+from .google_health_trends import NO_LOCATION_STR
 import delphi.operations.secrets as secrets
 from delphi.utils.epidate import EpiDate
 import delphi.utils.epiweek as flu
@@ -248,7 +249,7 @@ LOCATIONS = [
 ]
 
 
-def update(locations, terms, first=None, last=None):
+def update(locations, terms, first=None, last=None, country='US'):
   # connect to the database
   u, p = secrets.db.epi
   cnx = mysql.connector.connect(user=u, password=p, database='epidata')
@@ -292,7 +293,7 @@ def update(locations, terms, first=None, last=None):
         while True:
           attempt += 1
           try:
-            result = ght.get_data(ew0, ew1, location, term2)
+            result = ght.get_data(ew0, ew1, location, term2, country)
             break
           except Exception as ex:
             if attempt >= 5:
@@ -305,7 +306,12 @@ def update(locations, terms, first=None, last=None):
         ew = result['start_week']
         num_missing = 0
         for v in values:
-          sql_data = (term, location, ew, v, v)
+          sql_location = location
+          if country != 'US':
+            sql_location = country + "_"
+            if location != NO_LOCATION_STR:
+              sql_location = sql_location + location
+          sql_data = (term, sql_location, ew, v, v)
           cur.execute(sql, sql_data)
           total_rows += 1
           if v == 0:
@@ -334,6 +340,7 @@ def main():
   parser.add_argument('term', action='store', type=str, default=None, help='term/query/topic (ex: all; /m/0cycc; "flu fever")')
   parser.add_argument('--first', '-f', default=None, type=int, help='first epiweek override')
   parser.add_argument('--last', '-l', default=None, type=int, help='last epiweek override')
+  parser.add_argument('--country', '-c', default='US', type=string, help='location country (ex: US; BR)')
   args = parser.parse_args()
 
   # sanity check
@@ -348,6 +355,8 @@ def main():
   # decide what to update
   if args.location.lower() == 'all':
     locations = LOCATIONS
+  elif args.location.lower() == 'none':
+    locations = [NO_LOCATION_STR]
   else:
     locations = args.location.upper().split(',')
   if args.term.lower() == 'all':
@@ -355,8 +364,15 @@ def main():
   else:
     terms = [args.term]
 
+  # country argument
+  # Check that country follows ISO 1366 Alpha-2 code. 
+  # See https://www.iso.org/obp/ui/#search.
+  if len(args.country) != 2:
+    raise Exception('country name must be two letters (ISO 1366 Alpha-2)')
+  country = args.country.upper()
+
   # run the update
-  update(locations, terms, first, last)
+  update(locations, terms, first, last, country)
 
 
 if __name__ == '__main__':

--- a/src/acquisition/ght/ght_update.py
+++ b/src/acquisition/ght/ght_update.py
@@ -306,8 +306,14 @@ def update(locations, terms, first=None, last=None, country='US'):
         ew = result['start_week']
         num_missing = 0
         for v in values:
+          # Default SQL location value for US country for backwards compatibility
+          # i.e. California's location is still stored as 'CA',
+          # and having location == 'US' is still stored as 'US'
           sql_location = location if location != NO_LOCATION_STR else country
+
+          # Change SQL location for non-US countries
           if country != 'US':
+            # Underscore added to distinguish countries from 2-letter US states
             sql_location = country + "_"
             if location != NO_LOCATION_STR:
               sql_location = sql_location + location

--- a/src/acquisition/ght/ght_update.py
+++ b/src/acquisition/ght/ght_update.py
@@ -306,7 +306,7 @@ def update(locations, terms, first=None, last=None, country='US'):
         ew = result['start_week']
         num_missing = 0
         for v in values:
-          sql_location = location
+          sql_location = location if location != NO_LOCATION_STR else country
           if country != 'US':
             sql_location = country + "_"
             if location != NO_LOCATION_STR:
@@ -340,7 +340,7 @@ def main():
   parser.add_argument('term', action='store', type=str, default=None, help='term/query/topic (ex: all; /m/0cycc; "flu fever")')
   parser.add_argument('--first', '-f', default=None, type=int, help='first epiweek override')
   parser.add_argument('--last', '-l', default=None, type=int, help='last epiweek override')
-  parser.add_argument('--country', '-c', default='US', type=string, help='location country (ex: US; BR)')
+  parser.add_argument('--country', '-c', default='US', type=str, help='location country (ex: US; BR)')
   args = parser.parse_args()
 
   # sanity check

--- a/src/acquisition/ght/google_health_trends.py
+++ b/src/acquisition/ght/google_health_trends.py
@@ -68,6 +68,9 @@ class GHT:
       'time_endDate': end_date,
       'timelineResolution': resolution,
     }
+    # We have a special check for the US for backwards compatibility.
+    # i.e. if the country is 'US' AND the location is 'US', just put the geo-restriction for country.
+    # In contrast, another country might have a sub-region with initials 'US' and we want the region restriction instead.
     if country == 'US':
       if location == 'US' or location == NO_LOCATION_STR:
         params['geoRestriction_country'] = 'US'

--- a/src/acquisition/ght/google_health_trends.py
+++ b/src/acquisition/ght/google_health_trends.py
@@ -31,6 +31,7 @@ from apiclient.discovery import build
 from delphi.utils.epidate import EpiDate
 import delphi.utils.epiweek as flu
 
+NO_LOCATION_STR = 'none'
 
 class GHT:
 
@@ -55,7 +56,7 @@ class GHT:
 
   # get data from Google APIs
   # see: https://developers.google.com/apis-explorer/#p/trends/v1beta/trends.getTimelinesForHealth
-  def get_data(self, start_week, end_week, location, term, resolution='week'):
+  def get_data(self, start_week, end_week, location, term, resolution='week', country='US'):
     start_date = GHT._ew2date(start_week)
     end_date = GHT._ew2date(end_week)
     num_weeks = flu.delta_epiweeks(start_week, end_week) + 1
@@ -67,10 +68,16 @@ class GHT:
       'time_endDate': end_date,
       'timelineResolution': resolution,
     }
-    if location == 'US':
-      params['geoRestriction_country'] = location
+    if country == 'US':
+      if location == 'US':
+        params['geoRestriction_country'] = location
+      else:
+        params['geoRestriction_region'] = 'US-' + location
     else:
-      params['geoRestriction_region'] = 'US-' + location
+      if location == NO_LOCATION_STR:
+        params['geoRestriction_country'] = country
+      else:
+        params['geoRestriction_region'] = country + '-' + location
 
     # make the API call
     data = self.service.getTimelinesForHealth(**params).execute()
@@ -90,6 +97,7 @@ class GHT:
       'end_week': end_week,
       'num_weeks': num_weeks,
       'location': location,
+      'country' : country,
       'term': term,
       'resolution': resolution,
       'data': data,

--- a/src/acquisition/ght/google_health_trends.py
+++ b/src/acquisition/ght/google_health_trends.py
@@ -69,8 +69,8 @@ class GHT:
       'timelineResolution': resolution,
     }
     if country == 'US':
-      if location == 'US':
-        params['geoRestriction_country'] = location
+      if location == 'US' or location == NO_LOCATION_STR:
+        params['geoRestriction_country'] = 'US'
       else:
         params['geoRestriction_region'] = 'US-' + location
     else:


### PR DESCRIPTION
Added optional two-letter country argument to ght_update, as required by the google health trends API.
Nothing should change for the US. Other countries are now saved in the server database with location "XX_" where XX denotes the ISO 1366 alpha-2 country code.