### PR TITLE
replace remaining delphi.midas.cs.cmu.edu with delphi.cmu.edu

### DIFF
--- a/src/acquisition/cdcp/cdc_upload.py
+++ b/src/acquisition/cdcp/cdc_upload.py
@@ -6,7 +6,7 @@
 Reads zip/csv files from CDC and stores page hit counts in the database.
 
 Files can be uploaded at:
-https://delphi.midas.cs.cmu.edu/~automation/public/cdc_upload/
+https://delphi.cmu.edu/~automation/public/cdc_upload/
 
 When someone uploads a new file, two things happen:
   1. the uploaded file is moved to /common/cdc_stage

--- a/src/acquisition/flusurv/flusurv.py
+++ b/src/acquisition/flusurv/flusurv.py
@@ -79,7 +79,7 @@ def fetch_json(path, payload, call_count=1):
   """Send a request to the server and return the parsed JSON response."""
 
   # it's polite to self-identify this "bot"
-  delphi_url = 'https://delphi.midas.cs.cmu.edu/index.html'
+  delphi_url = 'https://delphi.cmu.edu/index.html'
   user_agent = 'Mozilla/5.0 (compatible; delphibot/1.0; +%s)' % delphi_url
 
   # the FluSurv AMF server

--- a/src/acquisition/fluview/fluview.py
+++ b/src/acquisition/fluview/fluview.py
@@ -168,7 +168,7 @@ def save_latest(path=None):
   sess = requests.session()
   sess.headers.update({
     # it's polite to self-identify this "bot"
-    'User-Agent': 'delphibot/1.0 (+https://delphi.midas.cs.cmu.edu/)',
+    'User-Agent': 'delphibot/1.0 (+https://delphi.cmu.edu/)',
   })
 
   # get metatdata

--- a/src/acquisition/norostat/norostat_raw.py
+++ b/src/acquisition/norostat/norostat_raw.py
@@ -25,7 +25,7 @@ from .norostat_utils import *
 def fetch_content(norostat_datatable_url="https://www.cdc.gov/norovirus/reporting/norostat/data-table.html"):
   """Download NoroSTAT data-table.  Returns the html content."""
   headers = {
-    'User-Agent': 'delphibot/1.0 (+https://delphi.midas.cs.cmu.edu/)',
+    'User-Agent': 'delphibot/1.0 (+https://delphi.cmu.edu/)',
   }
   resp = requests.get(norostat_datatable_url, headers=headers)
   expect_value_eq(resp.status_code, 200,

--- a/src/acquisition/wiki/master.php
+++ b/src/acquisition/wiki/master.php
@@ -4,7 +4,7 @@
 The job server for wiki scraping. Any number of clients (wiki_download.py
 instances) fetch jobs from, and upload results to, this server. A simple
 dashboard is available from dashboard.php, visible here:
-https://delphi.midas.cs.cmu.edu/~automation/public/wiki/
+https://delphi.cmu.edu/~automation/public/wiki/
 
 See wiki.py for many more details.
 */

--- a/src/acquisition/wiki/wiki_download.py
+++ b/src/acquisition/wiki/wiki_download.py
@@ -53,7 +53,7 @@ from . import wiki_util
 
 
 VERSION = 10
-MASTER_URL = 'https://delphi.midas.cs.cmu.edu/~automation/public/wiki/master.php'
+MASTER_URL = 'https://delphi.cmu.edu/~automation/public/wiki/master.php'
 
 def text(data_string):
   return str(data_string.decode('utf-8'))


### PR DESCRIPTION
replace remaining instances of "delphi.midas[.cs].cmu.edu" with "delphi.cmu.edu". the ide also fixed some errant carriage returns in the `wiki/master.php` file.

testing: all unit and integration tests pass.