### PR TITLE
Switch WIP signifier from dash to underscore

### DIFF
--- a/integrations/acquisition/covidcast/test_covidcast_meta_caching.py
+++ b/integrations/acquisition/covidcast/test_covidcast_meta_caching.py
@@ -67,6 +67,12 @@ class CovidcastMetaCacheTests(unittest.TestCase):
         (0, 'src', 'sig', 'day', 'state', 20200422, 'pa',
           123, 1, 2, 3, 456, 1)
     ''')
+    self.cur.execute('''
+      insert into covidcast values
+        (100, 'src', 'wip_sig', 'day', 'state', 20200422, 'pa',
+          456, 4, 5, 6, 789, -1)
+    ''')
+
     self.cnx.commit()
 
     # make sure covidcast_meta is serving something sensible

--- a/integrations/server/test_covidcast_meta.py
+++ b/integrations/server/test_covidcast_meta.py
@@ -92,10 +92,10 @@ class CovidcastMetaTests(unittest.TestCase):
     '''
     expected = []
     for src in ('src1', 'src2'):
-      for sig in ('sig1', 'sig2', 'wip-sig3'):
+      for sig in ('sig1', 'sig2', 'wip_sig3'):
         for tt in ('day', 'week'):
           for gt in ('hrr', 'msa'):
-            if sig != 'wip-sig3':
+            if sig != 'wip_sig3':
               expected.append({
                 'data_source': src,
                 'signal': sig,

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -974,7 +974,7 @@ function get_covidcast_meta() {
   // basic query info
   $table = '`covidcast` t';
   $fields = "t.`source` AS `data_source`, t.`signal`, t.`time_type`, t.`geo_type`, MIN(t.`time_value`) AS `min_time`, MAX(t.`time_value`) AS `max_time`, COUNT(DISTINCT `geo_value`) AS `num_locations`, MIN(`value`) AS `min_value`, MAX(`value`) AS `max_value`, AVG(`value`) AS `mean_value`, STD(`value`) AS `stdev_value`, MAX(`timestamp1`) AS `last_update`";
-  $condition_wip = "t.`signal` NOT LIKE 'wip-%'";
+  $condition_wip = "t.`signal` NOT LIKE 'wip_%'";
   $group = "t.`source`, t.`signal`, t.`time_type`, t.`geo_type`";
   $order = "t.`source` ASC, t.`signal` ASC, t.`time_type` ASC, t.`geo_type` ASC";
   // data type of each field


### PR DESCRIPTION
* Dash fouls up the acquisition regexes, and it's not clear what other parts of the pipeline will balk at them
* Underscore is already successfully in use as part of signal names
* Change SQL exclusion clause for WIP signals
* Change integration test for WIP signals
* Add acquisition tests for WIP signals

All tests pass in docker.