### PR TITLE
Use tmp dir to work around LOAD INFILE restrictions; add helper funs

### DIFF
--- a/src/acquisition/afhsb/afhsb_sql.py
+++ b/src/acquisition/afhsb/afhsb_sql.py
@@ -164,6 +164,25 @@ def init_all_tables(datapath):
         agg_by_state(raw_table_name, state_table_name)
         agg_by_region(state_table_name, region_table_name)
 
+def dangerously_drop_all_afhsb_tables():
+    (u, p) = secrets.db.epi
+    cnx = connector.connect(user=u, passwd=p, database="epidata")
+    try:
+        cursor = cnx.cursor()
+        cursor.execute('''
+          DROP TABLE IF EXISTS `afhsb_00to13_raw`,
+                               `afhsb_00to13_region`,
+                               `afhsb_00to13_state`,
+                               `afhsb_13to17_raw`,
+                               `afhsb_13to17_region`,
+                               `afhsb_13to17_state`,
+                               `state2region_table`,
+                               `dmisid_table`;
+        ''')
+        cnx.commit() # (might do nothing; each DROP commits itself anyway)
+    finally:
+        cnx.close()
+
 def run_cmd(cmd):
     (u, p) = secrets.db.epi
     cnx = connector.connect(user=u, passwd=p, database="epidata")
@@ -173,6 +192,3 @@ def run_cmd(cmd):
         cnx.commit()
     finally:
         cnx.close()
-
-if __name__ == '__main__':
-    init_all_tables("/")

--- a/src/acquisition/afhsb/afhsb_update.py
+++ b/src/acquisition/afhsb/afhsb_update.py
@@ -1,10 +1,38 @@
+# standard library
+import argparse
+import tempfile
+import os
+import stat
+import shutil
+
 # first party
 from . import afhsb_sql
 
-DATAPATH = '/home/automation/afhsb_data'
+DEFAULT_DATAPATH = '/home/automation/afhsb_data'
 
 def main():
-    afhsb_sql.init_all_tables(DATAPATH)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--datapath', action='store', type=str, default=DEFAULT_DATAPATH, help='filepath to directory containing csv files to input into database')
+    args = parser.parse_args()
+    # MariaDB appears to refuse to LOAD DATA INFILE except on files under
+    # /var/lib/mysql (which seems dedicated to its own files) or /tmp; create a
+    # temporary directory, make rwx for automation & rx for mysql user, copy in
+    # (or alternatively, symlink --- unimplemented) args.datapath to the
+    # temporary directory, then run init_all_tables on this temporary datapath.
+    #   Set up temporary directory that will hold temporary datapath (initial
+    #   permissions are very restrictive):
+    tmp_datapath_parent_dir = tempfile.mkdtemp()
+    os.chmod(tmp_datapath_parent_dir, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP)
+    shutil.chown(tmp_datapath_parent_dir, group="mysql_automation")
+    #     (here, mysql_automation is a group with members {mysql,automation})
+    tmp_datapath = os.path.join(tmp_datapath_parent_dir, "afhsb_data")
+    #   Copy datapath to temporary datapath (initial permission of copy are
+    #   permissive, but require directory access, which was set appropriately
+    #   above):
+    shutil.copytree(args.datapath, tmp_datapath)
+    #   Run init_all_tables on temporary datapath:
+    afhsb_sql.init_all_tables(tmp_datapath)
+    #   (Temporary parent directory should be deleted automatically.)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
MariaDB appears to refuse to LOAD DATA INFILE except on files under
/var/lib/mysql (which seems dedicated to its own files) or /tmp; create a
temporary directory, make rwx for automation & rx for mysql user, copy in
args.datapath to the temporary directory, then run init_all_tables on this
temporary datapath.

Add afhsb_sql.dangerously_drop_all_afhsb_tables function to allow for more rapid
iteration on acquisition code, which stops when encountering a partially or
fully initialized set of AFHSB database tables.

Remove __main__ functionality from afhsb_sql.

Add argparse functionality to afhsb_update to allow for --datapath argument
to override default afhsb_data directory path.