### PR TITLE
covidcast_meta alias source as data_source

### DIFF
--- a/integrations/test_covidcast_meta.py
+++ b/integrations/test_covidcast_meta.py
@@ -52,7 +52,7 @@ class CovidcastMetaTests(unittest.TestCase):
         for tt in ('day', 'week'):
           for gt in ('hrr', 'msa'):
             expected.append({
-              'source': src,
+              'data_source': src,
               'signal': sig,
               'time_type': tt,
               'geo_type': gt,

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -973,11 +973,11 @@ function get_covidcast($source, $signal, $time_type, $geo_type, $time_values, $g
 function get_covidcast_meta() {
   // basic query info
   $table = '`covidcast` t';
-  $fields = "t.`source`, t.`signal`, t.`time_type`, t.`geo_type`, MIN(t.`time_value`) AS `min_time`, MAX(t.`time_value`) AS `max_time`, COUNT(DISTINCT `geo_value`) AS `num_locations`, min(`value`) AS `min_value`, max(`value`) AS `max_value`";
+  $fields = "t.`source` AS `data_source`, t.`signal`, t.`time_type`, t.`geo_type`, MIN(t.`time_value`) AS `min_time`, MAX(t.`time_value`) AS `max_time`, COUNT(DISTINCT `geo_value`) AS `num_locations`, min(`value`) AS `min_value`, max(`value`) AS `max_value`";
   $group = "t.`source`, t.`signal`, t.`time_type`, t.`geo_type`";
   $order = "t.`source` ASC, t.`signal` ASC, t.`time_type` ASC, t.`geo_type` ASC";
   // data type of each field
-  $fields_string = array('source', 'signal', 'time_type', 'geo_type');
+  $fields_string = array('data_source', 'signal', 'time_type', 'geo_type');
   $fields_int = array('min_time', 'max_time', 'num_locations');
   $fields_float = array('min_value', 'max_value');
   // the query


### PR DESCRIPTION
- this is consistent with the `data_source` parameter of the `covidcast` 
endpoint
- ✔ All 9 tests passed!