### PR TITLE
Issue lag docs

### DIFF
--- a/docs/api/covidcast.md
+++ b/docs/api/covidcast.md
@@ -82,6 +82,8 @@ and lists.
 
 ### Parameters
 
+#### Required
+
 | Parameter | Description | Type |
 | --- | --- | --- |
 | `data_source` | name of upstream data source (e.g., `doctor-visits` or `fb-survey`; [see full list](covidcast_signals.md)) | string |
@@ -96,9 +98,16 @@ The current set of signals available for each data source is returned by the
 
 #### Optional
 
-The default API behavior is to return the most recently issued value for each `time_value` selected.
+Estimates for a specific `time_value` and `geo_value` are sometimes updated
+after they are first published. Many of our data sources issue corrections or
+backfill estimates as data arrives; see the [documentation for each
+source](covidcast_signals.md) for details.
 
-We also provide access to previous versions of data using the optional parameters below.
+The default API behavior is to return the most recently issued value for each
+`time_value` selected.
+
+We also provide access to previous versions of data using the optional query
+parameters below.
 
 | Parameter | Description | Type |
 | --- | --- | --- |
@@ -109,7 +118,7 @@ We also provide access to previous versions of data using the optional parameter
 Use cases:
 
 * To pretend like you queried the API on June 1, such that the returned results
-  do not include any updates which became available after June 1, use
+  do not include any updates that became available after June 1, use
   `as_of=20200601`.
 * To retrieve only data that was published or updated on June 1, and exclude
   records whose most recent update occured earlier than June 1, use
@@ -121,10 +130,12 @@ Use cases:
 * To retrieve only data that was published or updated exactly 3 days after the
   underlying events occurred, use `lag=3`.
 
-NB: Each issue in the versioning system contains only the records that were
-added or updated during that time unit; we exclude records whose values remain
-the same as a previous issue. If you have a research problem that would require
-knowing when an unchanged value was last confirmed, please get in touch.
+You should specify only one of these three parameters in any given query.
+
+**Note:** Each issue in the versioning system contains only the records that
+were added or updated during that time unit; we exclude records whose values
+remain the same as a previous issue. If you have a research problem that would
+require knowing when an unchanged value was last confirmed, please get in touch.
 
 ### Response
 

--- a/docs/api/covidcast_meta.md
+++ b/docs/api/covidcast_meta.md
@@ -33,13 +33,16 @@ See [this documentation](README.md) for details on specifying epiweeks, dates, a
 | `epidata[].signal` | signal name | string |
 | `epidata[].time_type` | temporal resolution of the signal (e.g., `day`, `week`) | string |
 | `epidata[].geo_type` | geographic resolution (e.g. `county`, `hrr`, `msa`, `dma`, `state`) | string |
-| `epidata[].min_time` | minimum time (e.g., 20200406) | integer |
-| `epidata[].max_time` | maximum time (e.g., 20200413) | integer |
+| `epidata[].min_time` | minimum observation time (e.g., 20200406) | integer |
+| `epidata[].max_time` | maximum observation time (e.g., 20200413) | integer |
 | `epidata[].num_locations` | number of distinct geographic locations with data | integer |
 | `epidata[].min_value` | minimum value | float |
 | `epidata[].max_value` | maximum value | float |
 | `epidata[].mean_value` | mean of value | float |
 | `epidata[].stdev_value` | standard deviation of value | float |
+| `epidata[].max_issue` | most recent date data was issued (e.g., 20200710) | integer |
+| `epidata[].min_lag` | smallest lag from observation to issue, in `time_type` units | integer |
+| `epidata[].max_lag` | largest lag from observation to issue, in `time_type` units | integer |
 | `message` | `success` or error message | string |
 
 ## Example URLs


### PR DESCRIPTION
This

* documents the new columns in the metadata (although I'm not sure I interpreted min_lag and max_lag correctly?)
* slightly expands the text about as_of/issues/lag.

The client API docs will have extended examples on fetching issue dates, which is what I expect the users to most rely upon.