### PR TITLE
Skip computing direction on signals without enough history

### DIFF
--- a/src/acquisition/covidcast/direction_updater.py
+++ b/src/acquisition/covidcast/direction_updater.py
@@ -85,6 +85,11 @@ def update_loop(database, direction_impl=Direction):
       series_length,
     ) = row
 
+    if source not in data_stdevs or signal not in data_stdevs[source]:
+      msg = '%s.%s is too new a signal to have a historical stdev reference; skipping'
+      print(msg % (source,signal))
+      continue
+
     # progress reporting for anyone debugging/watching the output
     be_verbose = ts_index < 100
     be_verbose = be_verbose or ts_index % 100 == 0


### PR DESCRIPTION
Stopgap for the dreaded Direction crashes. This will skip direction on signals that don't have an entry in the output of `database.get_data_stdev_across_locations`  (which cuts off at 22 April 2020)