### PR TITLE
Add support for querying multiple signals

### DIFF
--- a/integrations/acquisition/covidcast/test_covidcast_meta_caching.py
+++ b/integrations/acquisition/covidcast/test_covidcast_meta_caching.py
@@ -1,6 +1,7 @@
 """Integration tests for covidcast's metadata caching."""
 
 # standard library
+import json
 import unittest
 
 # third party
@@ -100,15 +101,15 @@ class CovidcastMetaCacheTests(unittest.TestCase):
         'stdev_value': 0,
         'max_issue': 20200423,
         'min_lag': 0,
-        'max_lag': 1
+        'max_lag': 1,
       }
     ])
-    epidata1={'result':1,'message':'success','epidata':epidata1}
+    epidata1={'result':1, 'message':'success', 'epidata':epidata1}
 
     # make sure the API covidcast_meta is still blank, since it only serves
     # the cached version and we haven't cached anything yet
     epidata2 = Epidata.covidcast_meta()
-    self.assertEqual(epidata2['result'], -2)
+    self.assertEqual(epidata2['result'], -2, json.dumps(epidata2))
 
     # update the cache
     args = None

--- a/integrations/acquisition/covidcast/test_csv_uploading.py
+++ b/integrations/acquisition/covidcast/test_csv_uploading.py
@@ -126,6 +126,7 @@ class CsvUploadingTests(unittest.TestCase):
           'stderr': 0.1,
           'sample_size': 10,
           'direction': None,
+          'signal': 'test',
         },
         {
           'time_value': 20200419,
@@ -134,6 +135,7 @@ class CsvUploadingTests(unittest.TestCase):
           'stderr': 0.3,
           'sample_size': 30,
           'direction': None,
+          'signal': 'test',
         },
         {
           'time_value': 20200419,
@@ -142,6 +144,7 @@ class CsvUploadingTests(unittest.TestCase):
           'stderr': 0.2,
           'sample_size': 20,
           'direction': None,
+          'signal': 'test',
         },
     ]),
       'message': 'success',
@@ -164,6 +167,7 @@ class CsvUploadingTests(unittest.TestCase):
           'stderr': 0.01,
           'sample_size': 100,
           'direction': None,
+          'signal': 'wip_prototype',
         },
         {
           'time_value': 20200419,
@@ -172,6 +176,7 @@ class CsvUploadingTests(unittest.TestCase):
           'stderr': 0.02,
           'sample_size': 200,
           'direction': None,
+          'signal': 'wip_prototype',
         },
         {
           'time_value': 20200419,
@@ -180,6 +185,7 @@ class CsvUploadingTests(unittest.TestCase):
           'stderr': 0.03,
           'sample_size': 300,
           'direction': None,
+          'signal': 'wip_prototype',
         },
        ]),
       'message': 'success',
@@ -202,6 +208,7 @@ class CsvUploadingTests(unittest.TestCase):
           'stderr': 5.4,
           'sample_size': 624,
           'direction': None,
+          'signal': 'wip_really_long_name_that_will_be_accepted',
         },
       ])
     })

--- a/integrations/acquisition/covidcast/test_direction_updating.py
+++ b/integrations/acquisition/covidcast/test_direction_updating.py
@@ -107,7 +107,8 @@ class DirectionUpdatingTests(unittest.TestCase):
         'sample_size': 0,
         'direction': None,
         'issue': 20201028,
-        'lag': 0
+        'lag': 0,
+        'signal': 'sig1'
       },
       {
         'time_value': 20201029,
@@ -117,7 +118,8 @@ class DirectionUpdatingTests(unittest.TestCase):
         'sample_size': 0,
         'direction': None,
         'issue': 20201029,
-        'lag': 0
+        'lag': 0,
+        'signal': 'sig1'
       },
       {
         'time_value': 20201030,
@@ -127,7 +129,8 @@ class DirectionUpdatingTests(unittest.TestCase):
         'sample_size': 0,
         'direction': None,
         'issue': 20201030,
-        'lag': 0
+        'lag': 0,
+        'signal': 'sig1'
       },
     ],
       'message': 'success',
@@ -149,7 +152,8 @@ class DirectionUpdatingTests(unittest.TestCase):
           'sample_size': 0,
           'direction': None,
           'issue': 20200228,
-          'lag': 0
+          'lag': 0,
+          'signal': 'sig',
         },
         {
           'time_value': 20200229,
@@ -159,7 +163,8 @@ class DirectionUpdatingTests(unittest.TestCase):
           'sample_size': 0,
           'direction': None,
           'issue': 20200229,
-          'lag': 0
+          'lag': 0,
+          'signal': 'sig',
         },
         {
           'time_value': 20200301,
@@ -169,7 +174,8 @@ class DirectionUpdatingTests(unittest.TestCase):
           'sample_size': 0,
           'direction': 1,
           'issue': 20200301,
-          'lag': 0
+          'lag': 0,
+          'signal': 'sig',
         },
         {
           'time_value': 20200511,
@@ -179,7 +185,8 @@ class DirectionUpdatingTests(unittest.TestCase):
           'sample_size': 0,
           'direction': None,
           'issue': 20200511,
-          'lag': 0
+          'lag': 0,
+          'signal': 'sig',
         },
         {
           'time_value': 20200512,
@@ -189,7 +196,8 @@ class DirectionUpdatingTests(unittest.TestCase):
           'sample_size': 0,
           'direction': None,
           'issue': 20200512,
-          'lag': 0
+          'lag': 0,
+          'signal': 'sig',
         },
         {
           'time_value': 20200517,
@@ -199,7 +207,8 @@ class DirectionUpdatingTests(unittest.TestCase):
           'sample_size': 0,
           'direction': 0,
           'issue': 20200517,
-          'lag': 0
+          'lag': 0,
+          'signal': 'sig',
         },
         {
           'time_value': 20200615,
@@ -209,7 +218,8 @@ class DirectionUpdatingTests(unittest.TestCase):
           'sample_size': 0,
           'direction': None,
           'issue': 20200615,
-          'lag': 0
+          'lag': 0,
+          'signal': 'sig',
         },
         {
           'time_value': 20200616,
@@ -219,7 +229,8 @@ class DirectionUpdatingTests(unittest.TestCase):
           'sample_size': 0,
           'direction': None,
           'issue': 20200616,
-          'lag': 0
+          'lag': 0,
+          'signal': 'sig',
         },
         {
           'time_value': 20200617,
@@ -229,7 +240,8 @@ class DirectionUpdatingTests(unittest.TestCase):
           'sample_size': 0,
           'direction': 1,
           'issue': 20200617,
-          'lag': 0
+          'lag': 0,
+          'signal': 'sig',
         },
        ],
       'message': 'success',

--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -45,11 +45,14 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
 
   def test_covidcast(self):
     """Test that the covidcast endpoint returns expected data."""
-
+    self.maxDiff=None
+    
     # insert dummy data
     self.cur.execute('''
       insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
+          123, 1.5, 2.5, 3.5, 456, 4, 20200414, 0, 0, False),
+        (0, 'src', 'sig2', 'day', 'county', 20200414, '01234',
           123, 1.5, 2.5, 3.5, 456, 4, 20200414, 0, 0, False),
         (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
           456, 5.5, 1.2, 10.5, 789, 0, 20200415, 1, 0, False),
@@ -58,6 +61,69 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
     ''')
     self.cnx.commit()
 
+    # fetch data
+    response = Epidata.covidcast(
+        'src', ['sig','sig2'], 'day', 'county', 20200414, '01234')
+
+    # check result
+    self.assertEqual(response, {
+      'result': 1,
+      'epidata': [{
+        'time_value': 20200414,
+        'geo_value': '01234',
+        'value': 6.5,
+        'stderr': 2.2,
+        'sample_size': 11.5,
+        'direction': 0,
+        'issue': 20200416,
+        'lag': 2,
+        'signal': 'sig',
+      },{
+        'time_value': 20200414,
+        'geo_value': '01234',
+        'value': 1.5,
+        'stderr': 2.5,
+        'sample_size': 3.5,
+        'direction': 4,
+        'issue': 20200414,
+        'lag': 0,
+        'signal': 'sig2',
+      }],
+      'message': 'success',
+    })
+
+    # fetch data
+    response = Epidata.covidcast(
+        'src', ['sig','sig2'], 'day', 'county', 20200414, '01234', format='tree')
+
+    # check result
+    self.assertEqual(response, {
+      'result': 1,
+      'epidata': [{
+        'sig': [{
+          'time_value': 20200414,
+          'geo_value': '01234',
+          'value': 6.5,
+          'stderr': 2.2,
+          'sample_size': 11.5,
+          'direction': 0,
+          'issue': 20200416,
+          'lag': 2,
+        }],
+        'sig2': [{
+          'time_value': 20200414,
+          'geo_value': '01234',
+          'value': 1.5,
+          'stderr': 2.5,
+          'sample_size': 3.5,
+          'direction': 4,
+          'issue': 20200414,
+          'lag': 0,
+        }],
+      }],
+      'message': 'success',
+    })
+    
     # fetch data, without specifying issue or lag
     response_1 = Epidata.covidcast(
         'src', 'sig', 'day', 'county', 20200414, '01234')
@@ -73,7 +139,8 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
         'sample_size': 11.5,
         'direction': 0,
         'issue': 20200416,
-        'lag': 2
+        'lag': 2,
+        'signal': 'sig',
        }],
       'message': 'success',
     })
@@ -94,7 +161,8 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
         'sample_size': 10.5,
         'direction': 0,
         'issue': 20200415,
-        'lag': 1
+        'lag': 1,
+        'signal': 'sig',
        }],
       'message': 'success',
     })
@@ -115,7 +183,8 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
             'sample_size': 3.5,
             'direction': 4,
             'issue': 20200414,
-            'lag': 0
+            'lag': 0,
+            'signal': 'sig',
         }, {
             'time_value': 20200414,
             'geo_value': '01234',
@@ -124,7 +193,8 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
             'sample_size': 10.5,
             'direction': 0,
             'issue': 20200415,
-            'lag': 1
+            'lag': 1,
+            'signal': 'sig',
         }],
         'message': 'success',
     })
@@ -145,7 +215,8 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
             'sample_size': 11.5,
             'direction': 0,
             'issue': 20200416,
-            'lag': 2
+            'lag': 2,
+            'signal': 'sig',
         }],
         'message': 'success',
     })
@@ -189,7 +260,7 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
         'last_update': 345,
         'max_issue': 20200416,
         'min_lag': 1,
-        'max_lag': 2
+        'max_lag': 2,
        }],
       'message': 'success',
     })

--- a/integrations/server/test_covidcast.py
+++ b/integrations/server/test_covidcast.py
@@ -73,7 +73,8 @@ class CovidcastTests(unittest.TestCase):
         'sample_size': 3.5,
         'direction': 4,
         'issue': 20200414,
-        'lag': 0
+        'lag': 0,
+        'signal': 'sig',
        }],
       'message': 'success',
     })
@@ -125,6 +126,7 @@ class CovidcastTests(unittest.TestCase):
           'direction': 13,
           'issue': 20200414,
           'lag': 0,
+          'signal': 'sig',
         }, {
           'time_value': 20200414,
           'geo_value': '22222',
@@ -134,6 +136,7 @@ class CovidcastTests(unittest.TestCase):
           'direction': 23,
           'issue': 20200414,
           'lag': 0,
+          'signal': 'sig',
         }, {
           'time_value': 20200414,
           'geo_value': '33333',
@@ -142,7 +145,8 @@ class CovidcastTests(unittest.TestCase):
           'sample_size': 32,
           'direction': 33,
           'issue': 20200414,
-          'lag': 0
+          'lag': 0,
+          'signal': 'sig',
         },
        ],
       'message': 'success',
@@ -195,6 +199,7 @@ class CovidcastTests(unittest.TestCase):
           'direction': 13,
           'issue': 20200413,
           'lag': 2,
+          'signal': 'sig',
         }, {
           'time_value': 20200412,
           'geo_value': '01234',
@@ -204,6 +209,7 @@ class CovidcastTests(unittest.TestCase):
           'direction': 23,
           'issue': 20200413,
           'lag': 1,
+          'signal': 'sig',
         }, {
           'time_value': 20200413,
           'geo_value': '01234',
@@ -213,6 +219,7 @@ class CovidcastTests(unittest.TestCase):
           'direction': 33,
           'issue': 20200413,
           'lag': 0,
+          'signal': 'sig',
         },
        ],
       'message': 'success',
@@ -280,6 +287,7 @@ class CovidcastTests(unittest.TestCase):
         'direction': None,
         'issue': 20200414,
         'lag': 0,
+        'signal': 'sig',
        }],
       'message': 'success',
     })
@@ -327,7 +335,8 @@ class CovidcastTests(unittest.TestCase):
         'sample_size': 32,
         'direction': 33,
         'issue': 202016,
-        'lag': 0
+        'lag': 0,
+        'signal': 'sig',
        }],
       'message': 'success',
     })

--- a/src/acquisition/covidcast/database.py
+++ b/src/acquisition/covidcast/database.py
@@ -19,6 +19,7 @@ class CovidcastRow():
 
   @staticmethod
   def fromCsvRowValue(row_value, source, signal, time_type, geo_type, time_value, issue, lag, is_wip):
+    if row_value is None: return None
     return CovidcastRow(source, signal, time_type, geo_type, time_value,
                         row_value.geo_value,
                         row_value.value,

--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -503,10 +503,13 @@ Epidata <- (function() {
   }
 
   # Fetch Delphi's COVID-19 Surveillance Streams
-  covidcast <- function(data_source, signal, time_type, geo_type, time_values, geo_value, as_of, issues, lag) {
+  covidcast <- function(data_source, signals, time_type, geo_type, time_values, geo_value, as_of, issues, lag, format=c("flat","tree"), signal) {
     # Check parameters
-    if(missing(data_source) || missing(signal) || missing(time_type) || missing(geo_type) || missing(time_values) || missing(geo_value)) {
-      stop('`data_source`, `signal`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required')
+    if(missing(data_source) || (missing(signals) && missing(signal)) || missing(time_type) || missing(geo_type) || missing(time_values) || missing(geo_value)) {
+      stop('`data_source`, `signals`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required')
+    }
+    if (missing(signals)) {
+      signals <- signal
     }
     if(!missing(issues) && !missing(lag)) {
       stop('`issues` and `lag` are mutually exclusive')
@@ -515,11 +518,12 @@ Epidata <- (function() {
     params <- list(
       source = 'covidcast',
       data_source = data_source,
-      signal = signal,
+      signals = .list(signals),
       time_type = time_type,
       geo_type = geo_type,
       time_values = .list(time_values),
-      geo_value = geo_value
+      geo_value = geo_value,
+      format = format
     )
     if(!missing(as_of)) {
       params$as_of <- as_of

--- a/src/client/delphi_epidata.coffee
+++ b/src/client/delphi_epidata.coffee
@@ -356,17 +356,17 @@ class Epidata
     _request(callback, {'source': 'meta'})
 
   # Fetch Delphi's COVID-19 Surveillance Streams
-  @covidcast: (callback, data_source, signal, time_type, geo_type, time_values, geo_value, as_of, issues, lag) ->
+  @covidcast: (callback, data_source, signals, time_type, geo_type, time_values, geo_value, as_of, issues, lag, format) ->
     # Check parameters
-    unless data_source? and signal? and time_type? and geo_type? and time_values? and geo_value?
-      throw { msg: '`data_source`, `signal`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required' }
+    unless data_source? and signals? and time_type? and geo_type? and time_values? and geo_value?
+      throw { msg: '`data_source`, `signals`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required' }
     if issues? and lag?
       throw { msg: '`issues` and `lag` are mutually exclusive' }
     # Set up request
     params =
       'source': 'covidcast'
       'data_source': data_source
-      'signal': signal
+      'signals': signals
       'time_type': time_type
       'geo_type': geo_type
       'time_values': _list(time_values)
@@ -377,6 +377,8 @@ class Epidata
       params.issues = _list(issues)
     if lag?
       params.lag = lag
+    if format?
+      params.format = format
     # Make the API call
     _request(callback, params)
 

--- a/src/client/delphi_epidata.js
+++ b/src/client/delphi_epidata.js
@@ -551,12 +551,12 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
       }, {
         key: "covidcast",
-        value: function covidcast(callback, data_source, signal, time_type, geo_type, time_values, geo_value, as_of, issues, lag) {
+        value: function covidcast(callback, data_source, signals, time_type, geo_type, time_values, geo_value, as_of, issues, lag, format) {
           var params; // Check parameters
 
-          if (!(data_source != null && signal != null && time_type != null && geo_type != null && time_values != null && geo_value != null)) {
+          if (!(data_source != null && signals != null && time_type != null && geo_type != null && time_values != null && geo_value != null)) {
             throw {
-              msg: '`data_source`, `signal`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required'
+              msg: '`data_source`, `signals`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required'
             };
           }
 
@@ -570,7 +570,7 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
           params = {
             'source': 'covidcast',
             'data_source': data_source,
-            'signal': signal,
+            'signals': signals,
             'time_type': time_type,
             'geo_type': geo_type,
             'time_values': _list(time_values),
@@ -587,6 +587,10 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
           if (lag != null) {
             params.lag = lag;
+          }
+
+          if (format != null) {
+            params.format = format;
           } // Make the API call
 
 
@@ -682,4 +686,3 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
   (typeof exports !== "undefined" && exports !== null ? exports : window).Epidata = Epidata;
 }).call(void 0);
-

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -555,20 +555,22 @@ class Epidata:
   # Fetch Delphi's COVID-19 Surveillance Streams
   @staticmethod
   def covidcast(
-          data_source, signal, time_type, geo_type,
-          time_values, geo_value, as_of=None, issues=None, lag=None):
+          data_source, signals, time_type, geo_type,
+          time_values, geo_value, as_of=None, issues=None, lag=None, **kwargs):
     """Fetch Delphi's COVID-19 Surveillance Streams"""
+    # also support old parameter name
+    if signals is None and 'signal' in kwargs:
+      signals=kwargs['signal']
     # Check parameters
-    if data_source is None or signal is None or time_type is None or geo_type is None or time_values is None or geo_value is None:
-      raise Exception('`data_source`, `signal`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required')
+    if data_source is None or signals is None or time_type is None or geo_type is None or time_values is None or geo_value is None:
+      raise Exception('`data_source`, `signals`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required')
     if issues is not None and lag is not None:
       raise Exception('`issues` and `lag` are mutually exclusive')
-
     # Set up request
     params = {
       'source': 'covidcast',
       'data_source': data_source,
-      'signal': signal,
+      'signals': Epidata._list(signals),
       'time_type': time_type,
       'geo_type': geo_type,
       'time_values': Epidata._list(time_values),
@@ -581,6 +583,9 @@ class Epidata:
       params['issues'] = Epidata._list(issues)
     if lag is not None:
       params['lag'] = lag
+
+    if 'format' in kwargs:
+      params['format'] = kwargs['format']
 
     # Make the API call
     return Epidata._request(params)

--- a/src/server/api_helpers.php
+++ b/src/server/api_helpers.php
@@ -159,7 +159,8 @@ function execute_query($query, &$epidata, $fields_string, $fields_int, $fields_f
   error_log($query);
   $result = mysqli_query($dbh, $query . " LIMIT {$MAX_RESULTS}");
   if (!$result) {
-    error_log(sprintf("Error: %s\n",mysqli_error($dbh)));
+    error_log("Bad query: ".$query);
+    error_log(mysqli_error($dbh));
     return;
   }
   while($row = mysqli_fetch_array($result)) {


### PR DESCRIPTION
 Fixes cmu-delphi/covidcast-indicators#116

* backwards-compatible signal/signals parameter
* optional 'format' parameter for retrieving results as a tree (preferred by Viz) or as a flat list (backwards-compatible); defaults to flat list
* client support: coffee, js, R, py
* integration tests to check multi-signal queries and queries for tree format