### PR TITLE
Remove garbage characters in get_norostat query

### DIFF
--- a/src/server/api.php
+++ b/src/server/api.php
@@ -566,7 +566,7 @@ function get_norostat($location, $epiweeks) {
     ON `latest`.`location_id` = `later`.`location_id` AND
        `latest`.`epiweek` = `later`.`epiweek` AND
        (`latest`.`release_date`, `latest`.`parse_time`) <
-         (`later`.`release_date`, `later`.`parse_time`) ANDou z z
+         (`later`.`release_date`, `later`.`parse_time`) AND
        `later`.`new_value` IS NOT NULL
     WHERE ({$condition_location}) AND
           ({$condition_epiweek}) AND


### PR DESCRIPTION
Low priority for review as this is currently auth-gated from public use.

Can test with Epidata$norostat(auth="(auth token)","Minnesota, Ohio, Oregon, Tennessee, and Wisconsin",epiweeks=Epidata$range(100052,300052)).
