### PR TITLE
Add covidcast and covidcast_meta endpoints to clients

### DIFF
--- a/docs/api/covidcast.md
+++ b/docs/api/covidcast.md
@@ -77,7 +77,7 @@ See [this documentation](README.md) for details on specifying epiweeks, dates, a
 
 # Example URLs
 
-### Delphi's COVID-19 Surveillance Streams from Facebook Survey ILI on 2020-04-06 - 2010-04-10 (county 06001)
+### Delphi's COVID-19 Surveillance Streams from Facebook Survey ILI on 2020-04-06 - 2020-04-10 (county 06001)
 https://delphi.midas.cs.cmu.edu/epidata/api.php?source=covidcast&data_source=fb_survey&signal=ili&time_type=day&geo_type=county&time_values=20200406-20200410&geo_value=06001
 ```json
 {
@@ -102,4 +102,58 @@ https://delphi.midas.cs.cmu.edu/epidata/api.php?source=covidcast&data_source=fb_
 
 # Code Samples
 
-No client support yet.
+Libraries are available for [CoffeeScript](../../src/client/delphi_epidata.coffee), [JavaScript](../../src/client/delphi_epidata.js), [Python](../../src/client/delphi_epidata.py), and [R](../../src/client/delphi_epidata.R).
+The following samples show how to import the library and fetch Delphi's COVID-19 Surveillance Streams from Facebook Survey ILI for county 06001 and days `20200401` and `20200405-20200414` (11 days total).
+
+### CoffeeScript (in Node.js)
+
+````coffeescript
+# Import
+{Epidata} = require('./delphi_epidata')
+# Fetch data
+callback = (result, message, epidata) ->
+  console.log(result, message, epidata?.length)
+Epidata.covidcast(callback, 'fb_survey', 'ili', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001')
+````
+
+### JavaScript (in a web browser)
+
+````html
+<!-- Imports -->
+<script src="jquery.js"></script>
+<script src="delphi_epidata.js"></script>
+<!-- Fetch data -->
+<script>
+  var callback = function(result, message, epidata) {
+    console.log(result, message, epidata != null ? epidata.length : void 0);
+  };
+  Epidata.covidcast(callback, 'fb_survey', 'ili', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001');
+</script>
+````
+
+### Python
+
+Optionally install the package using pip(env):
+````bash
+pip install delphi-epidata
+````
+
+Otherwise, place `delphi_epidata.py` from this repo next to your python script.
+
+````python
+# Import
+from delphi_epidata import Epidata
+# Fetch data
+res = Epidata.covidcast('fb_survey', 'ili', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001')
+print(res['result'], res['message'], len(res['epidata']))
+````
+
+### R
+
+````R
+# Import
+source('delphi_epidata.R')
+# Fetch data
+res <- Epidata$covidcast('fb_survey', 'ili', 'day', 'county', list(20200401, Epidata$range(20200405, 20200414)), '06001')
+cat(paste(res$result, res$message, length(res$epidata), "\n"))
+````

--- a/docs/api/covidcast_meta.md
+++ b/docs/api/covidcast_meta.md
@@ -93,4 +93,58 @@ https://delphi.midas.cs.cmu.edu/epidata/api.php?source=covidcast_meta
 
 # Code Samples
 
-<!-- TODO: fix -->
+Libraries are available for [CoffeeScript](../../src/client/delphi_epidata.coffee), [JavaScript](../../src/client/delphi_epidata.js), [Python](../../src/client/delphi_epidata.py), and [R](../../src/client/delphi_epidata.R).
+The following samples show how to import the library and fetch Delphi's COVID-19 Surveillance Streams metadata.
+
+### CoffeeScript (in Node.js)
+
+````coffeescript
+# Import
+{Epidata} = require('./delphi_epidata')
+# Fetch data
+callback = (result, message, epidata) ->
+  console.log(result, message, epidata?.length)
+Epidata.covidcast_meta(callback)
+````
+
+### JavaScript (in a web browser)
+
+````html
+<!-- Imports -->
+<script src="jquery.js"></script>
+<script src="delphi_epidata.js"></script>
+<!-- Fetch data -->
+<script>
+  var callback = function(result, message, epidata) {
+    console.log(result, message, epidata != null ? epidata.length : void 0);
+  };
+  Epidata.covidcast_meta(callback);
+</script>
+````
+
+### Python
+
+Optionally install the package using pip(env):
+````bash
+pip install delphi-epidata
+````
+
+Otherwise, place `delphi_epidata.py` from this repo next to your python script.
+
+````python
+# Import
+from delphi_epidata import Epidata
+# Fetch data
+res = Epidata.covidcast_meta()
+print(res['result'], res['message'], len(res['epidata']))
+````
+
+### R
+
+````R
+# Import
+source('delphi_epidata.R')
+# Fetch data
+res <- Epidata$covidcast_meta()
+cat(paste(res$result, res$message, length(res$epidata), "\n"))
+````

--- a/docs/api/wiki.md
+++ b/docs/api/wiki.md
@@ -186,6 +186,6 @@ Note:
 # Import
 source('delphi_epidata.R')
 # Fetch data
-res <- Epidata$fluview_clinical(list('nat'), NULL, list(201940, Epidata$range(202001, 202010)), list(0, 12), 'en')
+res <- Epidata$wiki(list('nat'), NULL, list(201940, Epidata$range(202001, 202010)), list(0, 12), 'en')
 cat(paste(res$result, res$message, length(res$epidata), "\n"))
 ````

--- a/integrations/test_delphi_epidata.py
+++ b/integrations/test_delphi_epidata.py
@@ -1,0 +1,49 @@
+"""Integration tests for delphi_epidata.py."""
+import unittest
+
+# first party
+from delphi.epidata.client.delphi_epidata import Epidata
+
+# py3tester coverage target
+__test_target__ = 'delphi.epidata.client.delphi_epidata'
+
+class DelphiEpidataPythonClientTests(unittest.TestCase):
+    """Tests the Python client."""
+
+    def test_covidcast_happy_path(self):
+        """Test that the covidcast endpoint returns expected data."""
+
+        # Fetch data
+        res = Epidata.covidcast('fb_survey', 'ili', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001')
+        # Check result
+        self.assertEqual(res['result'], 1)
+        self.assertEqual(res['message'], 'success')
+        self.assertGreater(len(res['epidata']), 0)
+        item = res['epidata'][0]
+        self.assertIn('geo_value', item)
+        self.assertIn('time_value', item)
+        self.assertIn('direction', item)
+        self.assertIn('value', item)
+        self.assertIn('stderr', item)
+        self.assertIn('sample_size', item)
+
+
+    def test_covidcast_meta(self):
+        """Test that the covidcast_meta endpoint returns expected data."""
+
+        # Fetch data
+        res = Epidata.covidcast_meta()
+        # Check result
+        self.assertEqual(res['result'], 1)
+        self.assertEqual(res['message'], 'success')
+        self.assertGreater(len(res['epidata']), 0)
+        item = res['epidata'][0]
+        self.assertIn('data_source', item)
+        self.assertIn('time_type', item)
+        self.assertIn('geo_type', item)
+        self.assertIn('min_time', item)
+        self.assertIn('max_time', item)
+        self.assertIn('num_locations', item)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -506,7 +506,7 @@ Epidata <- (function() {
       time_type = time_type,
       geo_type = geo_type,
       time_values = .list(time_values),
-      geo_values = geo_value
+      geo_value = geo_value
     )
     # Make the API call
     return(.request(params))

--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -492,6 +492,31 @@ Epidata <- (function() {
     return(.request(list(source='meta')))
   }
 
+  # Fetch Delphi's COVID-19 Surveillance Streams
+  covidcast <- function(data_source, signal, time_type, geo_type, time_values, geo_value) {
+    # Check parameters
+    if(missing(data_source) || missing(signal) || missing(time_type) || missing(geo_type) || missing(time_values) || missing(geo_value)) {
+      stop('`data_source`, `signal`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required')
+    }
+    # Set up request
+    params <- list(
+      source = 'covidcast',
+      data_source = data_source,
+      signal = signal,
+      time_type = time_type,
+      geo_type = geo_type,
+      time_values = .list(time_values),
+      geo_values = geo_value
+    )
+    # Make the API call
+    return(.request(params))
+  }
+
+  # Fetch Delphi's COVID-19 Surveillance Streams metadata
+  covidcast_meta <- function() {
+    return(.request(list(source='covidcast_meta')))
+  }
+
   # Export the public methods
   return(list(
     range = range,
@@ -515,6 +540,8 @@ Epidata <- (function() {
     dengue_sensors = dengue_sensors,
     nowcast = nowcast,
     dengue_nowcast = dengue_nowcast,
-    meta = meta
+    meta = meta,
+    covidcast = covidcast,
+    covidcast_meta = covidcast_meta
   ))
 })()

--- a/src/client/delphi_epidata.coffee
+++ b/src/client/delphi_epidata.coffee
@@ -346,6 +346,26 @@ class Epidata
   @meta: (callback) ->
     _request(callback, {'source': 'meta'})
 
+  # Fetch Delphi's COVID-19 Surveillance Streams
+  @covidcast: (callback, data_source, signal, time_type, geo_type, time_values, geo_value) ->
+    # Check parameters
+    unless data_source? and signal? and time_type? and geo_type? and time_values? and geo_values?
+      throw { msg: '`data_source`, `signal`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required' }
+    # Set up request
+    params =
+      'source': 'covidcast'
+      'data_source': data_source
+      'signal': signal
+      'time_type': time_type
+      'geo_type': geo_type
+      'time_values': _list(time_values)
+      'geo_values': geo_value
+    # Make the API call
+    _request(callback, params)
+
+  # Fetch Delphi's COVID-19 Surveillance Streams metadata
+  @covidcast_meta: (callback) ->
+    _request(callback, {'source': 'covidcast_meta'})
 
 # Export the API to the global environment
 (exports ? window).Epidata = Epidata

--- a/src/client/delphi_epidata.coffee
+++ b/src/client/delphi_epidata.coffee
@@ -359,7 +359,7 @@ class Epidata
       'time_type': time_type
       'geo_type': geo_type
       'time_values': _list(time_values)
-      'geo_values': geo_value
+      'geo_value': geo_value
     # Make the API call
     _request(callback, params)
 

--- a/src/client/delphi_epidata.js
+++ b/src/client/delphi_epidata.js
@@ -458,7 +458,7 @@ Notes:
         'time_type': time_type,
         'geo_type': geo_type,
         'time_values': _list(time_values),
-        'geo_values': geo_value
+        'geo_value': geo_value
       };
     };
 

--- a/src/client/delphi_epidata.js
+++ b/src/client/delphi_epidata.js
@@ -444,6 +444,30 @@ Notes:
       });
     };
 
+    Epidata.covidcast = function(callback, data_source, signal, time_type, geo_type, time_values, geo_value) {
+      var params;
+      if (!((data_source != null) && (signal != null) && (time_type != null) && (geo_type != null) && (time_values != null) && (geo_value != null))) {
+        throw {
+          msg: '`data_source`, `signal`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required'
+        };
+      }
+      params = {
+        'source': 'covidcast',
+        'data_source': data_source,
+        'signal': signal,
+        'time_type': time_type,
+        'geo_type': geo_type,
+        'time_values': _list(time_values),
+        'geo_values': geo_value
+      };
+    };
+
+    Epidata.covidcast_meta = function(callback) {
+      return _request(callback, {
+        'source': 'covidcast_meta'
+      });
+    };
+
     return Epidata;
 
   })();

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -543,7 +543,7 @@ class Epidata:
       'time_type': time_type,
       'geo_type': geo_type,
       'time_values': Epidata._list(time_values),
-      'geo_values': geo_value,
+      'geo_value': geo_value,
     }
     # Make the API call
     return Epidata._request(params)

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -527,3 +527,29 @@ class Epidata:
   def meta():
     """Fetch API metadata."""
     return Epidata._request({'source': 'meta'})
+
+  # Fetch Delphi's COVID-19 Surveillance Streams
+  @staticmethod
+  def covidcast(data_source, signal, time_type, geo_type, time_values, geo_value):
+    """Fetch Delphi's COVID-19 Surveillance Streams"""
+    # Check parameters
+    if data_source is None or signal is None or time_type is None or geo_type is None or time_values is None or geo_value is None:
+      raise Exception('`data_source`, `signal`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required')
+    # Set up request
+    params = {
+      'source': 'covidcast',
+      'data_source': data_source,
+      'signal': signal,
+      'time_type': time_type,
+      'geo_type': geo_type,
+      'time_values': Epidata._list(time_values),
+      'geo_values': geo_value,
+    }
+    # Make the API call
+    return Epidata._request(params)
+
+  # Fetch Delphi's COVID-19 Surveillance Streams metadata
+  @staticmethod
+  def covidcast_meta():
+    """Fetch Delphi's COVID-19 Surveillance Streams metadata"""
+    return Epidata._request({'source': 'covidcast_meta'})


### PR DESCRIPTION
add `covidcast` and `covidcast_meta` endpoints to clients, add integration tests for the python changes, and add documentation to the corresponding api docs. also some other minor fixes.

testing: the new integration tests pass.