### PR TITLE
fix search for testdata

### DIFF
--- a/src/acquisition/covid_hosp/state_timeseries/test_utils.py
+++ b/src/acquisition/covid_hosp/state_timeseries/test_utils.py
@@ -21,7 +21,7 @@ class TestUtils:
   def __init__(self, abs_path_to_caller):
     # navigate to the root of the delphi-epidata repo
     path_to_repo = Path(abs_path_to_caller)
-    while path_to_repo.name != 'delphi-epidata':
+    while not (path_to_repo / 'testdata').exists():
       if not path_to_repo.name:
         raise Exception('unable to determine path to delphi-epidata repo')
       path_to_repo = path_to_repo.parent


### PR DESCRIPTION
- don't look for specific repo name, but look for the testdata directory 
directly
- should fix the deploy of delpi-epidata, which currently fails due to 
unit tests failing due to being unable to find test data