### PR TITLE
List data changes from cmu-delphi/covidcast-indicators#47 in a changelog

### DIFF
--- a/docs/api/covidcast_changelog.md
+++ b/docs/api/covidcast_changelog.md
@@ -6,7 +6,6 @@ When Delphi makes substantial changes to the computation of a signal, we will ty
 ### `doctor-visits`
 ### `fb-survey`
 
-<a name="fb-survey-v1.3"></a> 
 #### 3 June 2020: v1.3
 
 Duplicate survey weights had corrupted historical figures for the following signals and dates. The correct data has been restored to the API.

--- a/docs/api/covidcast_changelog.md
+++ b/docs/api/covidcast_changelog.md
@@ -1,0 +1,28 @@
+# Delphi's COVID-19 Surveillance Streams Changelog
+
+When Delphi makes substantial changes to the computation of a signal, we will typically publish it under a new name rather than revising the existing signal. By contrast, the changes documented here are bug fixes and pipeline repairs.
+
+## Sources and Signals
+### `doctor-visits`
+### `fb-survey`
+
+<a name="fb-survey-v1.3"></a> 
+#### 3 June 2020: v1.3
+
+Duplicate survey weights had corrupted historical figures for the following signals and dates. The correct data has been restored to the API.
+* `raw_wcli`
+  * `county`: 20200406, 20200408, 20200410, 20200430
+  * `hrr`: 20200406, 20200408-20200410, 20200430
+  * `msa`: 20200408, 20200410, 20200430
+  * `state`: 20200408-20200410, 20200430
+* `smoothed_wcli`
+  * `county`: 20200406, 20200408-20200414, 20200430-20200506
+  * `hrr`: 20200406-20200415, 20200430-20200506
+  * `msa`: 20200408-20200414, 20200430-20200506
+  * `state`: 20200408-20200416, 20200430-20200506
+
+### `google-survey`
+### `ght`
+### `quidel`
+### `jhu-csse`
+### `indicator-combination`

--- a/docs/api/covidcast_signals.md
+++ b/docs/api/covidcast_signals.md
@@ -33,6 +33,9 @@ several days after they occur, these signals are typically available with
 several days of lag. This means that estimates for a specific day are only
 available several days later.
 
+* Number of data revisions since 19 May 2020: 0
+* Date of last change: Never
+
 ### `fb-survey`
 
 Data source based on symptom surveys run by Carnegie Mellon. Facebook directs a 
@@ -66,6 +69,9 @@ the way in which our smoothing works, which is based on pooling data across
 successive days), these smoothed signals are generally available at many more
 counties (and MSAs) than the raw signals. 
 
+* Number of data revisions since 19 May 2020: 1
+* Date of last change: [19 May 2020](covidcast_changelog.md#fb-survey-v1.3)
+
 ### `google-survey`
 
 Data source based on Google-run symptom surveys, through publisher websites,
@@ -94,6 +100,9 @@ specific geographical areas as needed to support forecasting efforts.
 | `raw_cli` | Estimated percentage of people who know someone in their community with COVID-like illness |
 | `smoothed_cli` | Estimated percentage of people who know someone in their community with COVID-like illness, smoothed in time |
 
+* Number of data revisions since 19 May 2020: 0
+* Date of last change: Never
+
 ### `ght`
 
 Data source based on Google searches, provided to us by Google Health 
@@ -108,6 +117,9 @@ so county estimates are not available from the API.
 | --- | --- |
 | `raw_search` | Google search volume for COVID-related searches, in arbitrary units that are normalized for population | 
 | `smoothed_search` | Google search volume for COVID-related searches, in arbitrary units that are normalized for population, smoothed in time using a local linear smoother with Gaussian kernel | 
+
+* Number of data revisions since 19 May 2020: 0
+* Date of last change: Never
 
 ### `quidel`
 
@@ -134,6 +146,9 @@ small. The data may be updated again when the Winter 2020 flu season begins.
 | `raw_tests_per_device` | The number of flu tests conducted by each testing device; measures volume of testing | 
 | `smoothed_tests_per_device` | Same as above, but smoothed in time |
 
+* Number of data revisions since 19 May 2020: 0
+* Date of last change: Never
+
 ### `jhu-csse`
 
 Data source of confirmed COVID-19 cases and deaths, based on reports made
@@ -152,6 +167,9 @@ University.
 Our signals here are taken directly from the JHU CSSE 
 [COVID-19 GitHub repository](https://github.com/CSSEGISandData/COVID-19) without 
 filtering, smoothing, or changes.
+
+* Number of data revisions since 19 May 2020: 0
+* Date of last change: Never
 
 ### `indicator-combination`
 
@@ -174,6 +192,9 @@ sources above. It is not a primary data source.
   It also uses `smoothed_cli` from the `doctor-visits` source instead of
   `smoothed_adj_cli`. This signal is deprecated and is no longer updated as of
   May 28, 2020.
+
+* Number of data revisions since 19 May 2020: 0
+* Date of last change: Never
 
 ## COVIDcast Map Signals
 

--- a/docs/api/covidcast_signals.md
+++ b/docs/api/covidcast_signals.md
@@ -70,7 +70,7 @@ successive days), these smoothed signals are generally available at many more
 counties (and MSAs) than the raw signals. 
 
 * Number of data revisions since 19 May 2020: 1
-* Date of last change: [19 May 2020](covidcast_changelog.md#fb-survey-v1.3)
+* Date of last change: [3 June 2020](covidcast_changelog.md#fb-survey)
 
 ### `google-survey`
 


### PR DESCRIPTION
* Creates a new page to hold the changelog
* Prototypes a changelog format that balances completeness with concision
* Adds references to changelog in each source section of `_signals.md`

We may want to pick a different anchor date, particularly for Quidel and Google Surveys.