### PR TITLE
covidcast_meta optional caching

### DIFF
--- a/integrations/acquisition/covidcast/test_covidcast_meta_caching.py
+++ b/integrations/acquisition/covidcast/test_covidcast_meta_caching.py
@@ -1,0 +1,151 @@
+"""Integration tests for covidcast's metadata caching."""
+
+# standard library
+import unittest
+
+# third party
+import mysql.connector
+import requests
+
+# first party
+from delphi.epidata.client.delphi_epidata import Epidata
+import delphi.operations.secrets as secrets
+
+# py3tester coverage target (equivalent to `import *`)
+__test_target__ = (
+  'delphi.epidata.acquisition.covidcast.'
+  'covidcast_meta_cache_updater'
+)
+
+# use the local instance of the Epidata API
+BASE_URL = 'http://delphi_web_epidata/epidata/api.php'
+
+
+class CovidcastMetaCacheTests(unittest.TestCase):
+  """Tests covidcast metadata caching."""
+
+  def setUp(self):
+    """Perform per-test setup."""
+
+    # connect to the `epidata` database
+    cnx = mysql.connector.connect(
+        user='user',
+        password='pass',
+        host='delphi_database_epidata',
+        database='epidata')
+    cur = cnx.cursor()
+
+    # clear the `covidcast` table
+    cur.execute('truncate table covidcast')
+    # reset the `covidcast_meta_cache` table (it should always have one row)
+    cur.execute('update covidcast_meta_cache set timestamp = 0, epidata = ""')
+    cnx.commit()
+    cur.close()
+
+    # make connection and cursor available to test cases
+    self.cnx = cnx
+    self.cur = cnx.cursor()
+
+    # use the local instance of the epidata database
+    secrets.db.host = 'delphi_database_epidata'
+    secrets.db.epi = ('user', 'pass')
+
+    # use the local instance of the Epidata API
+    Epidata.BASE_URL = BASE_URL
+
+  def tearDown(self):
+    """Perform per-test teardown."""
+    self.cur.close()
+    self.cnx.close()
+
+  def test_caching(self):
+    """Populate, query, cache, query, and verify the cache."""
+
+    # insert dummy data
+    self.cur.execute('''
+      insert into covidcast values
+        (0, 'src', 'sig', 'day', 'state', 20200422, 'pa',
+          123, 1, 2, 3, 456, 1)
+    ''')
+    self.cnx.commit()
+
+    # make sure covidcast_meta is serving something sensible
+    epidata1 = Epidata.covidcast_meta()
+    self.assertEqual(epidata1['result'], 1)
+    self.assertEqual(epidata1['epidata'], [
+      {
+        'data_source': 'src',
+        'signal': 'sig',
+        'time_type': 'day',
+        'geo_type': 'state',
+        'min_time': 20200422,
+        'max_time': 20200422,
+        'num_locations': 1,
+        'last_update': 123,
+        'min_value': 1,
+        'max_value': 1,
+        'mean_value': 1,
+        'stdev_value': 0,
+      }
+    ])
+
+    # fetch the cached version (manually)
+    params = {'source': 'covidcast_meta', 'cached': 'true'}
+    response = requests.get(BASE_URL, params=params)
+    response.raise_for_status()
+    epidata2 = response.json()
+
+    # API should fallback to live version
+    self.assertEqual(epidata1, epidata2)
+
+    # update the cache
+    main()
+
+    # fetch the cached version (manually)
+    params = {'source': 'covidcast_meta', 'cached': 'true'}
+    response = requests.get(BASE_URL, params=params)
+    response.raise_for_status()
+    epidata3 = response.json()
+
+    # cached version should equal live version
+    self.assertEqual(epidata1, epidata3)
+
+    # insert dummy data timestamped as of now
+    self.cur.execute('''
+      update covidcast_meta_cache set
+        timestamp = UNIX_TIMESTAMP(NOW()),
+        epidata = '[{"hello": "world"}]'
+    ''')
+    self.cnx.commit()
+
+    # fetch the cached version (manually)
+    params = {'source': 'covidcast_meta', 'cached': 'true'}
+    response = requests.get(BASE_URL, params=params)
+    response.raise_for_status()
+    epidata4 = response.json()
+
+    # make sure the cache was actually served
+    self.assertEqual(epidata4, {
+      'result': 1,
+      'epidata': [{
+        'hello': 'world',
+      }],
+      'message': 'success',
+    })
+
+    # insert dummy data timestamped as 2 hours old
+    self.cur.execute('''
+      update covidcast_meta_cache set
+        timestamp = UNIX_TIMESTAMP(NOW()) - 3600 * 2,
+        epidata = '[{"hello": "world"}]'
+    ''')
+    self.cnx.commit()
+
+    # fetch the cached version (manually)
+    params = {'source': 'covidcast_meta', 'cached': 'true'}
+    response = requests.get(BASE_URL, params=params)
+    response.raise_for_status()
+    epidata5 = response.json()
+
+    # make sure the cache was bypassed
+    self.assertEqual(epidata1, epidata5)

--- a/src/acquisition/covidcast/covidcast_meta_cache_updater.py
+++ b/src/acquisition/covidcast/covidcast_meta_cache_updater.py
@@ -1,0 +1,30 @@
+"""Updates the cache for the `covidcast_meta` endpiont."""
+
+# standard library
+import json
+
+# first party
+from delphi.epidata.acquisition.covidcast.database import Database
+from delphi.epidata.client.delphi_epidata import Epidata
+
+
+def main():
+  response = Epidata.covidcast_meta()
+  print(response['result'])
+
+  if response['result'] == 1:
+    commit = False
+    database = Database()
+    database.connect()
+    try:
+      database.update_covidcast_meta_cache(json.dumps(response['epidata']))
+      commit = True
+      print('successfully cached epidata')
+    finally:
+      database.disconnect(commit)
+  else:
+    print('metadata is not available')
+
+
+if __name__ == '__main__':
+  main()

--- a/src/acquisition/covidcast/database.py
+++ b/src/acquisition/covidcast/database.py
@@ -321,3 +321,16 @@ class Database:
     )
 
     self._cursor.execute(sql, args)
+
+  def update_covidcast_meta_cache(self, epidata_json):
+    """Updates the `covidcast_meta_cache` table."""
+
+    sql = '''
+      UPDATE
+        `covidcast_meta_cache`
+      SET
+        `timestamp` = UNIX_TIMESTAMP(NOW()),
+        `epidata` = %s
+    '''
+
+    self._cursor.execute(sql, (epidata_json,))

--- a/src/ddl/covidcast.sql
+++ b/src/ddl/covidcast.sql
@@ -85,3 +85,29 @@ CREATE TABLE `covidcast` (
   -- for fast lookup of a time-series for a given location
   KEY (`source`, `signal`, `time_type`, `geo_type`, `geo_value`, `time_value`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+/*
+`covidcast_meta_cache` stores a cache of the `covidcast_meta` endpoint
+response, e.g. for faster visualization load times.
+
+Data is public.
+
++-----------+----------+------+-----+---------+-------+
+| Field     | Type     | Null | Key | Default | Extra |
++-----------+----------+------+-----+---------+-------+
+| timestamp | int(11)  | NO   | PRI | NULL    |       |
+| epidata   | longtext | NO   |     | NULL    |       |
++-----------+----------+------+-----+---------+-------+
+
+- `timestamp`
+  unix time in seconds when the cache was updated
+- `response`
+  JSON string containing a successful API response for `covidcast_meta`
+*/
+
+CREATE TABLE `covidcast_meta_cache` (
+  `timestamp` int(11) NOT NULL,
+  `epidata` LONGTEXT NOT NULL,
+  PRIMARY KEY (`timestamp`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+INSERT INTO covidcast_meta_cache VALUES (0, '');

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -989,6 +989,44 @@ function get_covidcast_meta() {
   return count($epidata) === 0 ? null : $epidata;
 }
 
+// queries the `covidcast` table for metadata only. attempts to used the cached
+// version, falling back to `get_covidcast_meta` otherwise.
+function get_covidcast_meta_cached() {
+  // only use the cache if it's less than ~1 hour old (75 minutes max to allow
+  // for some wiggle room)
+  $max_age = 75 * 60;
+
+  // basic query info
+  $query = 'SELECT UNIX_TIMESTAMP(NOW()) - `timestamp` AS `age`, `epidata` FROM `covidcast_meta_cache` LIMIT 1';
+
+  // get the data from the database
+  global $dbh;
+  $fallback = true;
+  $epidata = array();
+  $result = mysqli_query($dbh, $query);
+  if($row = mysqli_fetch_array($result)) {
+    if (intval($row['age']) < $max_age && strlen($row['epidata']) > 0) {
+      // parse and use the cached response
+      $cached_rows = json_decode($row['epidata'], true);
+      foreach($cached_rows as $row) {
+        array_push($epidata, $row);
+      }
+      // no need to fallback
+      $fallback = false;
+    }
+  }
+
+  // fallback to the real thing if necessary
+  if ($fallback) {
+    error_log('covidcast_meta cache miss');
+    $epidata = get_covidcast_meta();
+  }
+
+  // return the data
+  $has_values = $epidata !== null && count($epidata) > 0;
+  return $has_values ? $epidata : null;
+}
+
 // queries a bunch of epidata tables
 function get_meta() {
   // query and return metadata
@@ -1443,7 +1481,11 @@ if(database_connect()) {
     }
   } else if($source === 'covidcast_meta') {
     // get the metadata
-    $epidata = get_covidcast_meta();
+    if (isset($_REQUEST['cached']) && $_REQUEST['cached'] === 'true') {
+      $epidata = get_covidcast_meta_cached();
+    } else {
+      $epidata = get_covidcast_meta();
+    }
     store_result($data, $epidata);
   } else {
     $data['message'] = 'no data source specified';

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -1001,23 +1001,17 @@ function get_covidcast_meta_cached() {
 
   // get the data from the database
   global $dbh;
-  $fallback = true;
-  $epidata = array();
+  $epidata = null;
   $result = mysqli_query($dbh, $query);
   if($row = mysqli_fetch_array($result)) {
     if (intval($row['age']) < $max_age && strlen($row['epidata']) > 0) {
       // parse and use the cached response
-      $cached_rows = json_decode($row['epidata'], true);
-      foreach($cached_rows as $row) {
-        array_push($epidata, $row);
-      }
-      // no need to fallback
-      $fallback = false;
+      $epidata = json_decode($row['epidata'], true);
     }
   }
 
   // fallback to the real thing if necessary
-  if ($fallback) {
+  if ($epidata === null) {
     error_log('covidcast_meta cache miss');
     $epidata = get_covidcast_meta();
   }


### PR DESCRIPTION
- use a short-lived cache to make `covidcast_meta` super fast
- integration tested
- all unit and integration tests pass
- i owe unit tests for this