### PR TITLE
add missing import

### DIFF
--- a/tests/acquisition/covidcast/test_covidcast_meta_cache_updater.py
+++ b/tests/acquisition/covidcast/test_covidcast_meta_cache_updater.py
@@ -1,6 +1,7 @@
 """Unit tests for covidcast_meta_cache_updater.py."""
 
 # standard library
+import argparse
 import json
 import unittest
 from unittest.mock import MagicMock


### PR DESCRIPTION
- missing `argparse`
- worked before because py3tester included it, but should have been 
explicitly included anyway