### PR TITLE
1.11 docs: Fix markdown headers

### DIFF
--- a/docs/api/covidcast-signals/google-symptoms.md
+++ b/docs/api/covidcast-signals/google-symptoms.md
@@ -1,7 +1,7 @@
 ---
 title: Google Symptoms
 parent: Data Sources and Signals
-grand_parent: COVIDcast API
+grand_parent: COVIDcast Epidata API
 ---
 
 # Google Symptoms

--- a/docs/api/covidcast-signals/safegraph.md
+++ b/docs/api/covidcast-signals/safegraph.md
@@ -1,5 +1,5 @@
 ---
-title: SafeGraph Mobility
+title: SafeGraph
 parent: Data Sources and Signals
 grand_parent: COVIDcast Epidata API
 ---


### PR DESCRIPTION
We missed some header misspellings, so this PR will make the new signals actually visible...