### PR TITLE
Increase maximum signal length for COVIDcast to 64 characters

### DIFF
--- a/integrations/acquisition/covidcast/test_csv_uploading.py
+++ b/integrations/acquisition/covidcast/test_csv_uploading.py
@@ -76,7 +76,12 @@ class CsvUploadingTests(unittest.TestCase):
       f.write('wa,30,0.03,300\n')
 
     # invalid
-    with open(source_receiving_dir + '/20200419_state_wip_really_long_name_that_will_get_truncated.csv', 'w') as f:
+    with open(source_receiving_dir + '/20200419_state_wip_really_long_name_that_will_be_accepted.csv', 'w') as f:
+      f.write('geo_id,val,se,sample_size\n')
+      f.write('pa,100,5.4,624\n')
+      
+    # invalid
+    with open(source_receiving_dir + '/20200419_state_wip_really_long_name_that_will_get_truncated_lorem_ipsum_dolor_sit_amet.csv', 'w') as f:
       f.write('geo_id,val,se,sample_size\n')
       f.write('pa,100,5.4,624\n')
 
@@ -180,9 +185,30 @@ class CsvUploadingTests(unittest.TestCase):
       'message': 'success',
     })
 
+    
+    # request CSV data from the API on the signal with name length 32<x<64
+    response = Epidata.covidcast(
+      'src-name', 'wip_really_long_name_that_will_be_accepted', 'day', 'state', 20200419, '*')
+
+    # verify data matches the CSV
+    self.assertEqual(response, {
+      'result': 1,
+      'message': 'success',
+      'epidata': apply_lag([
+        {
+          'time_value': 20200419,
+          'geo_value': 'pa',
+          'value': 100,
+          'stderr': 5.4,
+          'sample_size': 624,
+          'direction': None,
+        },
+      ])
+    })
+    
     # request CSV data from the API on the long-named signal
     response = Epidata.covidcast(
-      'src-name', 'wip_really_long_name_that_will_g', 'day', 'state', 20200419, '*')
+      'src-name', 'wip_really_long_name_that_will_get_truncated_lorem_ipsum_dolor_s', 'day', 'state', 20200419, '*')
 
     # verify data matches the CSV
     # if the CSV failed correctly there should be no results

--- a/src/acquisition/covidcast/csv_importer.py
+++ b/src/acquisition/covidcast/csv_importer.py
@@ -142,8 +142,8 @@ class CsvImporter:
       # extract additional values, lowercased for consistency
       source = match.group(1).lower()
       signal = match.group(4).lower()
-      if len(signal) > 32:
-        print(' invalid signal name (32 char limit)',signal)
+      if len(signal) > 64:
+        print(' invalid signal name (64 char limit)',signal)
         yield (path, None)
         continue
 

--- a/src/ddl/covidcast.sql
+++ b/src/ddl/covidcast.sql
@@ -8,12 +8,13 @@ Delphi's COVID-19 surveillance streams.
 
 Data is public.
 
+
 +------------------------------+-------------+------+-----+---------+----------------+
 | Field                        | Type        | Null | Key | Default | Extra          |
 +------------------------------+-------------+------+-----+---------+----------------+
 | id                           | int(11)     | NO   | PRI | NULL    | auto_increment |
 | source                       | varchar(32) | NO   | MUL | NULL    |                |
-| signal                       | varchar(32) | NO   |     | NULL    |                |
+| signal                       | varchar(64) | NO   |     | NULL    |                |
 | time_type                    | varchar(12) | NO   |     | NULL    |                |
 | geo_type                     | varchar(12) | NO   |     | NULL    |                |
 | time_value                   | int(11)     | NO   |     | NULL    |                |
@@ -87,7 +88,7 @@ Data is public.
 CREATE TABLE `covidcast` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `source` varchar(32) NOT NULL,
-  `signal` varchar(32) NOT NULL,
+  `signal` varchar(64) NOT NULL,
   `time_type` varchar(12) NOT NULL,
   `geo_type` varchar(12) NOT NULL,
   `time_value` int(11) NOT NULL,


### PR DESCRIPTION
* Database schema
* Signal name length guard in CSV uploader
* Integration test verifies signal length 32<x<64 succeeds, x>64 fails

Unit tests and integration tests pass.

To apply this to the live DB, use the following:

```
ALTER TABLE `covidcast`
MODIFY `signal` varchar(64) NOT NULL;
```