### PR TITLE
Mention smoothed fb-survey signals closer to raw signal discussion

### DIFF
--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -77,14 +77,14 @@ influenza-like illness (fever, along with cough or sore throat). Using this
 survey data, we estimate the percentage of people who have a COVID-like illness,
 or influenza-like illness, in a given location, on a given day.
 
-| Signal | Description |
+| Signals | Description |
 | --- | --- |
-| `raw_cli` | Estimated percentage of people with COVID-like illness based on the [criteria below](#ili-and-cli-indicators), with no smoothing or survey weighting |
-| `raw_ili` | Estimated percentage of people with influenza-like illness based on the [criteria below](#ili-and-cli-indicators), with no smoothing or survey weighting |
-| `raw_wcli` | Estimated percentage of people with COVID-like illness; adjusted using survey weights [as described below](#survey-weighting) |
-| `raw_wili` | Estimated percentage of people with influenza-like illness; adjusted using survey weights [as described below](#survey-weighting) |
-| `raw_hh_cmnty_cli` | Estimated percentage of people reporting illness in their local community, as [described below](#estimating-community-cli), including their household, with no smoothing or survey weighting |
-| `raw_nohh_cmnty_cli` | Estimated percentage of people reporting illness in their local community, as [described below](#estimating-community-cli), not including their household, with no smoothing or survey weighting |
+| `raw_cli` and `smoothed_cli` | Estimated percentage of people with COVID-like illness based on the [criteria below](#ili-and-cli-indicators), with no survey weighting |
+| `raw_ili` and `smoothed_ili` | Estimated percentage of people with influenza-like illness based on the [criteria below](#ili-and-cli-indicators), with no survey weighting |
+| `raw_wcli` and `smoothed_wcli` | Estimated percentage of people with COVID-like illness; adjusted using survey weights [as described below](#survey-weighting) |
+| `raw_wili` and `smoothed_wili` | Estimated percentage of people with influenza-like illness; adjusted using survey weights [as described below](#survey-weighting) |
+| `raw_hh_cmnty_cli` and `smoothed_hh_cmnty_cli` | Estimated percentage of people reporting illness in their local community, as [described below](#estimating-community-cli), including their household, with no survey weighting |
+| `raw_nohh_cmnty_cli` and `smoothed_nohh_cmnty_cli` | Estimated percentage of people reporting illness in their local community, as [described below](#estimating-community-cli), not including their household, with no survey weighting |
 
 Note that for `raw_hh_cmnty_cli` and `raw_nohh_cmnty_cli`, the illnesses
 included are broader: a respondent is included if they know someone in their
@@ -108,10 +108,9 @@ can be asymptomatic. Instead, we expect these indicators to be useful for
 comparison across the United States and across time, to determine where symptoms
 appear to be increasing.
 
-**Smoothing.** For the `raw_` signals above, there are additional signals with
-names beginning with `smoothed_`. These estimate the same quantities as the
-above signals, but are smoothed in time to reduce day-to-day sampling noise; see
-[details below](#smoothing). Crucially, because the smoothed signals combine
+The signals beginning with `smoothed_` estimate the same quantities as their
+`raw` partners, but are smoothed in time to reduce day-to-day sampling noise;
+see [details below](#smoothing). Crucially, because the smoothed signals combine
 information across multiple days, they have larger sample sizes and hence are
 available for more counties and MSAs than the raw signals.
 

--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -30,13 +30,6 @@ described in the sections below:
 3. [Testing indicators](#testing-indicators) based on respondent reporting of
    their COVID test results
 
-For most `raw_` signals below, there are additional signals with names beginning
-with `smoothed_`. These estimate the same quantities as the above signals, but
-are smoothed in time to reduce day-to-day sampling noise; see [details
-below](#smoothing). Crucially, because the smoothed signals combine information
-across multiple days, they have larger sample sizes and hence are available for
-more counties and MSAs than the raw signals.
-
 ## Table of contents
 {: .no_toc .text-delta}
 
@@ -114,6 +107,13 @@ These symptoms can be caused by many other conditions, and many true infections
 can be asymptomatic. Instead, we expect these indicators to be useful for
 comparison across the United States and across time, to determine where symptoms
 appear to be increasing.
+
+**Smoothing.** For the `raw_` signals above, there are additional signals with
+names beginning with `smoothed_`. These estimate the same quantities as the
+above signals, but are smoothed in time to reduce day-to-day sampling noise; see
+[details below](#smoothing). Crucially, because the smoothed signals combine
+information across multiple days, they have larger sample sizes and hence are
+available for more counties and MSAs than the raw signals.
 
 ### Defining Household ILI and CLI
 
@@ -268,9 +268,9 @@ problematic.
 
 ### Smoothing
 
-The smoothed versions of the signals described above (with `smoothed_` prefix)
-are calculated using seven day pooling. For example, the estimate reported for
-June 7 in a specific geographical area (such as county or MSA) is formed by
+The smoothed versions of all `fb-survey` signals (with `smoothed_` prefix) are
+calculated using seven day pooling. For example, the estimate reported for June
+7 in a specific geographical area (such as county or MSA) is formed by
 collecting all surveys completed between June 1 and 7 (inclusive) and using that
 data in the estimation procedures described above.
 

--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -108,7 +108,7 @@ can be asymptomatic. Instead, we expect these indicators to be useful for
 comparison across the United States and across time, to determine where symptoms
 appear to be increasing.
 
-The signals beginning with `smoothed_` estimate the same quantities as their
+**Smoothing.** The signals beginning with `smoothed_` estimate the same quantities as their
 `raw` partners, but are smoothed in time to reduce day-to-day sampling noise;
 see [details below](#smoothing). Crucially, because the smoothed signals combine
 information across multiple days, they have larger sample sizes and hence are


### PR DESCRIPTION
Raw signals are not listed for the other indicators, so we only need this comment for the CLI/ILI signals.

cc @dshemetov, who couldn't find the information he needed because of this issue.