### PR TITLE
Fix a bug in deploying

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -100,6 +100,11 @@
       "dst": "[[auto_web]]/wiki/wiki_download.py",
       "add-header-comment": true
     },{
+      "type": "copy",
+      "src": "src/acquisition/wiki/wiki_util.py",
+      "dst": "[[auto_web]]/wiki/wiki_util.py",
+      "add-header-comment": true
+    },{
       "type": "move",
       "src": "src/acquisition/wiki/",
       "dst": "[[package]]/acquisition/wiki/",

--- a/src/acquisition/wiki/wiki_download.py
+++ b/src/acquisition/wiki/wiki_download.py
@@ -49,7 +49,7 @@ import time
 import os
 from sys import platform
 
-from wiki_util import Articles
+from . import wiki_util
 
 
 VERSION = 10
@@ -216,8 +216,8 @@ def run(secret, download_limit=None, job_limit=None, sleep_time=1, job_type=0, d
 
       # Use python to read the file and extract counts, if you want to use the original shell method, please use
       counts = {}
-      for language in Articles.available_languages:
-        lang2articles = {'en': Articles.en_articles, 'es': Articles.es_articles, 'pt': Articles.pt_articles}
+      for language in wiki_util.Articles.available_languages:
+        lang2articles = {'en': wiki_util.Articles.en_articles, 'es': wiki_util.Articles.es_articles, 'pt': wiki_util.Articles.pt_articles}
         articles = lang2articles[language]
         articles = sorted(articles)
         if debug_mode:


### PR DESCRIPTION
The error raised is `ImportError: No module named wiki_util`

I am always tortured by the python's path finding mechanism. So, here I use two methods to cope with this error.
1. copy the `wiki_util.py` file to the same directory with wiki_download.py
2. Use the same import format as shown in `wiki.py` (although this cannot run in my local environment) 