### PR TITLE
Fix bad default 'flat' value for format parameter in raw R client

### DIFF
--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -503,7 +503,7 @@ Epidata <- (function() {
   }
 
   # Fetch Delphi's COVID-19 Surveillance Streams
-  covidcast <- function(data_source, signals, time_type, geo_type, time_values, geo_value, as_of, issues, lag, format=c("flat","tree"), signal) {
+  covidcast <- function(data_source, signals, time_type, geo_type, time_values, geo_value, as_of, issues, lag, format=c("classic","tree"), signal) {
     # Check parameters
     if(missing(data_source) || (missing(signals) && missing(signal)) || missing(time_type) || missing(geo_type) || missing(time_values) || missing(geo_value)) {
       stop('`data_source`, `signals`, `time_type`, `geo_type`, `time_values`, and `geo_value` are all required')


### PR DESCRIPTION
#210 accidentally clobbered the default `format` parameter I was using in the R client, because R doesn't have as nice default-specification capabilities as coffee and python.

This only affects people still using the raw Epidata clients for COVIDcast, which notably includes the combination indicator.
