### PR TITLE
Compress CSV responses from the API

### DIFF
--- a/src/server/.htaccess
+++ b/src/server/.htaccess
@@ -3,10 +3,10 @@ Header set Access-Control-Allow-Origin "*"
 
 # Compress API responses
 <IfModule mod_deflate.c>
-    AddOutputFilterByType DEFLATE application/json
+    AddOutputFilterByType DEFLATE application/json text/csv
 </IfModule>
 <IfModule mod_brotli.c>
-    AddOutputFilterByType BROTLI_COMPRESS application/json
+    AddOutputFilterByType BROTLI_COMPRESS application/json text/csv
 </IfModule>
 
 # Allow brief caching of API responses


### PR DESCRIPTION
#210 added format=csv, but these responses are not currently compressed like JSON responses are.

I'd like to switch to CSV format in the R client, so compression is important to add here.