### PR TITLE
v1.2 documentation update

### DIFF
--- a/docs/api/covidcast.md
+++ b/docs/api/covidcast.md
@@ -89,6 +89,30 @@ Other possible `geo_type`s include:
 Some signals are not available for all `geo_type`s, since they may be reported
 from their original sources with different levels of aggregation.
 
+## Small Sample Sizes and "Megacounties"
+
+Most sources do not report the same amount of data for every county; for
+example, the survey sources rely on survey responses each day, and many counties
+may have comparatively few survey responses. We do not report individual county
+estimates when small sample sizes would make estimates unreliable or would allow
+identification of respondents, violating privacy and confidentiality agreements.
+Additional considerations for specific signals are discussed in the [source and
+signal documentation](covidcast_signals.md).
+
+In each state, we collect together the data from all counties with insufficient
+data to be individually reported. These counties are combined into a single
+"megacounty". For example, if only five counties in a state have sufficient data
+to be reported, the remaining counties will form one megacounty representing the
+rest of that state. As sample sizes vary from day to day, the counties composing
+the megacounty can vary daily; the geographic area covered by the megacounty is
+simply the state minus the counties reported for that day.
+
+Megacounty estimates are reported with a FIPS code ending with 000, which is
+never a FIPS code for a real county. For example, megacounty estimates for the
+state of New York are reported with FIPS code 36000, since 36 is the FIPS code
+prefix for New York.
+
+
 ## FIPS Exceptions in JHU Data
 
 At the County (FIPS) level, we report the data _exactly_ as JHU reports their

--- a/docs/api/covidcast_signals.md
+++ b/docs/api/covidcast_signals.md
@@ -148,14 +148,14 @@ Our signals here are taken directly from the JHU CSSE
 [COVID-19 GitHub repository](https://github.com/CSSEGISandData/COVID-19) without 
 filtering, smoothing, or changes.
 
-### `combination`
+### `indicator-combination`
 
 This source provides signals which are statistical combinations of the other
 sources above. It is not a primary data source.
 
 * `nmf_day_doc_fbs_ght`: This signal uses a rank-1 approximation, from a
   nonnegative matrix factorization approach, to identify an underlying signal
-  that best reconstructs the Doctor Visits, Surveys, and Search Trends
+  that best reconstructs the Doctor Visits (`smoothed_cli`), Facebook Symptoms surveys (`smoothed_cli`), and Search Trends (`smoothed_search`)
   indicators. It does not include official reports (cases and deaths from the
   `jhu-csse` source). Higher values of the combined signal correspond to higher
   values of the other indicators, but the scale (units) of the combination is

--- a/docs/api/covidcast_signals.md
+++ b/docs/api/covidcast_signals.md
@@ -74,6 +74,16 @@ COVID-like illness*. Note that this is tracking a different quantity than the
 surveys through Facebook, and (unsurprisingly) the estimates here tend to be
 much larger.
 
+The survey sampled from all counties with greater than 100,000 population, along
+with a separate random sample from each state. This means that the megacounties
+(discussed in the [COVIDcast API documentation](covidcast.md)) are always the
+counties with populations smaller than 100,000, and megacounty estimates are
+created by combining the state-level survey with the observed county surveys.
+
+These surveys were run daily until May 15, 2020. After that date, new national
+data will not be collected regularly, although the surveys may be deployed in
+specific geographical areas as needed to support forecasting efforts.
+
 | Signal | Description |
 | --- | --- |
 | `raw_cli` | Estimated fraction of people who know someone in their community with COVID-like illness | 
@@ -85,7 +95,9 @@ Data source based on Google searches, provided to us by Google Health
 Trends.  Using this search data, we estimate the volume of COVID-related
 searches in a given location, on a given day.  This signal is measured in
 arbitrary units (its scale is meaningless); larger numbers represent higher
-numbers of COVID-related searches.
+numbers of COVID-related searches. Note that this source is not available for
+individual counties, as it is reported only for larger geographical areas, and
+so county estimates are not available from the API.
 
 | Signal | Description |
 | --- | --- |
@@ -135,6 +147,20 @@ University.
 Our signals here are taken directly from the JHU CSSE 
 [COVID-19 GitHub repository](https://github.com/CSSEGISandData/COVID-19) without 
 filtering, smoothing, or changes.
+
+### `combination`
+
+This source provides signals which are statistical combinations of the other
+sources above. It is not a primary data source.
+
+* `nmf_day_doc_fbs_ght`: This signal uses a rank-1 approximation, from a
+  nonnegative matrix factorization approach, to identify an underlying signal
+  that best reconstructs the Doctor Visits, Surveys, and Search Trends
+  indicators. It does not include official reports (cases and deaths from the
+  `jhu-csse` source). Higher values of the combined signal correspond to higher
+  values of the other indicators, but the scale (units) of the combination is
+  arbitrary. Note that the Search Trends source is not available at the county
+  level, so county values of this signal do not use it.
 
 ## COVIDcast Map Signals
 

--- a/docs/api/covidcast_signals.md
+++ b/docs/api/covidcast_signals.md
@@ -103,6 +103,13 @@ frequency), and the percentage of flu tests that are *negative* (since ruling
 out flu leaves open another cause---possibly covid---for the patient's
 symptoms), in a given location, on a given day.
 
+The number of flu tests conducted in individual counties can be quite small, so
+we do not report these signals at the county level.
+
+The flu test data is no longer updated as of May 19, 2020, as the number of flu
+tests conducted during the summer (outside of the normal flu season) is quite
+small. The data may be updated again when the Winter 2020 flu season begins.
+
 | Signal | Description |
 | --- | --- |
 | `raw_pct_negative` | The fraction of flu tests that are negative, suggesting the patient's illness has another cause, possibly COVID-19 | 


### PR DESCRIPTION
Continuing from #105, which I accidentally merged too soon and reverted.

This adds

* megacounty documentation
* end of routine Google Survey operation
* suspension of Quidel operation
* new combination signal

See also #109, which should be merged at the same time.