### PR TITLE
Enable compression but not caching

### DIFF
--- a/src/server/.htaccess
+++ b/src/server/.htaccess
@@ -1,2 +1,6 @@
 # Open up the API to all origins.
 Header set Access-Control-Allow-Origin "*"
+
+# Compress API responses
+AddOutputFilterByType DEFLATE application/json
+AddOutputFilterByType BROTLI_COMPRESS application/json

--- a/src/server/.htaccess
+++ b/src/server/.htaccess
@@ -2,8 +2,15 @@
 Header set Access-Control-Allow-Origin "*"
 
 # Compress API responses
-AddOutputFilterByType DEFLATE application/json
-AddOutputFilterByType BROTLI_COMPRESS application/json
+<IfModule mod_deflate.c>
+    AddOutputFilterByType DEFLATE application/json
+</IfModule>
+<IfModule mod_brotli.c>
+    AddOutputFilterByType BROTLI_COMPRESS application/json
+</IfModule>
 
 # Allow brief caching of API responses
-ExpiresByType application/json "access plus 2 hours"
+<IfModule mod_expires.c>
+    ExpiresByType application/json "access plus 2 hours"
+</IfModule>
+

--- a/src/server/.htaccess
+++ b/src/server/.htaccess
@@ -4,3 +4,6 @@ Header set Access-Control-Allow-Origin "*"
 # Compress API responses
 AddOutputFilterByType DEFLATE application/json
 AddOutputFilterByType BROTLI_COMPRESS application/json
+
+# Allow brief caching of API responses
+ExpiresByType application/json "access plus 2 hours"

--- a/src/server/.htaccess
+++ b/src/server/.htaccess
@@ -11,6 +11,7 @@ Header set Access-Control-Allow-Origin "*"
 
 # Allow brief caching of API responses
 <IfModule mod_expires.c>
-    ExpiresByType application/json "access plus 2 hours"
+    # ExpiresActive on
+    # ExpiresByType application/json "access plus 2 hours"
 </IfModule>
 


### PR DESCRIPTION
I think enabling expires will require `AllowOverride Index`, or something like it, in the main Apache conf. So let's settle for enabling compression alone.

It's a hack to only have the Expires directives commented-out, but hopefully we can soon figure out how to set the Apache config appropriately.

I've tested on staging and the compression seems to work.