### PR TITLE
Remove minimum sample size requirement.

### DIFF
--- a/src/acquisition/covidcast/csv_importer.py
+++ b/src/acquisition/covidcast/csv_importer.py
@@ -229,8 +229,6 @@ class CsvImporter:
     except ValueError:
       # expected a number, but got a string
       return (None, 'sample_size')
-    if sample_size is not None and sample_size < CsvImporter.MIN_SAMPLE_SIZE:
-      return (None, 'sample_size')
 
     # return extracted and validated row values
     row_values = CsvImporter.RowValues(geo_id, value, stderr, sample_size)

--- a/src/acquisition/covidcast/csv_importer.py
+++ b/src/acquisition/covidcast/csv_importer.py
@@ -29,10 +29,6 @@ class CsvImporter:
   MIN_YEAR = 2019
   MAX_YEAR = 2030
 
-  # reasonable lower bound for sanity checking sample size (if sample size is
-  # present, then, for privacy, it should definitely be larger than this value)
-  MIN_SAMPLE_SIZE = 5
-
   # NOTE: this should be a Python 3.7+ `dataclass`, but the server is on 3.4
   # See https://docs.python.org/3/library/dataclasses.html
   class RowValues:


### PR DESCRIPTION
Indicators will do their own sample size validation from here on out.

This is necessary for the safegraph indicator, which uses a special definition of sample size (requested by forecasting) that is not based on individual users but on clusters.