### PR TITLE
Add wiki language parameter to rest of clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Number of page visits for selected English, Influenza-related wikipedia articles
  - Data source: [Wikimedia](https://dumps.wikimedia.org/other/pagecounts-raw/)
  - Temporal Resolution: Hourly, daily, and weekly from 2007-12-09 (2007w50)
  - Spatial Resolution: N/A
- - Other resolution: By article ([54](labels/articles.txt))
+ - Other resolution: By article ([54](src/acquisition/wiki/wiki_util.py)), By language ([3](src/acquisition/wiki/wiki_util.py))
  - Open access
 
 
@@ -146,7 +146,7 @@ Require one of:
 ### Wiki Parameters
 
 Required:
- - `articles`: a `list` of [article](labels/articles.txt) labels
+ - `articles`: a `list` of [article](src/acquisition/wiki/wiki_util.py) labels
 
 Require one of:
  - `dates`: a `list` of dates
@@ -154,6 +154,7 @@ Require one of:
 
 Optional:
  - `hours`: a `list` of hours
+ - `language` : a single [two-letter language code](src/acquisition/wiki/wiki_util.py); defaults to `'en'`
 
 ### NIDSS-Flu Parameters
 

--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -186,7 +186,7 @@ Epidata <- (function() {
   }
 
   # Fetch Wikipedia access data
-  wiki <- function(articles, dates, epiweeks, hours) {
+  wiki <- function(articles, dates, epiweeks, hours, language='en') {
     # Check parameters
     if(missing(articles)) {
       stop('`articles` is required')
@@ -194,10 +194,19 @@ Epidata <- (function() {
     if(!xor(missing(dates), missing(epiweeks))) {
       stop('exactly one of `dates` and `epiweeks` is required')
     }
+    if(!missing(dates)) {
+      if(is.character(dates) && any(grepl(dates,"[0-9]{4}-[0-9]{2}-[0-9]{2}"))) {
+        stop('`dates` must use yyyymmdd format or Date class or POSIXlt class; hyphens are reserved for forming ranges.')
+      }
+      if(is.list(dates)) {
+        dates <- rapply(dates, format, format="%Y%m%d", classes=c("Date","POSIXlt"), how="replace")
+      }
+    }
     # Set up request
     params <- list(
       source = 'wiki',
-      articles = .list(articles)
+      articles = .list(articles),
+      language = language
     )
     if(!missing(dates)) {
       params$dates <- .list(dates)

--- a/src/client/delphi_epidata.coffee
+++ b/src/client/delphi_epidata.coffee
@@ -169,7 +169,7 @@ class Epidata
     _request(callback, params)
 
   # Fetch Wikipedia access data
-  @wiki: (callback, articles, dates, epiweeks, hours) ->
+  @wiki: (callback, articles, dates, epiweeks, hours, language='en') ->
     # Check parameters
     unless articles?
       throw { msg: '`articles` is required' }
@@ -179,6 +179,7 @@ class Epidata
     params =
       'source': 'wiki'
       'articles': _list(articles)
+      'language': language
     if dates?
       params.dates = _list(dates)
     if epiweeks?

--- a/src/client/delphi_epidata.js
+++ b/src/client/delphi_epidata.js
@@ -229,8 +229,11 @@ Notes:
       return _request(callback, params);
     };
 
-    Epidata.wiki = function(callback, articles, dates, epiweeks, hours) {
+    Epidata.wiki = function(callback, articles, dates, epiweeks, hours, language) {
       var params;
+      if (language == null) {
+        language = 'en';
+      }
       if (articles == null) {
         throw {
           msg: '`articles` is required'
@@ -243,7 +246,8 @@ Notes:
       }
       params = {
         'source': 'wiki',
-        'articles': _list(articles)
+        'articles': _list(articles),
+        'language': language
       };
       if (dates != null) {
         params.dates = _list(dates);


### PR DESCRIPTION
The language parameter in the wiki data source is already supported in the
python client. Add support for this parameter in the R, coffeescript, and js
clients.

Also, in R client, perform some checks to try to detect some alternative date
formats and generate errors or automatically convert to the expected format.