### PR TITLE
Enable gzip/brotli compression and caching of API responses

### DIFF
--- a/src/server/.htaccess
+++ b/src/server/.htaccess
@@ -1,2 +1,6 @@
 # Open up the API to all origins.
 Header set Access-Control-Allow-Origin "*"
+
+# Compress API responses
+AddOutputFilterByType DEFLATE application/json
+AddOutputFilterByType BROTLI_COMPRESS application/json

--- a/src/server/.htaccess
+++ b/src/server/.htaccess
@@ -2,8 +2,15 @@
 Header set Access-Control-Allow-Origin "*"
 
 # Compress API responses
-AddOutputFilterByType DEFLATE application/json
-AddOutputFilterByType BROTLI_COMPRESS application/json
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE application/json
+</IfModule>
+<IfModule mod_brotli.c>
+    AddOutputFilterByType BROTLI_COMPRESS application/json
+</IfModule>
 
 # Allow brief caching of API responses
-ExpiresByType application/json "access plus 2 hours"
+<IfModule mod_expires.c>
+    ExpiresByType application/json "access plus 2 hours"
+</IfModule>
+

--- a/src/server/.htaccess
+++ b/src/server/.htaccess
@@ -4,3 +4,6 @@ Header set Access-Control-Allow-Origin "*"
 # Compress API responses
 AddOutputFilterByType DEFLATE application/json
 AddOutputFilterByType BROTLI_COMPRESS application/json
+
+# Allow brief caching of API responses
+ExpiresByType application/json "access plus 2 hours"


### PR DESCRIPTION
See #160 -- this will only help if deployed to the AWS API endpoints at api.covidcast.cmu.edu, since those run Apache and the others run nginx.

This assumes we have mod_deflate and mod_brotli available on those servers.