### PR TITLE
Add a script that can be used to load the metadata cache from a JSON file

### DIFF
--- a/src/acquisition/covidcast/covidcast_meta_cache_manual_updater.py
+++ b/src/acquisition/covidcast/covidcast_meta_cache_manual_updater.py
@@ -1,0 +1,47 @@
+"""Updates the cache for the `covidcast_meta` endpoint by reading JSON out of a file"""
+
+import argparse
+import json
+import sys
+
+from delphi.epidata.acquisition.covidcast.database import Database
+
+
+def get_argument_parser():
+    """Define command line arguments."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("metadata", type=str)
+    return parser
+
+def main(args, database_impl=Database):
+    """Read metadata out of a JSON file and use that to update the meta cache.
+
+    File format accepts either the JSON that would be returned from a
+    metadata call (ie a dict with keys [result, message, epidata]) or
+    the JSON that is cached in the table (ie a list of dicts, one dict
+    per signal configuration)
+    """
+    meta = {}
+    with open(args.metadata) as new_metadata:
+        meta = json.load(new_metadata)
+    if isinstance(meta, dict):
+        if "epidata" in meta:
+            meta = meta['epidata']
+    if not isinstance(meta, list):
+        print("Bad metadata type: expected list, got {type(meta)}")
+        sys.exit(1)
+
+    database = database_impl()
+    database.connect()
+
+    try:
+        database.update_covidcast_meta_cache(json.dumps(meta))
+        print('successfully cached epidata')
+    finally:
+        database.disconnect(True)
+    return True
+
+if __name__ == '__main__':
+    if not main(get_argument_parser().parse_args()):
+        sys.exit(1)

--- a/tests/acquisition/covidcast/test_covidcast_meta_cache_manual_updater.py
+++ b/tests/acquisition/covidcast/test_covidcast_meta_cache_manual_updater.py
@@ -1,0 +1,50 @@
+"""Unit tests for covidcast_meta_cache_manual_updater.py"""
+
+# standard library
+import argparse
+import json
+import unittest
+from unittest.mock import MagicMock, patch, mock_open
+
+# py3tester coverage target
+__test_target__ = (
+  'delphi.epidata.acquisition.covidcast.'
+  'covidcast_meta_cache_manual_updater'
+)
+
+
+class UnitTests(unittest.TestCase):
+  """Basic unit tests."""
+
+  def test_get_argument_parser(self):
+    """Return a parser for command-line arguments."""
+
+    self.assertIsInstance(get_argument_parser(), argparse.ArgumentParser)
+
+  def test_main_successful(self):
+    """Run the main program successfully."""
+
+    api_response = {
+      'result': 1,
+      'message': 'yes',
+      'epidata': [{'foo': 'bar'}],
+    }
+
+    args = MagicMock(metadata="")
+    mock_database = MagicMock()
+    fake_database_impl = lambda: mock_database
+
+    with patch('builtins.open', mock_open(read_data=json.dumps(api_response))):
+        main(
+            args,
+            database_impl=fake_database_impl)
+
+    self.assertTrue(mock_database.connect.called)
+
+    self.assertTrue(mock_database.update_covidcast_meta_cache.called)
+    actual_args = mock_database.update_covidcast_meta_cache.call_args[0]
+    expected_args = (json.dumps(api_response['epidata']),)
+    self.assertEqual(actual_args, expected_args)
+
+    self.assertTrue(mock_database.disconnect.called)
+    self.assertTrue(mock_database.disconnect.call_args[0][0])


### PR DESCRIPTION
We've had to do this a couple times, so here is some code to support it, with tests.