### PR TITLE
suppress covidcast meta for WIP signals

### DIFF
--- a/src/server/api.php
+++ b/src/server/api.php
@@ -973,7 +973,8 @@ function get_covidcast($source, $signal, $time_type, $geo_type, $time_values, $g
 function get_covidcast_meta() {
   // basic query info
   $table = '`covidcast` t';
-  $fields = "t.`source` AS `data_source`, t.`signal`, t.`time_type`, t.`geo_type`, MIN(t.`time_value`) AS `min_time`, MAX(t.`time_value`) AS `max_time`, COUNT(DISTINCT `geo_value`) AS `num_locations`, MIN(`value`) AS `min_value`, MAX(`value`) AS `max_value`, AVG(`value`) as `mean_value`, STD(`value`) as `stdev_value`, MAX(`timestamp1`) AS `last_update`";
+  $fields = "t.`source` AS `data_source`, t.`signal`, t.`time_type`, t.`geo_type`, MIN(t.`time_value`) AS `min_time`, MAX(t.`time_value`) AS `max_time`, COUNT(DISTINCT `geo_value`) AS `num_locations`, MIN(`value`) AS `min_value`, MAX(`value`) AS `max_value`, AVG(`value`) AS `mean_value`, STD(`value`) AS `stdev_value`, MAX(`timestamp1`) AS `last_update`";
+  $condition_wip = "t.`signal` NOT LIKE 'wip-%'";
   $group = "t.`source`, t.`signal`, t.`time_type`, t.`geo_type`";
   $order = "t.`source` ASC, t.`signal` ASC, t.`time_type` ASC, t.`geo_type` ASC";
   // data type of each field
@@ -981,7 +982,7 @@ function get_covidcast_meta() {
   $fields_int = array('min_time', 'max_time', 'num_locations', 'last_update');
   $fields_float = array('min_value', 'max_value', 'mean_value', 'stdev_value');
   // the query
-  $query = "SELECT {$fields} FROM {$table} GROUP BY {$group} ORDER BY {$order}";
+  $query = "SELECT {$fields} FROM {$table} WHERE {$condition_wip} GROUP BY {$group} ORDER BY {$order}";
   // get the data from the database
   $epidata = array();
   execute_query($query, $epidata, $fields_string, $fields_int, $fields_float);


### PR DESCRIPTION
- in covidcast_meta, don't return signals named like "wip-*"
- this lets delphi iterate on modelling decisions before surfacing a 
signal for outside consumption
- added integration test for this case
- all unit and integration tests pass