### PR TITLE
Make sure that exceptions are reraised if the SQL insert fails.

### DIFF
--- a/src/acquisition/covidcast/database.py
+++ b/src/acquisition/covidcast/database.py
@@ -229,7 +229,7 @@ class Database:
       raise e
     finally:
       self._cursor.execute(drop_tmp_table_sql)
-      return total
+    return total
 
   def get_data_stdev_across_locations(self, max_day):
     """

--- a/tests/acquisition/covidcast/test_database.py
+++ b/tests/acquisition/covidcast/test_database.py
@@ -250,3 +250,15 @@ class UnitTests(unittest.TestCase):
     self.assertIn('`covidcast_meta_cache`', sql)
     self.assertIn('timestamp', sql)
     self.assertIn('epidata', sql)
+
+  def test_insert_or_update_batch_exception_reraised(self):
+    """Test that an exception is reraised"""
+    mock_connector = MagicMock()
+    database = Database()
+    database.connect(connector_impl=mock_connector)
+    connection = mock_connector.connect()
+    cursor = connection.cursor() 
+    cursor.executemany.side_effect = Exception('Test')
+
+    cc_rows = {MagicMock(geo_id='CA', val=1, se=0, sample_size=0)}
+    self.assertRaises(Exception, database.insert_or_update_batch, cc_rows)


### PR DESCRIPTION
Currently the return statement is inside of the `finally` block, this means that if an exception is caught and re-raised by the `except` block, it will be cached but then immediately discarded -- i.e., the function will never re-raise the exception. This will cause inserts that result in an exception to appear successful (though I believe with 0 lines inserted).

See https://stackoverflow.com/questions/43830803/re-raising-the-exception-doesnt-work-with-finally-clause for more context on the try/except/finally behavior.

This is an additional fix for #203.