### PR TITLE
fix docs/readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,14 +7,5 @@ For now, the API is documented in the repo's top-level
 
 The Epidata API is built and maintained by the Carnegie Mellon University
 [Delphi research group](https://delphi.cmu.edu/). Explore one way in which
-Delphi is responding to the pandemic by visiting the [COVID-19 Survey
-page](covid_survey.md).
-
-# ignore
-
-gotta love testing in production.
-
-visiting the [COVID-19 Survey page](covid_survey.md).
-
-visiting the [COVID-19 Survey
-page](covid_survey.md).
+Delphi is responding to the pandemic by visiting the
+[COVID-19 Survey page](covid_survey.md).


### PR DESCRIPTION
turns out *github* renders link text that spans lines, no problem. but 
*github pages* chokes on link text that span lines, instead linking to 
the raw markdown rather than the rendered html as intended.

lesson learned the hard way: one line per link.