### PR TITLE
feat: support geo_values (single geo_type)

### DIFF
--- a/integrations/server/test_covidcast.py
+++ b/integrations/server/test_covidcast.py
@@ -384,23 +384,30 @@ class CovidcastTests(unittest.TestCase):
       'signal': 'sig',
     }]
 
+    # test fetch all
     r = fetch('*')
     self.assertEqual(r['message'], 'success')
     self.assertEqual(r['epidata'], counties)
+    # test fetch a specific region
     r = fetch('11111')
     self.assertEqual(r['message'], 'success')
     self.assertEqual(r['epidata'], [counties[0]])
+    # test fetch a specific yet not existing region
     r = fetch('55555')
     self.assertEqual(r['message'], 'no results')
+    # test fetch a multiple regions
     r = fetch(['11111', '22222'])
     self.assertEqual(r['message'], 'success')
     self.assertEqual(r['epidata'], [counties[0], counties[1]])
+    # test fetch a multiple regions in another variant
     r = fetch(['11111', '33333'])
     self.assertEqual(r['message'], 'success')
     self.assertEqual(r['epidata'], [counties[0], counties[2]])
+    # test fetch a multiple regions but one is not existing
     r = fetch(['11111', '55555'])
     self.assertEqual(r['message'], 'success')
     self.assertEqual(r['epidata'], [counties[0]])
+    # test fetch a multiple regions but specify no region
     r = fetch([])
     self.assertEqual(r['message'], 'no results')
 

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -929,7 +929,7 @@ function get_dengue_nowcast($locations, $epiweeks) {
 //   $time_type (required): temporal resolution (e.g. day, week)
 //   $geo_type (required): spatial resolution (e.g. county, msa, state)
 //   $time_values (required): array of time values/ranges
-//   $geo_value (required): location identifier or `*` as a wildcard for all
+//   $geo_values (required): string, array of string, or `*` as a wildcard for all
 //     locations (specific to `$geo_type`)
 //   $issues (optional): array of time values/ranges
 //     overrides $lag
@@ -937,19 +937,18 @@ function get_dengue_nowcast($locations, $epiweeks) {
 //   $lag (optional): number of time units between each time value and its issue
 //     overridden by $issues
 //     default: most recent issue
-function get_covidcast($source, $signals, $time_type, $geo_type, $time_values, $geo_value, $as_of, $issues, $lag) {
+function get_covidcast($source, $signals, $time_type, $geo_type, $time_values, $geo_values, $as_of, $issues, $lag) {
   // required for `mysqli_real_escape_string`
   global $dbh;
   $source = mysqli_real_escape_string($dbh, $source);
   $time_type = mysqli_real_escape_string($dbh, $time_type);
   $geo_type = mysqli_real_escape_string($dbh, $geo_type);
-  $geo_value = mysqli_real_escape_string($dbh, $geo_value);
   // basic query info
   $table = '`covidcast` t';
   $fields = "t.`signal`, t.`time_value`, t.`geo_value`, t.`value`, t.`stderr`, t.`sample_size`, t.`direction`, t.`issue`, t.`lag`";
   $order = "t.`signal` ASC, t.`time_value` ASC, t.`geo_value` ASC, t.`issue` ASC";
   // data type of each field
-  $fields_string = array('geo_value','signal');
+  $fields_string = array('geo_value', 'signal');
   $fields_int = array('time_value', 'direction', 'issue', 'lag');
   $fields_float = array('value', 'stderr', 'sample_size');
   // build the source, signal, time, and location (type and id) filters
@@ -959,12 +958,16 @@ function get_covidcast($source, $signals, $time_type, $geo_type, $time_values, $
   $condition_geo_type = "t.`geo_type` = '{$geo_type}'";
   $condition_time_value = filter_integers('t.`time_value`', $time_values);
 
-  if ($geo_value === '*') {
+  if ($geo_values === '*') {
     // the wildcard query should return data for all locations in `geo_type`
     $condition_geo_value = 'TRUE';
+  } else if (is_array($geo_values)) {
+    // return data for multiple location
+    $condition_geo_value = filter_strings('t.`geo_value`', $geo_values);
   } else {
     // return data for a particular location
-    $condition_geo_value = "t.`geo_value` = '{$geo_value}'";
+    $geo_escaped_value = mysqli_real_escape_string($dbh, $geo_values);
+    $condition_geo_value = "t.`geo_value` = '{$geo_escaped_value}'";
   }
   $conditions = "({$condition_source}) AND ({$condition_signal}) AND ({$condition_time_type}) AND ({$condition_geo_type}) AND ({$condition_time_value}) AND ({$condition_geo_value})";
 
@@ -1518,14 +1521,16 @@ if(database_connect()) {
       }
     }
   } else if($source === 'covidcast') {
-    if(require_all($data, array('data_source', 'time_type', 'geo_type', 'time_values', 'geo_value'))
-       && require_any($data, array('signal', 'signals'))) {
+    if(require_all($data, array('data_source', 'time_type', 'geo_type', 'time_values'))
+       && require_any($data, array('signal', 'signals'))
+       && require_any($data, array('geo_value', 'geo_values'))) {
       // parse the request
       $time_values = extract_dates($_REQUEST['time_values']);
       $as_of = isset($_REQUEST['as_of']) ? parse_date($_REQUEST['as_of']) : null;
       $issues = isset($_REQUEST['issues']) ? extract_dates($_REQUEST['issues']) : null;
       $lag = isset($_REQUEST['lag']) ? intval($_REQUEST['lag']) : null;
       $signals = extract_values(isset($_REQUEST['signals']) ? $_REQUEST['signals'] : $_REQUEST['signal'], 'string');
+      $geo_values = isset($_REQUEST['geo_value']) ? $_REQUEST['geo_value'] : extract_values($_REQUEST['geo_values'], 'string');
       // get the data
       $epidata = get_covidcast(
           $_REQUEST['data_source'],
@@ -1533,7 +1538,7 @@ if(database_connect()) {
           $_REQUEST['time_type'],
           $_REQUEST['geo_type'],
           $time_values,
-          $_REQUEST['geo_value'],
+          $geo_values,
           $as_of,
           $issues,
           $lag);


### PR DESCRIPTION
closes #221 (single geo type only for now)

add support for `geo_values`.

valid variants:
 * `geo_value=*`
 * `geo_value=CA`
 * `geo_values=CA,NY`