### PR TITLE
Fix/cvc meta timeout

### DIFF
--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -8,6 +8,7 @@ import mysql.connector
 
 # first party
 from delphi.epidata.client.delphi_epidata import Epidata
+from delphi.epidata.acquisition.covidcast.covidcast_meta_cache_updater import main as update_covidcast_meta_cache
 
 # py3tester coverage target
 __test_target__ = 'delphi.epidata.client.delphi_epidata'
@@ -81,6 +82,9 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
           123, 1.5, 2.5, 3.5, 456, 4)
     ''')
     self.cnx.commit()
+
+    # cache it
+    update_covidcast_meta_cache(args=None)
 
     # fetch data
     response = Epidata.covidcast_meta()

--- a/integrations/server/test_covidcast_meta.py
+++ b/integrations/server/test_covidcast_meta.py
@@ -7,6 +7,8 @@ import unittest
 import mysql.connector
 import requests
 
+#first party
+from delphi.epidata.acquisition.covidcast.covidcast_meta_cache_updater import main as update_cache
 
 # use the local instance of the Epidata API
 BASE_URL = 'http://delphi_web_epidata/epidata/api.php'
@@ -69,6 +71,7 @@ class CovidcastMetaTests(unittest.TestCase):
               for gv, v in zip(('geo1', 'geo2'), (10, 20)):
                 self.cur.execute(template % (src, sig, tt, gt, tv, gv, v))
     self.cnx.commit()
+    update_cache(args=None)
 
     # make the request
     response = requests.get(BASE_URL, params={'source': 'covidcast_meta'})
@@ -114,6 +117,7 @@ class CovidcastMetaTests(unittest.TestCase):
               for gv, v in zip(('geo1', 'geo2'), (10, 20)):
                 self.cur.execute(template % (src, sig, tt, gt, tv, gv, v))
     self.cnx.commit()
+    update_cache(args=None)
 
     # make the request
     response = requests.get(BASE_URL, params={'source': 'covidcast_meta'})

--- a/src/acquisition/covidcast/database.py
+++ b/src/acquisition/covidcast/database.py
@@ -251,6 +251,42 @@ class Database:
     args = (source, signal, time_type, geo_type, geo_value)
     self._cursor.execute(sql, args)
 
+  def get_covidcast_meta(self):
+    """Compute and return metadata on all non-WIP COVIDcast signals."""
+
+    sql = '''
+      SELECT
+        t.`source` AS `data_source`,
+        t.`signal`,
+        t.`time_type`,
+        t.`geo_type`,
+        MIN(t.`time_value`) AS `min_time`,
+        MAX(t.`time_value`) AS `max_time`,
+        COUNT(DISTINCT t.`geo_value`) AS `num_locations`,
+        MIN(`value`) AS `min_value`,
+        MAX(`value`) AS `max_value`,
+        AVG(`value`) AS `mean_value`,
+        STD(`value`) AS `stdev_value`,
+        MAX(`timestamp1`) AS `last_update`
+      FROM
+        `covidcast` t
+      WHERE
+        t.`signal` NOT LIKE 'wip_%'
+      GROUP BY
+        t.`source`,
+        t.`signal`,
+        t.`time_type`,
+        t.`geo_type`
+      ORDER BY
+        t.`source` ASC,
+        t.`signal` ASC,
+        t.`time_type` ASC,
+        t.`geo_type` ASC
+'''
+    FIELDS="data_source signal time_type geo_type min_time max_time num_locations min_value max_value mean_value stdev_value last_update".split()
+    self._cursor.execute(sql)
+    return list(dict(zip(FIELDS,x)) for x in self._cursor)
+
   def update_covidcast_meta_cache(self, epidata_json):
     """Updates the `covidcast_meta_cache` table."""
 

--- a/src/acquisition/covidcast/database.py
+++ b/src/acquisition/covidcast/database.py
@@ -283,9 +283,8 @@ class Database:
         t.`time_type` ASC,
         t.`geo_type` ASC
 '''
-    FIELDS="data_source signal time_type geo_type min_time max_time num_locations min_value max_value mean_value stdev_value last_update".split()
     self._cursor.execute(sql)
-    return list(dict(zip(FIELDS,x)) for x in self._cursor)
+    return list(dict(zip(self._cursor.column_names,x)) for x in self._cursor)
 
   def update_covidcast_meta_cache(self, epidata_json):
     """Updates the `covidcast_meta_cache` table."""

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -563,4 +563,4 @@ class Epidata:
   @staticmethod
   def covidcast_meta():
     """Fetch Delphi's COVID-19 Surveillance Streams metadata"""
-    return Epidata._request({'source': 'covidcast_meta', 'cached': 'true'})
+    return Epidata._request({'source': 'covidcast_meta'})

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -969,32 +969,10 @@ function get_covidcast($source, $signal, $time_type, $geo_type, $time_values, $g
   return count($epidata) === 0 ? null : $epidata;
 }
 
-// queries the `covidcast` table for metadata only.
-// MAINTAINER WARNING: this query is duplicated in
-// acquisition/covidcast/database.py as a workaround for Gateway Timeout Error
-// during cache update jobs. If you make changes here, make changes there, too.
+// queries the `covidcast_meta_cache` table for metadata
 function get_covidcast_meta() {
-  // basic query info
-  $table = '`covidcast` t';
-  $fields = "t.`source` AS `data_source`, t.`signal`, t.`time_type`, t.`geo_type`, MIN(t.`time_value`) AS `min_time`, MAX(t.`time_value`) AS `max_time`, COUNT(DISTINCT `geo_value`) AS `num_locations`, MIN(`value`) AS `min_value`, MAX(`value`) AS `max_value`, AVG(`value`) AS `mean_value`, STD(`value`) AS `stdev_value`, MAX(`timestamp1`) AS `last_update`";
-  $condition_wip = "t.`signal` NOT LIKE 'wip_%'";
-  $group = "t.`source`, t.`signal`, t.`time_type`, t.`geo_type`";
-  $order = "t.`source` ASC, t.`signal` ASC, t.`time_type` ASC, t.`geo_type` ASC";
-  // data type of each field
-  $fields_string = array('data_source', 'signal', 'time_type', 'geo_type');
-  $fields_int = array('min_time', 'max_time', 'num_locations', 'last_update');
-  $fields_float = array('min_value', 'max_value', 'mean_value', 'stdev_value');
-  // the query
-  $query = "SELECT {$fields} FROM {$table} WHERE {$condition_wip} GROUP BY {$group} ORDER BY {$order}";
-  // get the data from the database
-  $epidata = array();
-  execute_query($query, $epidata, $fields_string, $fields_int, $fields_float);
-  // return the data
-  return count($epidata) === 0 ? null : $epidata;
-}
-
-// queries the `covidcast` table for cached metadata only. 
-function get_covidcast_meta_cached() {
+  // complain if the cache is more than 75 minutes old
+  $max_age = 75 * 60;
 
   // basic query info
   $query = 'SELECT UNIX_TIMESTAMP(NOW()) - `timestamp` AS `age`, `epidata` FROM `covidcast_meta_cache` LIMIT 1';
@@ -1007,7 +985,7 @@ function get_covidcast_meta_cached() {
     // parse and use the cached response
     $epidata = json_decode($row['epidata'], true);
 
-    if (intval($row['age']) < $max_age && strlen($row['epidata']) > 0) {
+    if (intval($row['age']) > $max_age && strlen($row['epidata']) > 0) {
       error_log('covidcast_meta cache is stale: '.$row['age']);
     }
   }
@@ -1475,11 +1453,7 @@ if(database_connect()) {
     }
   } else if($source === 'covidcast_meta') {
     // get the metadata
-    if (isset($_REQUEST['cached']) && $_REQUEST['cached'] === 'true') {
-      $epidata = get_covidcast_meta_cached();
-    } else {
-      $epidata = get_covidcast_meta();
-    }
+    $epidata = get_covidcast_meta();
     store_result($data, $epidata);
   } else {
     $data['message'] = 'no data source specified';

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -970,6 +970,9 @@ function get_covidcast($source, $signal, $time_type, $geo_type, $time_values, $g
 }
 
 // queries the `covidcast` table for metadata only.
+// MAINTAINER WARNING: this query is duplicated in
+// acquisition/covidcast/database.py as a workaround for Gateway Timeout Error
+// during cache update jobs. If you make changes here, make changes there, too.
 function get_covidcast_meta() {
   // basic query info
   $table = '`covidcast` t';

--- a/tests/acquisition/covidcast/test_covidcast_meta_cache_updater.py
+++ b/tests/acquisition/covidcast/test_covidcast_meta_cache_updater.py
@@ -37,6 +37,7 @@ class UnitTests(unittest.TestCase):
     mock_epidata_impl = MagicMock()
     mock_epidata_impl.covidcast_meta.return_value = api_response
     mock_database = MagicMock()
+    mock_database.get_covidcast_meta.return_value=api_response['epidata']
     fake_database_impl = lambda: mock_database
 
     main(
@@ -55,7 +56,7 @@ class UnitTests(unittest.TestCase):
     self.assertTrue(mock_database.disconnect.call_args[0][0])
 
   def test_main_failure(self):
-    """Run the main program with API failure."""
+    """Run the main program with a query failure."""
 
     api_response = {
       'result': -123,
@@ -63,9 +64,10 @@ class UnitTests(unittest.TestCase):
     }
 
     args = None
-    mock_epidata_impl = MagicMock()
-    mock_epidata_impl.covidcast_meta.return_value = api_response
+    mock_database = MagicMock()
+    mock_database.get_covidcast_meta.return_value = list()
+    fake_database_impl = lambda: mock_database
 
-    main(args, epidata_impl=mock_epidata_impl, database_impl=None)
+    main(args, epidata_impl=None, database_impl=fake_database_impl)
 
-    self.assertTrue(mock_epidata_impl.covidcast_meta.called)
+    self.assertTrue(mock_database.get_covidcast_meta.called)


### PR DESCRIPTION
This PR addresses the metadata cache update timeout problem by switching how the cache updater obtains live metadata computations. The cache updater used to call the python API for this; it now runs its own SQL query.

All integration and unit tests pass -- they have been updated with appropriate MagicMock settings for the covidcast database utility, and to call the cache updater when needed for testing the API `covidcast_meta` call (which now only supports pulling cached metadata)

If you ask the API server for cached metadata, and the metadata is stale, it will log an error on the server, and then give you the stale metadata anyway. 