### PR TITLE
Backfill->Backwards padding

### DIFF
--- a/docs/api/covidcast-signals/doctor-visits.md
+++ b/docs/api/covidcast-signals/doctor-visits.md
@@ -149,7 +149,7 @@ $$\dot{Y}_{it}^k = Y_{it}^k / \alpha_{wd(t)}.$$
 We then use these adjusted counts to estimate the CLI percentage as described
 above.
 
-### Backwards padding
+### Backwards Padding
 
 To help with the reporting delay, we perform the following simple
 correction on each location. At each time $$t$$, we consider the total visit

--- a/docs/api/covidcast-signals/doctor-visits.md
+++ b/docs/api/covidcast-signals/doctor-visits.md
@@ -149,9 +149,9 @@ $$\dot{Y}_{it}^k = Y_{it}^k / \alpha_{wd(t)}.$$
 We then use these adjusted counts to estimate the CLI percentage as described
 above.
 
-### Backfill
+### Backwards padding
 
-To help with the reporting delay, we perform the following simple "backfill"
+To help with the reporting delay, we perform the following simple
 correction on each location. At each time $$t$$, we consider the total visit
 count. If the value is less than a minimum sample threshold, we go back to the
 previous time $$t-1$$, and add this visit count to the previous total, again

--- a/docs/api/covidcast-signals/hospital-admissions.md
+++ b/docs/api/covidcast-signals/hospital-admissions.md
@@ -91,10 +91,10 @@ $$
 \widehat{\text{se}}(\hat{p}_{it}) = 100 \sqrt{\frac{\frac{\hat{p}_{it}}{100}(1-\frac{\hat{p}_{it}}{100})}{N_{it}}}.
 $$
 
-## Backfill
+## Backwards padding
 
-This source undergoes the same backfill adjustment as the `doctor-visits`
-source; see [its documentation](doctor-visits.md#backfill).
+This source undergoes the same backwards padding adjustment as the `doctor-visits`
+source; see [its documentation](doctor-visits.md#backwards-padding).
 
 ## Smoothing
 

--- a/docs/api/covidcast-signals/hospital-admissions.md
+++ b/docs/api/covidcast-signals/hospital-admissions.md
@@ -91,7 +91,7 @@ $$
 \widehat{\text{se}}(\hat{p}_{it}) = 100 \sqrt{\frac{\frac{\hat{p}_{it}}{100}(1-\frac{\hat{p}_{it}}{100})}{N_{it}}}.
 $$
 
-## Backwards padding
+## Backwards Padding
 
 This source undergoes the same backwards padding adjustment as the `doctor-visits`
 source; see [its documentation](doctor-visits.md#backwards-padding).


### PR DESCRIPTION
Clarify that this backwards padding is not specifically for adjusting reporting delay (backfill), but rather to deal with data sparsity issues (which occur regardless of backfill).