### PR TITLE
Change back to LOAD DATA INFILE in afhsb_sql.py

### DIFF
--- a/src/acquisition/afhsb/afhsb_sql.py
+++ b/src/acquisition/afhsb/afhsb_sql.py
@@ -20,7 +20,7 @@ def init_dmisid_table(sourcefile):
         );
         '''.format(table_name)
     populate_table_cmd = '''
-        LOAD DATA LOCAL INFILE '{}' 
+        LOAD DATA INFILE '{}'
         INTO TABLE {}
         FIELDS TERMINATED BY ',' 
         ENCLOSED BY '"'
@@ -53,7 +53,7 @@ def init_region_table(sourcefile):
         );
         '''.format(table_name)
     populate_table_cmd = '''
-        LOAD DATA LOCAL INFILE '{}' 
+        LOAD DATA INFILE '{}'
         INTO TABLE {}
         FIELDS TERMINATED BY ',' 
         ENCLOSED BY '"'
@@ -89,7 +89,7 @@ def init_raw_data(table_name, sourcefile):
         );
         '''.format(table_name)
     populate_table_cmd = '''
-        LOAD DATA LOCAL INFILE '{}' 
+        LOAD DATA INFILE '{}'
         INTO TABLE {}
         FIELDS TERMINATED BY ',' 
         ENCLOSED BY '"'


### PR DESCRIPTION
LOAD DATA LOCAL INFILE has security issues when used with untrusted servers and
is disabled by default in some versions of MariaDB.  Change back to using LOAD
DATA INFILE and ensure that afhsb_data directory is readable by the account
running the MariaDB server daemon.