### PR TITLE
Reorganize Epidata API docs to make hierarchy clearer

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,5 +1,5 @@
 ---
-title: Delphi Epidata API
+title: Epidata API (Other Epidemics)
 nav_order: 3
 has_children: true
 ---
@@ -7,7 +7,8 @@ has_children: true
 # Delphi Epidata API
 
 This is the home of [Delphi](https://delphi.cmu.edu/)'s epidemiological data
-API.
+API for tracking epidemics such as influenza, dengue, and norovirus. Note that
+our work on COVID-19 is available in the [COVIDcast Epidata API documentation](covidcast.md).
 
 ## Contributing
 

--- a/docs/api/afhsb.md
+++ b/docs/api/afhsb.md
@@ -1,6 +1,6 @@
 ---
 title: AFHSB
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # AFHSB

--- a/docs/api/cdc.md
+++ b/docs/api/cdc.md
@@ -1,6 +1,6 @@
 ---
 title: CDC
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # CDC

--- a/docs/api/covidcast-signals/_source-template.md
+++ b/docs/api/covidcast-signals/_source-template.md
@@ -1,7 +1,7 @@
 ---
 title: SOURCE NAME
 parent: Data Sources and Signals
-grand_parent: COVIDcast API
+grand_parent: COVIDcast Epidata API
 ---
 
 # SOURCE NAME

--- a/docs/api/covidcast-signals/doctor-visits.md
+++ b/docs/api/covidcast-signals/doctor-visits.md
@@ -1,7 +1,7 @@
 ---
 title: Doctor Visits
 parent: Data Sources and Signals
-grand_parent: COVIDcast API
+grand_parent: COVIDcast Epidata API
 ---
 
 # Doctor Visits

--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -1,7 +1,7 @@
 ---
 title: Symptom Surveys
 parent: Data Sources and Signals
-grand_parent: COVIDcast API
+grand_parent: COVIDcast Epidata API
 ---
 
 # Symptom Surveys

--- a/docs/api/covidcast-signals/ght.md
+++ b/docs/api/covidcast-signals/ght.md
@@ -1,7 +1,7 @@
 ---
 title: Google Health Trends
 parent: Data Sources and Signals
-grand_parent: COVIDcast API
+grand_parent: COVIDcast Epidata API
 ---
 
 # Google Health Trends

--- a/docs/api/covidcast-signals/google-survey.md
+++ b/docs/api/covidcast-signals/google-survey.md
@@ -1,7 +1,7 @@
 ---
 title: Google Symptom Surveys
 parent: Inactive Signals
-grand_parent: COVIDcast API
+grand_parent: COVIDcast Epidata API
 ---
 
 # Google Symptom Surveys

--- a/docs/api/covidcast-signals/hospital-admissions.md
+++ b/docs/api/covidcast-signals/hospital-admissions.md
@@ -1,7 +1,7 @@
 ---
 title: Hospital Admissions
 parent: Data Sources and Signals
-grand_parent: COVIDcast API
+grand_parent: COVIDcast Epidata API
 ---
 
 # Hospital Admissions

--- a/docs/api/covidcast-signals/indicator-combination.md
+++ b/docs/api/covidcast-signals/indicator-combination.md
@@ -1,7 +1,7 @@
 ---
 title: Indicator Combination
 parent: Data Sources and Signals
-grand_parent: COVIDcast API
+grand_parent: COVIDcast Epidata API
 ---
 
 # Indicator Combination

--- a/docs/api/covidcast-signals/jhu-csse.md
+++ b/docs/api/covidcast-signals/jhu-csse.md
@@ -1,7 +1,7 @@
 ---
 title: JHU Cases and Deaths
 parent: Data Sources and Signals
-grand_parent: COVIDcast API
+grand_parent: COVIDcast Epidata API
 ---
 
 # JHU Cases and Deaths

--- a/docs/api/covidcast-signals/quidel.md
+++ b/docs/api/covidcast-signals/quidel.md
@@ -1,7 +1,7 @@
 ---
 title: Quidel
 parent: Data Sources and Signals
-grand_parent: COVIDcast API
+grand_parent: COVIDcast Epidata API
 ---
 
 # Quidel

--- a/docs/api/covidcast-signals/safegraph.md
+++ b/docs/api/covidcast-signals/safegraph.md
@@ -1,7 +1,7 @@
 ---
 title: SafeGraph Mobility
 parent: Data Sources and Signals
-grand_parent: COVIDcast API
+grand_parent: COVIDcast Epidata API
 ---
 
 # SafeGraph Mobility

--- a/docs/api/covidcast-signals/usa-facts.md
+++ b/docs/api/covidcast-signals/usa-facts.md
@@ -1,7 +1,7 @@
 ---
 title: USAFacts Cases and Deaths
 parent: Data Sources and Signals
-grand_parent: COVIDcast API
+grand_parent: COVIDcast Epidata API
 ---
 
 # USAFacts Cases and Deaths

--- a/docs/api/covidcast.md
+++ b/docs/api/covidcast.md
@@ -1,10 +1,10 @@
 ---
-title: COVIDcast API
+title: COVIDcast Epidata API
 has_children: true
 nav_order: 1
 ---
 
-# Delphi's COVIDcast API
+# COVIDcast Epidata API
 
 This is the documentation for accessing the Delphi's COVID-19 Surveillance
 Streams (`covidcast`) endpoint of [Delphi](https://delphi.cmu.edu/)'s

--- a/docs/api/covidcast_changelog.md
+++ b/docs/api/covidcast_changelog.md
@@ -1,6 +1,6 @@
 ---
 title: Signal Changelog
-parent: COVIDcast API
+parent: COVIDcast Epidata API
 nav_order: 3
 ---
 

--- a/docs/api/covidcast_clients.md
+++ b/docs/api/covidcast_clients.md
@@ -1,6 +1,6 @@
 ---
 title: API Clients
-parent: COVIDcast API
+parent: COVIDcast Epidata API
 nav_order: 1
 ---
 

--- a/docs/api/covidcast_geography.md
+++ b/docs/api/covidcast_geography.md
@@ -1,6 +1,6 @@
 ---
 title: Geographic Coding
-parent: COVIDcast API
+parent: COVIDcast Epidata API
 nav_order: 4
 ---
 

--- a/docs/api/covidcast_inactive_signals.md
+++ b/docs/api/covidcast_inactive_signals.md
@@ -1,6 +1,6 @@
 ---
 title: Inactive Signals
-parent: COVIDcast API
+parent: COVIDcast Epidata API
 has_children: true
 nav_order: 6
 ---

--- a/docs/api/covidcast_meta.md
+++ b/docs/api/covidcast_meta.md
@@ -1,6 +1,6 @@
 ---
 title: Metadata
-parent: COVIDcast API
+parent: COVIDcast Epidata API
 nav_order: 5
 ---
 

--- a/docs/api/covidcast_signals.md
+++ b/docs/api/covidcast_signals.md
@@ -1,6 +1,6 @@
 ---
 title: Data Sources and Signals
-parent: COVIDcast API
+parent: COVIDcast Epidata API
 nav_order: 2
 has_children: true
 ---

--- a/docs/api/delphi.md
+++ b/docs/api/delphi.md
@@ -1,6 +1,6 @@
 ---
 title: Delphi Forecasts
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # Delphi Forecasts

--- a/docs/api/dengue_nowcast.md
+++ b/docs/api/dengue_nowcast.md
@@ -1,6 +1,6 @@
 ---
 title: Dengue Nowcast
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # Delphi's Dengue Nowcast

--- a/docs/api/dengue_sensors.md
+++ b/docs/api/dengue_sensors.md
@@ -1,6 +1,6 @@
 ---
 title: Dengue Digital Surveillance
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # Dengue Digital Surveillance Sensors

--- a/docs/api/ecdc_ili.md
+++ b/docs/api/ecdc_ili.md
@@ -1,6 +1,6 @@
 ---
 title: ECDC ILI
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # ECDC ILI

--- a/docs/api/flusurv.md
+++ b/docs/api/flusurv.md
@@ -1,6 +1,6 @@
 ---
 title: Flusurv
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # FluSurv

--- a/docs/api/fluview.md
+++ b/docs/api/fluview.md
@@ -1,6 +1,6 @@
 ---
 title: FluView
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # FluView

--- a/docs/api/fluview_clinical.md
+++ b/docs/api/fluview_clinical.md
@@ -1,6 +1,6 @@
 ---
 title: FluView Clinical
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # FluView Clinical

--- a/docs/api/fluview_meta.md
+++ b/docs/api/fluview_meta.md
@@ -1,6 +1,6 @@
 ---
 title: FluView metadata
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # FluView metadata

--- a/docs/api/gft.md
+++ b/docs/api/gft.md
@@ -1,6 +1,6 @@
 ---
 title: Google Flu Trends
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # Google Flu Trends

--- a/docs/api/ght.md
+++ b/docs/api/ght.md
@@ -1,6 +1,6 @@
 ---
 title: Google Health Trends
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # Google Health Trends

--- a/docs/api/kcdc_ili.md
+++ b/docs/api/kcdc_ili.md
@@ -1,6 +1,6 @@
 ---
 title: KCDC ILI
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # KCDC ILI

--- a/docs/api/meta.md
+++ b/docs/api/meta.md
@@ -1,6 +1,6 @@
 ---
 title: Metadata
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # API Metadata

--- a/docs/api/meta_afhsb.md
+++ b/docs/api/meta_afhsb.md
@@ -1,6 +1,6 @@
 ---
 title: AFHSB Metadata
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # AFHSB Metadata

--- a/docs/api/meta_norostat.md
+++ b/docs/api/meta_norostat.md
@@ -1,6 +1,6 @@
 ---
 title: NoroSTAT Metadata
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # NoroSTAT Metadata

--- a/docs/api/nidss_dengue.md
+++ b/docs/api/nidss_dengue.md
@@ -1,6 +1,6 @@
 ---
 title: NIDSS Dengue
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # NIDSS Dengue

--- a/docs/api/nidss_flu.md
+++ b/docs/api/nidss_flu.md
@@ -1,6 +1,6 @@
 ---
 title: NIDSS Flu
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # NIDSS Flu

--- a/docs/api/norostat.md
+++ b/docs/api/norostat.md
@@ -1,6 +1,6 @@
 ---
 title: NoroSTAT
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # NoroSTAT

--- a/docs/api/nowcast.md
+++ b/docs/api/nowcast.md
@@ -1,6 +1,6 @@
 ---
 title: ILI Nearby Nowcast
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # ILI Nearby Nowcast

--- a/docs/api/paho_dengue.md
+++ b/docs/api/paho_dengue.md
@@ -1,6 +1,6 @@
 ---
 title: PAHO Dengue
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # PAHO Dengue

--- a/docs/api/quidel.md
+++ b/docs/api/quidel.md
@@ -1,6 +1,6 @@
 ---
 title: Quidel
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # Quidel

--- a/docs/api/sensors.md
+++ b/docs/api/sensors.md
@@ -1,6 +1,6 @@
 ---
 title: Digital Surveillance Sensors
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # Digital Surveillance Sensors

--- a/docs/api/twitter.md
+++ b/docs/api/twitter.md
@@ -1,6 +1,6 @@
 ---
 title: Twitter Stream
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # Twitter Stream

--- a/docs/api/wiki.md
+++ b/docs/api/wiki.md
@@ -1,6 +1,6 @@
 ---
 title: Wikipedia Access
-parent: Delphi Epidata API
+parent: Epidata API (Other Epidemics)
 ---
 
 # Wikipedia Access

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,12 +9,11 @@ The Epidata API provides real-time access to epidemiological surveillance data.
 It is built and maintained by the Carnegie Mellon University [Delphi research
 group](https://delphi.cmu.edu/). The Epidata API includes:
 
-- The [COVIDcast API](api/covidcast.md), providing daily updates about COVID-19
-  activity across the United States. [API clients](api/covidcast_clients.md) are
-  available.
-- The general [Epidata API](api/README.md), providing information about
-  influenza, dengue, and other epidemics tracked by Delphi through a variety of
-  data streams.
+- [COVIDcast data](api/covidcast.md), providing daily updates about COVID-19
+  activity across the United States. [API clients](api/covidcast_clients.md) for
+  quick access to COVID data are available.
+- [Data about other epidemics](api/README.md), including influenza, dengue, and
+  other epidemics tracked by Delphi through a variety of data streams.
 
 The Delphi group is extremely grateful for Pedrito Maynard-Zhang for all his
 help with the Epidata API [documentation](api/index.md).


### PR DESCRIPTION
Based on comments by @RoniRos about the hierarchy being confusing here, with the site being named Epidata API, containing separate sections for COVIDcast (which is part of the Epidata API) and the Epidata API again.

Preview: http://rosmarus.refsmmat.com/delphi-epidata/

cc @dfarrow0 