### PR TITLE
update covidcast docs and tests to account for schema changes

### DIFF
--- a/docs/api/covidcast.md
+++ b/docs/api/covidcast.md
@@ -63,8 +63,8 @@ Notes:
 
 # Example URLs
 
-### Delphi's COVID-19 Surveillance Streams from Facebook Survey ILI on 2020-04-06 - 2010-04-10 (county 06001)
-https://delphi.cmu.edu/epidata/api.php?source=covidcast&data_source=fb_survey&signal=ili&time_type=day&geo_type=county&time_values=20200406-20200410&geo_value=06001
+### Delphi's COVID-19 Surveillance Streams from Facebook Survey CLI on 2020-04-06 - 2010-04-10 (county 06001)
+https://delphi.cmu.edu/epidata/api.php?source=covidcast&data_source=fb-survey&signal=cli&time_type=day&geo_type=county&time_values=20200406-20200410&geo_value=06001
 
 ```json
 {
@@ -72,11 +72,11 @@ https://delphi.cmu.edu/epidata/api.php?source=covidcast&data_source=fb_survey&si
   "epidata": [
     {
       "geo_value": "06001",
-      "time_value": 20200406,
-      "direction": 0,
-      "value": 0,
-      "stderr": null,
-      "sample_size": 417.2392
+      "time_value": 20200407,
+      "direction": null,
+      "value": 1.1293550689064,
+      "stderr": 0.53185454111042,
+      "sample_size": 281.0245
     },
     ...
   ],
@@ -84,13 +84,13 @@ https://delphi.cmu.edu/epidata/api.php?source=covidcast&data_source=fb_survey&si
 }
 ```
 
-## Delphi's COVID-19 Surveillance Streams from Facebook Survey ILI on 2020-04-06 (all counties)
-https://delphi.cmu.edu/epidata/api.php?source=covidcast&data_source=fb_survey&signal=ili&time_type=day&geo_type=county&time_values=20200406&geo_value=*
+## Delphi's COVID-19 Surveillance Streams from Facebook Survey CLI on 2020-04-06 (all counties)
+https://delphi.cmu.edu/epidata/api.php?source=covidcast&data_source=fb-survey&signal=cli&time_type=day&geo_type=county&time_values=20200406&geo_value=*
 
 # Code Samples
 
 Libraries are available for [CoffeeScript](../../src/client/delphi_epidata.coffee), [JavaScript](../../src/client/delphi_epidata.js), [Python](../../src/client/delphi_epidata.py), and [R](../../src/client/delphi_epidata.R).
-The following samples show how to import the library and fetch Delphi's COVID-19 Surveillance Streams from Facebook Survey ILI for county 06001 and days `20200401` and `20200405-20200414` (11 days total).
+The following samples show how to import the library and fetch Delphi's COVID-19 Surveillance Streams from Facebook Survey CLI for county 06001 and days `20200401` and `20200405-20200414` (11 days total).
 
 ### CoffeeScript (in Node.js)
 
@@ -100,7 +100,7 @@ The following samples show how to import the library and fetch Delphi's COVID-19
 # Fetch data
 callback = (result, message, epidata) ->
   console.log(result, message, epidata?.length)
-Epidata.covidcast(callback, 'fb_survey', 'ili', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001')
+Epidata.covidcast(callback, 'fb-survey', 'cli', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001')
 ````
 
 ### JavaScript (in a web browser)
@@ -114,7 +114,7 @@ Epidata.covidcast(callback, 'fb_survey', 'ili', 'day', 'county', [20200401, Epid
   var callback = function(result, message, epidata) {
     console.log(result, message, epidata != null ? epidata.length : void 0);
   };
-  Epidata.covidcast(callback, 'fb_survey', 'ili', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001');
+  Epidata.covidcast(callback, 'fb-survey', 'cli', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001');
 </script>
 ````
 
@@ -131,7 +131,7 @@ Otherwise, place `delphi_epidata.py` from this repo next to your python script.
 # Import
 from delphi_epidata import Epidata
 # Fetch data
-res = Epidata.covidcast('fb_survey', 'ili', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001')
+res = Epidata.covidcast('fb-survey', 'cli', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001')
 print(res['result'], res['message'], len(res['epidata']))
 ````
 
@@ -141,6 +141,6 @@ print(res['result'], res['message'], len(res['epidata']))
 # Import
 source('delphi_epidata.R')
 # Fetch data
-res <- Epidata$covidcast('fb_survey', 'ili', 'day', 'county', list(20200401, Epidata$range(20200405, 20200414)), '06001')
+res <- Epidata$covidcast('fb-survey', 'cli', 'day', 'county', list(20200401, Epidata$range(20200405, 20200414)), '06001')
 cat(paste(res$result, res$message, length(res$epidata), "\n"))
 ````

--- a/docs/api/covidcast_meta.md
+++ b/docs/api/covidcast_meta.md
@@ -34,6 +34,10 @@ None.
 | `epidata[].min_time` | minimum time (e.g., 20200406) | integer |
 | `epidata[].max_time` | maximum time (e.g., 20200413) | integer |
 | `epidata[].num_locations` | number of locations | integer |
+| `epidata[].min_value` | minimum value | float |
+| `epidata[].max_value` | maximum value | float |
+| `epidata[].mean_value` | mean of value | float |
+| `epidata[].stdev_value` | standard deviation of value | float |
 | `message` | `success` or error message | string |
 
 # Example URLs
@@ -45,15 +49,17 @@ https://delphi.cmu.edu/epidata/api.php?source=covidcast_meta
   "result": 1,
   "epidata": [
     {
-      "data_source": "fb_survey",
+      "data_source": "doctor-visits",
       "signal": "cli",
       "time_type": "day",
       "geo_type": "county",
-      "min_time": 20200406,
-      "max_time": 20200413,
-      "num_locations": 555,
+      "min_time": 20200201,
+      "max_time": 20200418,
+      "num_locations": 1411,
       "min_value": 0,
-      "max_value": 5.0805650596568
+      "max_value": 23.079023,
+      "mean_value": 0.42745842933726,
+      "stdev_value": 0.96461526722895
     },
     ...
   ],

--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -14,7 +14,7 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
         """Test that the covidcast endpoint returns expected data."""
 
         # Fetch data
-        res = Epidata.covidcast('fb_survey', 'ili', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001')
+        res = Epidata.covidcast('fb-survey', 'cli', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001')
         # Check result
         self.assertEqual(res['result'], 1)
         self.assertEqual(res['message'], 'success')
@@ -44,6 +44,10 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
         self.assertIn('min_time', item)
         self.assertIn('max_time', item)
         self.assertIn('num_locations', item)
+        self.assertIn('min_value', item)
+        self.assertIn('max_value', item)
+        self.assertIn('mean_value', item)
+        self.assertIn('stdev_value', item)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
update examples in `covidcast` and `covidcast_meta` docs and integration tests to:
* switch '_' with '-' in data source names.
* add new fields in responses.
* use 'cli' signal instead of 'ili' since these sources are focused on covid.

testing:
* all unit tests pass
* all integration tests pass