### PR TITLE
Remove minimum sample size test; include unit tests in dev guide

### DIFF
--- a/docs/epidata_development.md
+++ b/docs/epidata_development.md
@@ -106,7 +106,29 @@ docker run --rm -p 10080:80 \
   delphi_web_epidata
 ```
 
-## manual
+## unit tests
+
+Once the server containers are running, you can run unit tests.
+
+First, build the `delphi_python` image per the
+  [backend development guide](https://github.com/cmu-delphi/operations/blob/master/docs/backend_development.md#creating-an-image).
+  Your test sources will live in, and be executed from within, this image.
+
+Then run the test container:
+
+  ```bash
+  docker run --rm --network delphi-net delphi_python \
+  python3 -m undefx.py3tester.py3tester \
+  repos/delphi/delphi-epidata/tests
+  ```
+  
+  The final line of output should be similar to the following:
+  
+  ```
+  All 48 tests passed! 68% (490/711) coverage.
+  ```
+
+## manual tests
 
 You can test your changes manually by:
 
@@ -195,7 +217,7 @@ Here's a full example based on the `fluview` endpoint:
   libraries are better candidates for automated integration tests (and unit
   tests, in the case of the python client) than one-off manual tests.
 
-## integration
+## integration tests
 
 Writing an integration test is outside of the scope of this document. However,
 a number of existing integration tests exist and can be used as a good starting

--- a/tests/acquisition/covidcast/test_csv_importer.py
+++ b/tests/acquisition/covidcast/test_csv_importer.py
@@ -132,7 +132,6 @@ class UnitTests(unittest.TestCase):
       (make_row(geo_type='state', geo_id='iowa'), 'geo_id'),
       (make_row(geo_type='country', geo_id='usa'), 'geo_type'),
       (make_row(se='-1'), 'se'),
-      (make_row(sample_size='3'), 'sample_size'),
       (make_row(geo_type=None), 'geo_type'),
       (make_row(geo_id=None), 'geo_id'),
       (make_row(val=None), 'val'),


### PR DESCRIPTION
The deploy of #126 failed because of failing unit tests. Unit tests were not included in the developer guide, so I've added a section describing how to run them. The failing test has been fixed (we no longer want acquisition to fail on a sample size < 5), and all tests pass.