### PR TITLE
WIP Add technical descriptions to API documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -30,7 +30,12 @@ plugins:
 
 remote_theme: pmarsceill/just-the-docs
 
-# Just the Docs config
+## Just the Docs config
+# The theme compresses HTML (remove newlines, whitespace) by default, but this
+# breaks KaTeX, since kramdown inserts % in some places in the output.
+compress_html:
+  ignore:
+    envs: "all"
 
 aux_links:
   "CMU Delphi Research Group":

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,0 +1,3 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/mathtex-script-type.min.js" integrity="sha384-LJ2FmexL77rmGm6SIpxq7y+XA6bkLzGZEgCywzKOZG/ws4va9fUVu2neMjvc3zdv" crossorigin="anonymous"></script>

--- a/docs/api/covidcast-signals/_source-template.md
+++ b/docs/api/covidcast-signals/_source-template.md
@@ -5,6 +5,7 @@ grand_parent: COVIDcast API
 ---
 
 # SOURCE NAME
+{: .no_toc}
 
 * **Source name:** `SOURCE-API-NAME`
 * **First issued:** DATE RELEASED TO API
@@ -17,6 +18,40 @@ A brief description of what this source measures.
 | Signal | Description |
 | --- | --- |
 | `signal_name` | Brief description of the signal, including the units it is measured in and any smoothing that is applied |
+
+## Table of contents
+{: .no_toc .text-delta}
+
+1. TOC
+{:toc}
+
+## Estimation
+
+Describe how any relevant quantities are estimated---both statistically and in
+terms of the underlying features or inputs. (For example, if a signal is based
+on hospitalizations, what specific types of hospitalization are counted?)
+
+If you need mathematics, we use KaTeX; you can see its supported LaTeX
+[here](https://katex.org/docs/supported.html). Inline math is done with *double*
+dollar signs, as in $$x = y/z$$, and display math by placing them with
+surrounding blank lines, as in
+
+$$
+\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}.
+$$
+
+Note that the blank lines are essential.
+
+### Standard Error
+
+If this signal is a random variable, e.g. if it is a survey or based on
+proportion estimates, describe here how its standard error is reported and the
+nature of the random variation.
+
+### Smoothing
+
+If the smoothing is unusual or involves extra steps beyond a simple moving
+average, describe it here.
 
 ## Limitations
 
@@ -31,12 +66,6 @@ If this signal is reported with a consistent lag, describe it here.
 
 If this signal is regularly backfilled, describe the reason and nature of the
 backfill here.
-
-## Standard Error
-
-If this signal is a random variable, e.g. if it is a survey or based on
-proportion estimates, describe here how its standard error is reported and the
-nature of the random variation.
 
 ## Source
 

--- a/docs/api/covidcast-signals/doctor-visits.md
+++ b/docs/api/covidcast-signals/doctor-visits.md
@@ -13,12 +13,12 @@ grand_parent: COVIDcast API
 * **Available for:** county, hrr, msa, state (see [geography coding docs](../covidcast_geography.md))
 
 This data source is based on information about outpatient visits, provided to us
-by healthcare partners. Using this outpatient data, we estimate the percentage
-of COVID-related doctor's visits in a given location, on a given day.
+by a national health system. Using this outpatient data, we estimate the
+percentage of COVID-related doctor's visits in a given location, on a given day.
 
 | Signal | Description |
 | --- | --- |
-| `smoothed_cli` | Estimated percentage of outpatient doctor visits primarily about COVID-related symptoms, based on data from healthcare partners, smoothed in time using a Gaussian linear smoother |
+| `smoothed_cli` | Estimated percentage of outpatient doctor visits primarily about COVID-related symptoms, based on data from a national health system, smoothed in time using a Gaussian linear smoother |
 | `smoothed_adj_cli` | Same, but with systematic day-of-week effects removed; see [details below](#day-of-week-adjustment) |
 
 ## Table of contents
@@ -29,10 +29,10 @@ of COVID-related doctor's visits in a given location, on a given day.
 
 ## Lag and Backfill
 
-Note that because doctor's visits may be reported to our healthcare partners
-several days after they occur, these signals are typically available with
-several days of lag. This means that estimates for a specific day are only
-available several days later.
+Note that because doctor's visits may be reported to the health system several
+days after they occur, these signals are typically available with several days
+of lag. This means that estimates for a specific day are only available several
+days later.
 
 The amount of lag in reporting can vary, and not all visits are reported with
 the same lag. After we first report estimates for a specific date, further data
@@ -43,15 +43,16 @@ June 16th.
 
 ## Limitations
 
-This data source is based on outpatient visit data provided to us by healthcare
-partners. Our partners can report on a portion of the United States healthcare
-market, but not all of it, and so this source only represents those visits known
-to our partners. Their coverage and market share may vary across the United
-States.
+This data source is based on outpatient visit data provided to us by a national
+health system. The system can report on a portion of United States outpatient
+doctor's visits, but not all of them, and so this source only represents those
+visits known to them. Their coverage may vary across the United States.
+
+Standard errors are not available for this data source.
 
 ## Qualifying Conditions
 
-Our healthcare partners provide data on the following five categories of counts:
+We receive data on the following five categories of counts:
 
 - Denominator: Daily count of all unique outpatient visits.
 - COVID-like: Daily count of all unique outpatient visits with primary ICD-10 code

--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -25,12 +25,12 @@ given day.
 
 | Signal | Description |
 | --- | --- |
-| `raw_cli` | Estimated percentage of people with COVID-like illness, with no smoothing or survey weighting |
-| `raw_ili` | Estimated percentage of people with influenza-like illness, with no smoothing or survey weighting |
+| `raw_cli` | Estimated percentage of people with COVID-like illness based on the [criteria below](#defining-household-ili-and-cli), with no smoothing or survey weighting |
+| `raw_ili` | Estimated percentage of people with influenza-like illness based on the [criteria below](#defining-household-ili-and-cli), with no smoothing or survey weighting |
 | `raw_wcli` | Estimated percentage of people with COVID-like illness; adjusted using survey weights |
 | `raw_wili` | Estimated percentage of people with influenza-like illness; adjusted using survey weights |
-| `raw_hh_cmnty_cli` | Estimated percentage of people reporting illness in their local community, including their household, with no smoothing or survey weighting |
-| `raw_nohh_cmnty_cli` | Estimated percentage of people reporting illness in their local community, not including their household, with no smoothing or survey weighting |
+| `raw_hh_cmnty_cli` | Estimated percentage of people reporting illness in their local community, as [described below](#estimating-community-cli), including their household, with no smoothing or survey weighting |
+| `raw_nohh_cmnty_cli` | Estimated percentage of people reporting illness in their local community, as [described below](#estimating-community-cli), not including their household, with no smoothing or survey weighting |
 
 Note that for `raw_hh_cmnty_cli` and `raw_nohh_cmnty_cli`, the illnesses
 included are broader: a respondent is included if they know someone in their
@@ -40,10 +40,10 @@ attempt to distinguish between COVID-like and influenza-like illness.
 
 Along with the `raw_` signals, there are additional signals with names beginning
 with `smoothed_`. These estimate the same quantities as the above signals, but
-are smoothed in time to reduce day-to-day sampling noise; importantly (due to
-the way in which our smoothing works, which is based on pooling data across
-successive days), these smoothed signals are generally available at many more
-counties (and MSAs) than the raw signals.
+are smoothed in time to reduce day-to-day sampling noise; see [details
+below](#smoothing). Because the smoothed signals combine information across
+seven days, they have larger sample sizes and hence are available for more
+counties and MSAs than the raw signals.
 
 ## Table of contents
 {: .no_toc .text-delta}
@@ -72,8 +72,9 @@ The survey starts with the following 5 questions:
 
 Beyond these 5 questions, there are also many other questions that follow in the
 survey, which go into more detail on symptoms and demographics. These are
-primarily of interest to other researchers, but could still be useful for our
-purposes. The full survey can be found TODO.
+primarily of interest to researchers studying the social and economic effects of
+the pandemic, but could still be useful for forecasting purposes. The full
+survey can be found TODO. TODO Link to details on obtaining research access
 
 As of mid-June 2020, the median number of Facebook survey responses per day, is
 about 72,000.
@@ -143,11 +144,11 @@ We estimate $$p$$ and $$q$$ across 4 temporal-spatial aggregation schemes:
 
 Note that these spatial aggregations are possible as we have the ZIP code of the
 household from Q4 of the survey. Our current rule-of-thumb is to discard any
-estimate (whether at a county, MSA, HRR, or state level) that is comprised of
-less than 100 survey responses. When our geographical mapping data indicates
-that a ZIP code is part of multiple geographical units in a single aggregation,
-we assign weights to each of these units and proceed as described below, but
-with uniform participation weights ($$w^{\text{part}}_i=1$$ for all $$i$$).
+estimate (whether at a county, MSA, HRR, or state level) that is based on fewer
+than 100 survey responses. When our geographical mapping data indicates that a
+ZIP code is part of multiple geographical units in a single aggregation, we
+assign weights to each of these units and proceed as described below, but with
+uniform participation weights ($$w^{\text{part}}_i=1$$ for all $$i$$).
 
 In a given temporal-spatial unit (for example, daily-county), let $$X_i$$ and
 $$Y_i$$ denote number of ILI and CLI cases in the household, respectively
@@ -218,7 +219,8 @@ $$
 \hat{b} = 100 \cdot \frac{1}{m} \sum_{i=1}^m V_i.
 $$
 
-Their estimated standard errors are:
+Hence $$\hat{a}$$ is reported in the `hh_cmnty_cli` signals and $$\hat{b}$$ in
+the `nohh_cmnty_cli` signals. Their estimated standard errors are:
 
 $$
 \begin{aligned}
@@ -236,6 +238,16 @@ similarly for $$V$$. Hence $$\hat{a}$$ and $$\hat{b}$$ will generally
 overestimate $$a$$ and $$b$$. However, given the extremely high overlap between
 the definitions of ILI and CLI, we do not consider this to be practically very
 problematic.
+
+
+### Smoothing
+
+The smoothed versions of the signals described above (with `smoothed_` prefix)
+are calculated using seven day pooling. For example, the estimate reported for
+June 7 in a specific geographical area (such as county or MSA) is formed by
+collecting all surveys completed between June 1 and 7 (inclusive) and using that
+data in the estimation procedures described above.
+
 
 ## Survey Weighting
 

--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -5,6 +5,7 @@ grand_parent: COVIDcast API
 ---
 
 # Symptom Surveys
+{: .no_toc}
 
 * **Source name:** `fb-survey`
 * **Number of data revisions since 19 May 2020:** 1
@@ -37,13 +38,351 @@ household (for `raw_hh_cmnty_cli`) or community with fever, along with sore
 throat, cough, shortness of breath, or difficulty breathing. This does not
 attempt to distinguish between COVID-like and influenza-like illness.
 
-The survey weights, provided by Facebook, are intended to make the sample
-representative of the US population, according to the state, age, and gender of
-the US population from the 2018 Census March Supplement.
-
 Along with the `raw_` signals, there are additional signals with names beginning
 with `smoothed_`. These estimate the same quantities as the above signals, but
 are smoothed in time to reduce day-to-day sampling noise; importantly (due to
 the way in which our smoothing works, which is based on pooling data across
 successive days), these smoothed signals are generally available at many more
 counties (and MSAs) than the raw signals.
+
+## Table of contents
+{: .no_toc .text-delta}
+
+1. TOC
+{:toc}
+
+## Survey Questions
+
+The survey starts with the following 5 questions:
+
+1. In the past 24 hours, have you or anyone in your household had any of the
+   following (yes/no for each):
+   - (a) Fever (100 °F or higher)
+   - (b) Sore throat
+   - (c) Cough
+   - (d) Shortness of breath
+   - (e) Difficulty breathing
+2. How many people in your household (including yourself) are sick (fever, along
+   with at least one other symptom from the above list)?
+3. How many people are there in your household in total (including yourself)?
+4. What is your current ZIP code?
+5. How many additional people in your local community that you know personally
+   are sick (fever, along with at least one other symptom from the above list)?
+
+
+Beyond these 5 questions, there are also many other questions that follow in the
+survey, which go into more detail on symptoms and demographics. These are
+primarily of interest to other researchers, but could still be useful for our
+purposes. The full survey can be found TODO.
+
+As of mid-June 2020, the median number of Facebook survey responses per day, is
+about 72,000.
+
+
+## ILI and CLI Indicators
+
+Influenza-like illness or ILI is a standard indicator, and is defined by the CDC
+as: fever along with sore throat or cough. From the list of symptoms from Q1 on
+our survey, this means a and (b or c).
+
+COVID-like illness or CLI is not a standard indicator. Through our discussions
+with the CDC, we chose to define it as: fever along with cough or shortness of
+breath or difficulty breathing.
+
+### Defining Household ILI and CLI
+
+For a single survey, we are interested in the quantities:
+
+- $$X =$$ the number of people in the household with ILI;
+- $$Y =$$ the number of people in the household with CLI;
+- $$N =$$ the number of people in the household.
+
+Note that $$N$$ comes directly from the answer to Q3, but neither $$X$$ nor
+$$Y$$ can be computed directly (because Q2 does not give an answer to the
+precise symptomatic profile of all individuals in the household, it only asks
+how many individuals have fever and at least one other symptom from the list).
+
+We hence estimate $$X$$ and $$Y$$ with the following simple strategy. Consider
+ILI, without a loss of generality (we apply the same strategy to CLI). Let $$Z$$
+be the answer to Q2.
+
+- If the answer to Q1 does not meet the ILI definition, then we report $$X=0$$.
+- If the answer to Q1 does meet the ILI definition, then we report $$X = Z$$.
+
+This can only "over count" (result in too large estimates of) the true $$X$$ and
+$$Y$$. For example, this happens when some members of the household experience
+ILI that does not also qualify as CLI, while others experience CLI that does not
+also qualify as ILI. In this case, for both $$X$$ and $$Y$$, our simple strategy
+would return the sum of both types of cases. However, given the extreme degree
+of overlap between the definitions of ILI and CLI, it is reasonable to believe
+that, if symptoms across all household members qualified as both ILI and CLI,
+each individual would have both, or neither---with neither being more common.
+Therefore we do not consider this "over counting" phenomenon practically
+problematic.
+
+### Estimating Percent ILI and CLI
+
+Let $$x$$ and $$y$$ be the number of people with ILI and CLI, respectively, over
+a given time period, and in a given location (for example, the time period being
+a particular day, and a location being a particular county). Let $$n$$ be the
+total number of people in this location. We are interested in estimating the
+true ILI and CLI percentages, which we denote by $$p$$ and $$q$$, respectively:
+
+$$
+p = 100 \cdot \frac{x}{n}
+\quad\text{and}\quad
+q = 100 \cdot \frac{y}{n}.
+$$
+
+We estimate $$p$$ and $$q$$ across 4 temporal-spatial aggregation schemes:
+
+1. daily, at the county level;
+2. daily, at the MSA (metropolitan statistical area) level;
+3. daily, at the HRR (hospital referral region) level;
+4. daily, at the state level.
+
+Note that these spatial aggregations are possible as we have the ZIP code of the
+household from Q4 of the survey. Our current rule-of-thumb is to discard any
+estimate (whether at a county, MSA, HRR, or state level) that is comprised of
+less than 100 survey responses. When our geographical mapping data indicates
+that a ZIP code is part of multiple geographical units in a single aggregation,
+we assign weights to each of these units and proceed as described below, but
+with uniform participation weights ($$w^{\text{part}}_i=1$$ for all $$i$$).
+
+In a given temporal-spatial unit (for example, daily-county), let $$X_i$$ and
+$$Y_i$$ denote number of ILI and CLI cases in the household, respectively
+(computed according to the simple strategy described above), and let $$N_i$$
+denote the total number of people in the household, in survey $$i$$, out of
+$$m$$ surveys we collected. Then our estimates of $$p$$ and $$q$$ (see Appendix
+below for motivating details) are:
+
+$$
+\hat{p} = 100 \cdot \frac{1}{m}\sum_{i=1}^m \frac{X_i}{N_i}
+\quad\text{and}\quad
+\hat{q} = 100 \cdot \frac{1}{m}\sum_{i=1}^m \frac{Y_i}{N_i}.
+$$
+
+Their estimated standard errors are:
+
+$$
+\begin{aligned}
+\widehat{\mathrm{se}}(\hat{p}) &= 100 \cdot \frac{1}{m+1}\sqrt{
+  \left(\frac{1}{2} - \hat{p}\right)^2 +
+  \sum_{i=1}^m \left(\frac{X_i}{N_i} - \hat{p}\right)^2
+} \\
+\widehat{\mathrm{se}}(\hat{q}) &= 100 \cdot \frac{1}{m+1}\sqrt{
+  \left(\frac{1}{2} - \hat{q}\right)^2 +
+  \sum_{i=1}^m \left(\frac{Y_i}{N_i} - \hat{q}\right)^2
+},
+\end{aligned}
+$$
+
+the standard deviations of the estimators after adding a single
+pseudo-observation at 1/2 (treating $$m$$ as fixed). The use of the
+pseudo-observation prevents standard error estimates of zero, and in simulations
+improves the quality of the standard error estimates.
+
+The pseudo-observation is not used in $$\hat{p}$$ and $$\hat{q}$$ themselves, to
+avoid potentially large amounts of estimation bias, as $$p$$ and $$q$$ are
+expected to be small.
+
+### Estimating "Community CLI"
+
+Over a given time period, and in a given location, let $$u$$ be the number of
+people who know someone in their community with CLI, and let $$v$$ be the number
+of people who know someone in their community, outside of their household, with
+CLI. With $$n$$ denoting the number of people total in this location, we are
+interested in the percentages:
+
+$$
+a = 100 \cdot \frac{u}{n}
+\quad\text{and}\quad
+b = 100 \cdot \frac{y}{n}.
+$$
+
+We will estimate $$a$$ and $$b$$ across the same 4 temporal-spatial aggregation
+schemes as before.
+
+For a single survey, let:
+
+- $$U = 1$$ if and only if a positive number is reported for Q2 or Q5;
+- $$V = 1$$ if and only if a positive number is reported for Q2.
+
+In a given temporal-spatial unit (for example, daily-county), let $$U_i$$ and
+$$V_i$$ denote these quantities for survey $$i$$, and $$m$$ denote the number of
+surveys total.  Then to estimate $$a$$ and $$b$$, we simply use:
+
+$$
+\hat{a} = 100 \cdot \frac{1}{m} \sum_{i=1}^m U_i
+\quad\text{and}\quad
+\hat{b} = 100 \cdot \frac{1}{m} \sum_{i=1}^m V_i.
+$$
+
+Their estimated standard errors are:
+
+$$
+\begin{aligned}
+\widehat{\mathrm{se}}(\hat{a}) &= 100 \cdot \sqrt{\frac{\hat{a}(1-\hat{a})}{m}} \\
+\widehat{\mathrm{se}}(\hat{b}) &= 100 \cdot \sqrt{\frac{\hat{b}(1-\hat{b})}{m}},
+\end{aligned}
+$$
+
+which are the plug-in estimates of the standard errors of the binomial
+proportions (treating $$m$$ as fixed).
+
+Note that $$\sum_{i=1}^m U_i$$ is the number of survey respondents who know
+someone in their community with *either ILI or CLI*, and not CLI alone; and
+similarly for $$V$$. Hence $$\hat{a}$$ and $$\hat{b}$$ will generally
+overestimate $$a$$ and $$b$$. However, given the extremely high overlap between
+the definitions of ILI and CLI, we do not consider this to be practically very
+problematic.
+
+## Survey Weighting
+
+Notice that the estimates defined in last two subsections actually reflect the
+percentage of inviduals with ILI and CLI, and individuals who know someone with
+CLI, with respect to the population of US Facebook users. (To be precise, the
+estimates above actually reflect the percentage inviduals with ILI and CLI, with
+respect to the population of US Facebook users *and* their households members).
+In reality, our estimates are even further skewed by the propensity of people in
+the population of US Facebook users to take our survey in the first place.
+
+When Facebook sends a user to our survey, it generates a random ID number and
+sends this to us as well. Once the user completes the survey, we pass this ID
+number back to Facebook to confirm completion, and in return receive a
+weight---call it $$w_i$$ for user $$i$$. (To be clear, the random ID number that
+is generated is completely meaningless for any other purpose than receiving said
+weight, and does not allow us to access any information about the user's
+Facebook profile, or anything else whatsoever.)
+
+We can use these weights to adjust our estimates of the true ILI and CLI
+proportions so that they are representative of the US population---adjusting
+both for the differences between the US population and US Facebook users
+(according to a state-by-age-gender stratification of the US population from the
+2018 Census March Supplement), and for the propensity of a Facebook user to
+take our survey in the first  place.
+
+In more detail, we receive a participation
+weight
+
+$$
+w^{\text{part}}_i = \frac{c^{\text{part}}}{\pi^{\text{part}}_i},
+$$
+
+where $$\pi_i$$ is an estimated probability (produced by Facebook) that an
+individual with the same state-by-age-gender profile as user $$i$$ would be a
+Facebook user and take our CMU survey, scaled by some unknown constant $$c>0$$.
+The adjustment we make follows a standard inverse probability weighting strategy
+(this being a special case of importance sampling).
+
+### Adjusting Household ILI and CLI
+
+As before, for a given temporal-spatial unit (for example, daily-county), let
+$$X_i$$ and $$Y_i$$ denote number of ILI and CLI cases in household $$i$$,
+respectively (computed according to the simple strategy above), and let $$N_i$$
+denote the total number of people in the household, out of the $$m$$ "relevant"
+surveys we collected. A survey is considered relevant if it was started during
+the time interval of interest and the respondent's ZIP code overlaps the spatial
+unit of interest. Each of these surveys is assigned two weights: the
+participation weight $$w^{\text{part}}_i$$, and a geographical-division weight
+$$w^{\text{geodiv}}_i$$ describing how much a participant's ZIP code "belongs"
+in the spatial unit of interest. (For example, a ZIP code may overlap with
+multiple counties, so the weight describes what proportion of the ZIP code's
+population is in each county.)
+
+Let $$w^{\text{init}}_i=w^{\text{part}}_i w^{\text{geodiv}}_i=c/\pi_i$$ denote
+the initial weight assigned to this survey, where $$c>0$$ is chosen so that
+$$\sum_{i=1}^m w_i=1$$.
+
+First, the initial weights are adjusted to reduce sensitivity to any individual
+survey by "mixing" them with a uniform weighting across all relevant surveys.
+
+Specifically, we select
+
+$$
+w_i=a\cdot\frac1m + (1-a)\cdot w^{\text{init}}_i
+$$
+
+using the smallest value of $$a\in[0.05,1]$$ such that $$w_i\le 0.01$$ for all
+$$i$$; if such a selection is impossible, then we have insufficient survey
+responses (less than 100), and do not produce an estimate for the given
+temporal-spatial unit.
+
+Then our adjusted estimates of $$p$$ and $$q$$ are:
+
+$$
+\begin{aligned}
+\hat{p}_w &= 100 \cdot \sum_{i=1}^m w_i \frac{X_i}{N_i} \\
+\hat{q}_w &= 100 \cdot \sum_{i=1}^m w_i \frac{Y_i}{N_i},
+\end{aligned}
+$$
+
+with estimated standard errors:
+
+$$
+\begin{aligned}
+\widehat{\mathrm{se}}(\hat{p}_w) &= 100 \cdot \sqrt{
+  \Big(\frac{1}{1 + n_e}\Big)^2 \Big(\frac12 - \hat{p}_w\Big)^2 +
+  n_e \hat{s}_p^2
+}\\
+\widehat{\mathrm{se}}(\hat{q}_w) &= 100 \cdot \sqrt{
+  \Big(\frac{1}{1 + n_e}\Big)^2 \Big(\frac12 - \hat{q}_w\Big)^2 +
+  n_e \hat{s}_q^2
+},
+\end{aligned}
+$$
+
+where
+
+$$
+\begin{aligned}
+\hat{s}_p^2 &= \sum_{i=1}^m w_i^2 \Big(\frac{X_i}{N_i} - \hat{p}_w\Big)^2 \\
+\hat{s}_q^2 &= \sum_{i=1}^m w_i^2 \Big(\frac{Y_i}{N_i} - \hat{q}_w\Big)^2 \\
+n_e &= \frac1{\sum_{i=1}^m w_i^2},
+\end{aligned}
+$$
+
+the delta method estimates of variance associated with self-normalized
+importance sampling estimators above, after combining with a pseudo-observation
+of 1/2 with weight assigned to appear like a single effective observation
+according to importance sampling diagnostics.
+
+The sample size reported is calculated by rounding down $$\sum_{i=1}^{m}
+w^{\text{geodiv}}_i$$ before adding the pseudo-observations. When ZIP codes do
+not overlap multiple spatial units of interest, these weights are all one, and
+this expression simplifies to $$m$$. When estimates are available for all
+spatial units of a given type over some time period, the sum of the associated
+sample sizes under this definition is consistent with the number of surveys used
+to prepare the estimate. (This notion of sample size is distinct from
+"effective" sample sizes based on variance of the importance sampling estimators
+which were used above.)
+
+### Adjusting Community CLI
+
+As before, in a given temporal-spatial unit (for example, daily-county), let
+$$U_i$$ and $$V_i$$ denote the indicators that the survey respondent knows someone
+in their community with CLI, including and not including their household,
+respectively, for survey $$i$$, out of $$m$$ surveys collected.   Also let $$w_i$$ be
+the self-normalized weight that accompanies survey $$i$$, as above. Then our
+adjusted estimates of $$a$$ and $$b$$ are:
+
+$$
+\begin{aligned}
+\hat{a}_w &= 100 \cdot \sum_{i=1}^m w_i U_i \\
+\hat{b}_w &= 100 \cdot \sum_{i=1}^m w_i V_i.
+\end{aligned}
+$$
+
+with estimated standard errors:
+
+$$
+\begin{aligned}
+\widehat{\mathrm{se}}(\hat{a}_w) &= 100 \cdot \sqrt{\sum_{i=1}^m
+w_i^2 (U_i - \hat{a}_w)^2} \\
+\widehat{\mathrm{se}}(\hat{b}_w) &= 100 \cdot \sqrt{\sum_{i=1}^m
+w_i^2 (V_i - \hat{b}_w)^2},
+\end{aligned}
+$$
+
+the delta method estimates of variance associated with self-normalized
+importance sampling estimators.

--- a/docs/api/covidcast-signals/ght.md
+++ b/docs/api/covidcast-signals/ght.md
@@ -5,6 +5,7 @@ grand_parent: COVIDcast API
 ---
 
 # Google Health Trends
+{: .no_toc}
 
 * **Source name:** `ght`
 * **Number of data revisions since 19 May 2020:** 0
@@ -15,14 +16,42 @@ This data source (`ght`) is based on Google searches, provided to us by Google
 Health Trends. Using this search data, we estimate the volume of COVID-related
 searches in a given location, on a given day. This signal is measured in
 arbitrary units (its scale is meaningless); larger numbers represent higher
-numbers of COVID-related searches. Note that this source is not available for
-individual counties, as it is reported only for larger geographical areas, and
-so county estimates are not available from the API.
+numbers of COVID-related searches.
 
 | Signal | Description |
 | --- | --- |
 | `raw_search` | Google search volume for COVID-related searches, in arbitrary units that are normalized for population |
-| `smoothed_search` | Google search volume for COVID-related searches, in arbitrary units that are normalized for population, smoothed in time using a local linear smoother with Gaussian kernel |
+| `smoothed_search` | Google search volume for COVID-related searches, in arbitrary units that are normalized for population, smoothed in time as [described below](#smoothing) |
+
+## Table of contents
+{: .no_toc .text-delta}
+
+1. TOC
+{:toc}
+
+## Estimation
+
+We query the Google Health Trends API for overall searcher interest in a set of
+COVID-19 related terms which encompass the following topics: coronavirus
+symptoms; coronavirus help; coronavirus test-seeking; anosmia (lack of smell or
+taste). The API provides data at the Nielsen Designated Marketing Area (DMA)
+level and at the State level. This information reported by the API is unitless
+and pre-normalized for population size; i.e., the time series obtained for New
+York and Wyoming states are directly comparable. The public has access to a
+limited view of such information through [Google
+Trends](https://trends.google.com).
+
+DMA-level data are aggregated to the MSA and HRR level through
+population-weighted averaging.
+
+## Smoothing
+
+The smoothed signal is produced using the following strategy. For each date, we
+fit a local linear regression, using a Gaussian kernel, with only data on or
+before that date. (This is equivalent to using a negative half normal
+distribution as the kernel.) The bandwidth is chosen such that most of the
+kernel weight is placed on the preceding seven days. The estimate for the data
+is the local linear regression's prediction for that date.
 
 ## Limitations
 

--- a/docs/api/covidcast-signals/jhu-csse.md
+++ b/docs/api/covidcast-signals/jhu-csse.md
@@ -28,13 +28,22 @@ University.
 
 These signals are taken directly from the JHU CSSE [COVID-19 GitHub
 repository](https://github.com/CSSEGISandData/COVID-19) without filtering,
-smoothing, or changes. **Note:** JHU's data reports cumulative cases and deaths,
-so our incidence signals are calculated by subtracting each day's cumulative
-count from the previous day. Since cumulative figures are sometimes corrected or
-amended by health authorities, this can sometimes result in negative incidence.
-This should be interpreted purely as an artifact of data reporting and
-correction.
+smoothing, or changes.
 
 Smoothed versions of all the signals above are available. These signals report
 moving averages of the preceding 7 days, so e.g. the signal for June 7 is the
 average of the underlying data for June 1 through 7, inclusive.
+
+## Limitations
+
+JHU's data reports cumulative cases and deaths, so our incidence signals are
+calculated by subtracting each day's cumulative count from the previous day.
+Since cumulative figures are sometimes corrected or amended by health
+authorities, this can sometimes result in negative incidence. This should be
+interpreted purely as an artifact of data reporting and correction.
+
+Due to differences in state reporting standards, certain counties are not
+reported in the JHU data or are reported combined with other counties. See the
+[geography coding
+documentation](../covidcast_geography.md#fips-exceptions-in-jhu-data) for
+details.

--- a/docs/api/covidcast_signals.md
+++ b/docs/api/covidcast_signals.md
@@ -23,12 +23,14 @@ map](https://covidcast.cmu.edu/):
 
 | Name | Source | Signal |
 | --- | --- | --- |
-| Doctor's Visits | `doctor-visits` | `smoothed_adj_cli` |
-| Symptoms (Facebook) | `fb-survey` | `smoothed_cli` |
-| Symptoms in Community (Facebook) | `fb-survey` | `smoothed_hh_cmnty_cli` |
-| Search Trends (Google) | `ght` | `smoothed_search` |
-| Combined | `indicator-combination` | `nmf_day_doc_fbc_fbs_ght` |
-| Cases | `jhu-csse` | `confirmed_incidence_num` |
-| Cases per capita | `jhu-csse` | `confirmed_incidence_prop` |
-| Deaths | `jhu-csse` | `deaths_incidence_num` |
-| Deaths per capita | `jhu-csse` | `confirmed_incidence_prop` |
+| Doctor's Visits | [`doctor-visits`](covidcast-signals/doctor-visits.md) | `smoothed_adj_cli` |
+| Symptoms (Facebook) | [`fb-survey`](covidcast-signals/fb-survey.md) | `smoothed_cli` |
+| Symptoms in Community (Facebook) | [`fb-survey`](covidcast-signals/fb-survey.md) | `smoothed_hh_cmnty_cli` |
+| Away from Home 6hr+ (SafeGraph) | [`safegraph`](covidcast-signals/safegraph.md) | `full_time_work_prop` |
+| Away from Home 3-6hr (SafeGraph) | [`safegraph`](covidcast-signals/safegraph.md) | `part_time_work_prop` |
+| Search Trends (Google) | [`ght`](covidcast-signals/ght.md) | `smoothed_search` |
+| Combined | [`indicator-combination`](covidcast-signals/indicator-combination.md) | `nmf_day_doc_fbc_fbs_ght` |
+| Cases | [`jhu-csse`](covidcast-signals/jhu-csse.md) | `confirmed_incidence_num` |
+| Cases per capita | [`jhu-csse`](covidcast-signals/jhu-csse.md) | `confirmed_incidence_prop` |
+| Deaths | [`jhu-csse`](covidcast-signals/jhu-csse.md) | `deaths_incidence_num` |
+| Deaths per capita | [`jhu-csse`](covidcast-signals/jhu-csse.md) | `confirmed_incidence_prop` |


### PR DESCRIPTION
Based on covid-19's signal_descriptions.tex file, ported to Markdown and with some copyedits.

Remaining:

- [ ] Google Surveys https://github.com/cmu-delphi/covid-19/pull/95
- [ ] Quidel https://github.com/cmu-delphi/covid-19/pull/94
- [ ] Combo indicator (is this documented anywhere yet?)

[Preview of this branch's documentation](http://rosmarus.refsmmat.com/delphi-epidata/api/covidcast_signals.html).