### PR TITLE
Update to 1.2.1 combination signal, and fix map table

### DIFF
--- a/docs/api/covidcast_signals.md
+++ b/docs/api/covidcast_signals.md
@@ -158,14 +158,20 @@ filtering, smoothing, or changes.
 This source provides signals which are statistical combinations of the other
 sources above. It is not a primary data source.
 
-* `nmf_day_doc_fbs_ght`: This signal uses a rank-1 approximation, from a
+* `nmf_day_doc_fbc_fbs_ght`: This signal uses a rank-1 approximation, from a
   nonnegative matrix factorization approach, to identify an underlying signal
-  that best reconstructs the Doctor Visits (`smoothed_cli`), Facebook Symptoms surveys (`smoothed_cli`), and Search Trends (`smoothed_search`)
-  indicators. It does not include official reports (cases and deaths from the
-  `jhu-csse` source). Higher values of the combined signal correspond to higher
-  values of the other indicators, but the scale (units) of the combination is
-  arbitrary. Note that the Search Trends source is not available at the county
-  level, so county values of this signal do not use it.
+  that best reconstructs the Doctor Visits (`smoothed_cli`), Facebook Symptoms
+  surveys (`smoothed_cli`), Facebook Symptoms in Community surveys
+  (`smoothed_hh_cmnty_cli`), and Search Trends (`smoothed_search`) indicators.
+  It does not include official reports (cases and deaths from the `jhu-csse`
+  source). Higher values of the combined signal correspond to higher values of
+  the other indicators, but the scale (units) of the combination is arbitrary.
+  Note that the Search Trends source is not available at the county level, so
+  county values of this signal do not use it.
+* `nmf_day_doc_fbs_ght`: This signal is calculated in the same way as
+  `nmf_day_doc_fbc_fbs_ght`, but does *not* include the Symptoms in Community
+  survey signal, which was not available at the time this signal was introduced.
+  This signal is deprecated and is no longer updated as of May 28, 2020.
 
 ## COVIDcast Map Signals
 
@@ -175,8 +181,9 @@ map](https://covidcast.cmu.edu/):
 | Name | Source | Signal |
 | --- | --- | --- |
 | Doctor's Visits | `doctor-visits` | `smoothed_adj_cli` |
-| Surveys (Facebook) | `fb-survey` | `smoothed_cli` |
-| Surveys (Google) | `google-survey` | `smoothed_cli` |
+| Symptoms (Facebook) | `fb-survey` | `smoothed_cli` |
+| Symptoms in Community (Facebook) | `fb-survey` | `smoothed_hh_cmnty_cli` |
 | Search Trends (Google) | `ght` | `smoothed_search` |
+| Combined | `indicator-combination` | `nmf_day_doc_fbc_fbs_ght` |
 | Cases (JHU) | `jhu-csse` | `confirmed_incidence_prop` |
 | Deaths (JHU) | `jhu-csse` | `deaths_incidence_prop` |

--- a/docs/api/covidcast_signals.md
+++ b/docs/api/covidcast_signals.md
@@ -160,8 +160,8 @@ sources above. It is not a primary data source.
 
 * `nmf_day_doc_fbc_fbs_ght`: This signal uses a rank-1 approximation, from a
   nonnegative matrix factorization approach, to identify an underlying signal
-  that best reconstructs the Doctor Visits (`smoothed_cli`), Facebook Symptoms
-  surveys (`smoothed_cli`), Facebook Symptoms in Community surveys
+  that best reconstructs the Doctor Visits (`smoothed_adj_cli`), Facebook
+  Symptoms surveys (`smoothed_cli`), Facebook Symptoms in Community surveys
   (`smoothed_hh_cmnty_cli`), and Search Trends (`smoothed_search`) indicators.
   It does not include official reports (cases and deaths from the `jhu-csse`
   source). Higher values of the combined signal correspond to higher values of
@@ -171,7 +171,9 @@ sources above. It is not a primary data source.
 * `nmf_day_doc_fbs_ght`: This signal is calculated in the same way as
   `nmf_day_doc_fbc_fbs_ght`, but does *not* include the Symptoms in Community
   survey signal, which was not available at the time this signal was introduced.
-  This signal is deprecated and is no longer updated as of May 28, 2020.
+  It also uses `smoothed_cli` from the `doctor-visits` source instead of
+  `smoothed_adj_cli`. This signal is deprecated and is no longer updated as of
+  May 28, 2020.
 
 ## COVIDcast Map Signals
 


### PR DESCRIPTION
Fixes the API docs for the updated combination signal, and fixes the table showing the signals included in the map.

Will merge only after the 1.2.1 site update goes live.