### PR TITLE
Make metadata requests use the cached endpoint automatically

### DIFF
--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -524,7 +524,7 @@ Epidata <- (function() {
 
   # Fetch Delphi's COVID-19 Surveillance Streams metadata
   covidcast_meta <- function() {
-    return(.request(list(source='covidcast_meta')))
+    return(.request(list(source='covidcast_meta', cached='true')))
   }
 
   # Export the public methods

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -563,4 +563,4 @@ class Epidata:
   @staticmethod
   def covidcast_meta():
     """Fetch Delphi's COVID-19 Surveillance Streams metadata"""
-    return Epidata._request({'source': 'covidcast_meta'})
+    return Epidata._request({'source': 'covidcast_meta', 'cached': 'true'})

--- a/src/client/packaging/pypi/setup.py
+++ b/src/client/packaging/pypi/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
   name='delphi_epidata',
-  version='0.0.5',
+  version='0.0.6',
   author='David Farrow',
   author_email='dfarrow0@gmail.com',
   description='A programmatic interface to Delphi\'s Epidata API.',


### PR DESCRIPTION
The overhead for the non-cached endpoint is substantial.

(I'm going to check if David can push a new version of `delphi-epidata` to PyPI for us, so we can release a Python package that has fast access to the metadata without monkey-patching the current version.)