### PR TITLE
`deploy.json` syntax test

### DIFF
--- a/integrations/test_deploy_syntax.py
+++ b/integrations/test_deploy_syntax.py
@@ -1,0 +1,15 @@
+"""Simple integration test to validate the syntax of `deploy.json`."""
+
+# standard library
+import json
+import unittest
+
+
+class DeploySyntaxTests(unittest.TestCase):
+  """Tests for `deploy.json`."""
+
+  def test_syntax(self):
+    """Ensure that `deploy.json` is valid JSON."""
+
+    with open('repos/delphi/delphi-epidata/deploy.json', 'r') as f:
+      self.assertIsInstance(json.loads(f.read()), dict)


### PR DESCRIPTION
- editing `deploy.json` is error-prone due to the strict parsing 
requirements of JSON
- many past prod deployments have failed due to simple mistakes, like 
missing or extra commas
- this test ensures that `deploy.json` is at least syntactically valid