### PR TITLE
add endpoint `covid_hosp_facility`

### DIFF
--- a/integrations/acquisition/covid_hosp/facility/test_scenarios.py
+++ b/integrations/acquisition/covid_hosp/facility/test_scenarios.py
@@ -1,0 +1,87 @@
+"""Integration tests for acquisition of COVID hospitalization facility."""
+
+# standard library
+import unittest
+from unittest.mock import MagicMock
+
+# first party
+from delphi.epidata.acquisition.covid_hosp.common.database import Database
+from delphi.epidata.acquisition.covid_hosp.common.test_utils import TestUtils
+from delphi.epidata.client.delphi_epidata import Epidata
+import delphi.operations.secrets as secrets
+
+# py3tester coverage target (equivalent to `import *`)
+__test_target__ = 'delphi.epidata.acquisition.covid_hosp.facility.update'
+
+
+class AcquisitionTests(unittest.TestCase):
+
+  def setUp(self):
+    """Perform per-test setup."""
+
+    # configure test data
+    self.test_utils = TestUtils(__file__)
+
+    # use the local instance of the Epidata API
+    Epidata.BASE_URL = 'http://delphi_web_epidata/epidata/api.php'
+
+    # use the local instance of the epidata database
+    secrets.db.host = 'delphi_database_epidata'
+    secrets.db.epi = ('user', 'pass')
+
+    # clear relevant tables
+    with Database.connect() as db:
+      with db.new_cursor() as cur:
+        cur.execute('truncate table covid_hosp_facility')
+        cur.execute('truncate table covid_hosp_meta')
+
+  def test_acquire_dataset(self):
+    """Acquire a new dataset."""
+
+    # only mock out network calls to external hosts
+    mock_network = MagicMock()
+    mock_network.fetch_metadata.return_value = \
+        self.test_utils.load_sample_metadata()
+    mock_network.fetch_dataset.return_value = \
+        self.test_utils.load_sample_dataset()
+
+    # make sure the data does not yet exist
+    with self.subTest(name='no data yet'):
+      response = Epidata.covid_hosp_facility(
+          '450822', Epidata.range(20200101, 20210101))
+      self.assertEqual(response['result'], -2)
+
+    # acquire sample data into local database
+    with self.subTest(name='first acquisition'):
+      acquired = Update.run(network=mock_network)
+      self.assertTrue(acquired)
+
+    # make sure the data now exists
+    with self.subTest(name='initial data checks'):
+      response = Epidata.covid_hosp_facility(
+          '450822', Epidata.range(20200101, 20210101))
+      self.assertEqual(response['result'], 1)
+      self.assertEqual(len(response['epidata']), 1)
+      row = response['epidata'][0]
+      self.assertEqual(row['hospital_pk'], '450822')
+      self.assertEqual(row['collection_week'], 20201030)
+      self.assertEqual(row['publication_date'], 20201208)
+      self.assertEqual(row['previous_day_total_ed_visits_7_day_sum'], 536)
+      self.assertAlmostEqual(row['total_beds_7_day_avg'], 69.3)
+      self.assertEqual(
+          row['previous_day_admission_influenza_confirmed_7_day_sum'], -999999)
+
+      # expect 94 fields per row (95 database columns, except `id`)
+      self.assertEqual(len(row), 94)
+
+    # re-acquisition of the same dataset should be a no-op
+    with self.subTest(name='second acquisition'):
+      acquired = Update.run(network=mock_network)
+      self.assertFalse(acquired)
+
+    # make sure the data still exists
+    with self.subTest(name='final data checks'):
+      response = Epidata.covid_hosp_facility(
+          '450822', Epidata.range(20200101, 20210101))
+      self.assertEqual(response['result'], 1)
+      self.assertEqual(len(response['epidata']), 1)

--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -566,6 +566,25 @@ Epidata <- (function() {
     return(.request(params))
   }
 
+  # Fetch COVID hospitalization data for specific facilities
+  covid_hosp_facility <- function(hospital_pks, collection_weeks, publication_dates) {
+    # Check parameters
+    if(missing(hospital_pks) || missing(collection_weeks)) {
+      stop('`hospital_pks` and `collection_weeks` are both required')
+    }
+    # Set up request
+    params <- list(
+      source = 'covid_hosp_facility',
+      hospital_pks = .list(hospital_pks),
+      collection_weeks = .list(collection_weeks)
+    )
+    if(!missing(publication_dates)) {
+      params$publication_dates <- .list(publication_dates)
+    }
+    # Make the API call
+    return(.request(params))
+  }
+
   # Export the public methods
   return(list(
     range = range,
@@ -593,6 +612,7 @@ Epidata <- (function() {
     meta = meta,
     covidcast = covidcast,
     covidcast_meta = covidcast_meta,
-    covid_hosp = covid_hosp
+    covid_hosp = covid_hosp,
+    covid_hosp_facility = covid_hosp_facility
   ))
 })()

--- a/src/client/delphi_epidata.coffee
+++ b/src/client/delphi_epidata.coffee
@@ -404,5 +404,20 @@ class Epidata
     # Make the API call
     _request(callback, params)
 
+  # Fetch COVID hospitalization data for specific facilities
+  @covid_hosp_facility: (callback, hospital_pks, collection_weeks, publication_dates) ->
+    # Check parameters
+    unless hospital_pks? and collection_weeks?
+      throw { msg: '`hospital_pks` and `collection_weeks` are both required' }
+    # Set up request
+    params =
+      'source': 'covid_hosp_facility'
+      'hospital_pks': _list(hospital_pks)
+      'collection_weeks': _list(collection_weeks)
+    if publication_dates?
+      params.publication_dates = _list(publication_dates)
+    # Make the API call
+    _request(callback, params)
+
 # Export the API to the global environment
 (exports ? window).Epidata = Epidata

--- a/src/client/delphi_epidata.js
+++ b/src/client/delphi_epidata.js
@@ -636,6 +636,32 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 
           return _request(callback, params);
+        } // Fetch COVID hospitalization data for specific facilities
+
+      }, {
+        key: "covid_hosp_facility",
+        value: function covid_hosp_facility(callback, hospital_pks, collection_weeks, publication_dates) {
+          var params; // Check parameters
+
+          if (!(hospital_pks != null && collection_weeks != null)) {
+            throw {
+              msg: '`hospital_pks` and `collection_weeks` are both required'
+            };
+          } // Set up request
+
+
+          params = {
+            'source': 'covid_hosp_facility',
+            'hospital_pks': _list(hospital_pks),
+            'collection_weeks': _list(collection_weeks)
+          };
+
+          if (publication_dates != null) {
+            params.publication_dates = _list(publication_dates);
+          } // Make the API call
+
+
+          return _request(callback, params);
         }
       }]);
 

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -624,3 +624,22 @@ class Epidata:
       params['issues'] = Epidata._list(issues)
     # Make the API call
     return Epidata._request(params)
+
+  # Fetch COVID hospitalization data for specific facilities
+  @staticmethod
+  def covid_hosp_facility(
+      hospital_pks, collection_weeks, publication_dates=None):
+    """Fetch COVID hospitalization data for specific facilities."""
+    # Check parameters
+    if hospital_pks is None or collection_weeks is None:
+      raise Exception('`hospital_pks` and `collection_weeks` are both required')
+    # Set up request
+    params = {
+      'source': 'covid_hosp_facility',
+      'hospital_pks': Epidata._list(hospital_pks),
+      'collection_weeks': Epidata._list(collection_weeks),
+    }
+    if publication_dates is not None:
+      params['publication_dates'] = Epidata._list(publication_dates)
+    # Make the API call
+    return Epidata._request(params)

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -1219,6 +1219,233 @@ function get_covid_hosp_state_timeseries($states, $dates, $issues) {
   return count($epidata) === 0 ? null : $epidata;
 }
 
+// queries the `covid_hosp_facility` table
+//   $hospital_pks (required): array of facility identifiers (`hospital_pk`)
+//   $collection_weeks (required): array of date values/ranges
+//   $publication_dates (optional): array of date values/ranges
+//     default: most recent issue
+function get_covid_hosp_facility($hospital_pks, $collection_weeks, $publication_dates) {
+  $epidata = array();
+  $table = '`covid_hosp_facility` c';
+  $fields = implode(', ', array(
+    'c.`publication_date`',
+    'c.`hospital_pk`',
+    'c.`collection_week`',
+    'c.`state`',
+    'c.`ccn`',
+    'c.`hospital_name`',
+    'c.`address`',
+    'c.`city`',
+    'c.`zip`',
+    'c.`hospital_subtype`',
+    'c.`fips_code`',
+    'c.`is_metro_micro`',
+    'c.`total_beds_7_day_avg`',
+    'c.`all_adult_hospital_beds_7_day_avg`',
+    'c.`all_adult_hospital_inpatient_beds_7_day_avg`',
+    'c.`inpatient_beds_used_7_day_avg`',
+    'c.`all_adult_hospital_inpatient_bed_occupied_7_day_avg`',
+    'c.`total_adult_patients_hosp_confirmed_suspected_covid_7d_avg`',
+    'c.`total_adult_patients_hospitalized_confirmed_covid_7_day_avg`',
+    'c.`total_pediatric_patients_hosp_confirmed_suspected_covid_7d_avg`',
+    'c.`total_pediatric_patients_hospitalized_confirmed_covid_7_day_avg`',
+    'c.`inpatient_beds_7_day_avg`',
+    'c.`total_icu_beds_7_day_avg`',
+    'c.`total_staffed_adult_icu_beds_7_day_avg`',
+    'c.`icu_beds_used_7_day_avg`',
+    'c.`staffed_adult_icu_bed_occupancy_7_day_avg`',
+    'c.`staffed_icu_adult_patients_confirmed_suspected_covid_7d_avg`',
+    'c.`staffed_icu_adult_patients_confirmed_covid_7_day_avg`',
+    'c.`total_patients_hospitalized_confirmed_influenza_7_day_avg`',
+    'c.`icu_patients_confirmed_influenza_7_day_avg`',
+    'c.`total_patients_hosp_confirmed_influenza_and_covid_7d_avg`',
+    'c.`total_beds_7_day_sum`',
+    'c.`all_adult_hospital_beds_7_day_sum`',
+    'c.`all_adult_hospital_inpatient_beds_7_day_sum`',
+    'c.`inpatient_beds_used_7_day_sum`',
+    'c.`all_adult_hospital_inpatient_bed_occupied_7_day_sum`',
+    'c.`total_adult_patients_hosp_confirmed_suspected_covid_7d_sum`',
+    'c.`total_adult_patients_hospitalized_confirmed_covid_7_day_sum`',
+    'c.`total_pediatric_patients_hosp_confirmed_suspected_covid_7d_sum`',
+    'c.`total_pediatric_patients_hospitalized_confirmed_covid_7_day_sum`',
+    'c.`inpatient_beds_7_day_sum`',
+    'c.`total_icu_beds_7_day_sum`',
+    'c.`total_staffed_adult_icu_beds_7_day_sum`',
+    'c.`icu_beds_used_7_day_sum`',
+    'c.`staffed_adult_icu_bed_occupancy_7_day_sum`',
+    'c.`staffed_icu_adult_patients_confirmed_suspected_covid_7d_sum`',
+    'c.`staffed_icu_adult_patients_confirmed_covid_7_day_sum`',
+    'c.`total_patients_hospitalized_confirmed_influenza_7_day_sum`',
+    'c.`icu_patients_confirmed_influenza_7_day_sum`',
+    'c.`total_patients_hosp_confirmed_influenza_and_covid_7d_sum`',
+    'c.`total_beds_7_day_coverage`',
+    'c.`all_adult_hospital_beds_7_day_coverage`',
+    'c.`all_adult_hospital_inpatient_beds_7_day_coverage`',
+    'c.`inpatient_beds_used_7_day_coverage`',
+    'c.`all_adult_hospital_inpatient_bed_occupied_7_day_coverage`',
+    'c.`total_adult_patients_hosp_confirmed_suspected_covid_7d_cov`',
+    'c.`total_adult_patients_hospitalized_confirmed_covid_7_day_coverage`',
+    'c.`total_pediatric_patients_hosp_confirmed_suspected_covid_7d_cov`',
+    'c.`total_pediatric_patients_hosp_confirmed_covid_7d_cov`',
+    'c.`inpatient_beds_7_day_coverage`',
+    'c.`total_icu_beds_7_day_coverage`',
+    'c.`total_staffed_adult_icu_beds_7_day_coverage`',
+    'c.`icu_beds_used_7_day_coverage`',
+    'c.`staffed_adult_icu_bed_occupancy_7_day_coverage`',
+    'c.`staffed_icu_adult_patients_confirmed_suspected_covid_7d_cov`',
+    'c.`staffed_icu_adult_patients_confirmed_covid_7_day_coverage`',
+    'c.`total_patients_hospitalized_confirmed_influenza_7_day_coverage`',
+    'c.`icu_patients_confirmed_influenza_7_day_coverage`',
+    'c.`total_patients_hosp_confirmed_influenza_and_covid_7d_cov`',
+    'c.`previous_day_admission_adult_covid_confirmed_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_confirmed_18_19_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_confirmed_20_29_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_confirmed_30_39_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_confirmed_40_49_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_confirmed_50_59_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_confirmed_60_69_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_confirmed_70_79_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_confirmed_80plus_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_confirmed_unknown_7_day_sum`',
+    'c.`previous_day_admission_pediatric_covid_confirmed_7_day_sum`',
+    'c.`previous_day_covid_ed_visits_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_suspected_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_suspected_18_19_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_suspected_20_29_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_suspected_30_39_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_suspected_40_49_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_suspected_50_59_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_suspected_60_69_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_suspected_70_79_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_suspected_80plus_7_day_sum`',
+    'c.`previous_day_admission_adult_covid_suspected_unknown_7_day_sum`',
+    'c.`previous_day_admission_pediatric_covid_suspected_7_day_sum`',
+    'c.`previous_day_total_ed_visits_7_day_sum`',
+    'c.`previous_day_admission_influenza_confirmed_7_day_sum`',
+  ));
+  // basic query info
+  $order = "c.`collection_week` ASC, c.`hospital_pk` ASC, c.`publication_date` ASC";
+  // build the date filter
+  $condition_collection_week = filter_integers('c.`collection_week`', $collection_weeks);
+  // build the state filter
+  $condition_hospital_pk = filter_strings('c.`hospital_pk`', $hospital_pks);
+  if($publication_dates !== null) {
+    // build the issue filter
+    $condition_publication_date = filter_integers('c.`publication_date`', $publication_dates);
+    // final query using specific issues
+    $query = "SELECT {$fields} FROM {$table} WHERE ({$condition_collection_week}) AND ({$condition_hospital_pk}) AND ({$condition_publication_date}) ORDER BY {$order}";
+  } else {
+    // final query using most recent issues
+    $subquery = "(SELECT max(`publication_date`) `max_publication_date`, `collection_week`, `hospital_pk` FROM {$table} WHERE ({$condition_collection_week}) AND ({$condition_hospital_pk}) GROUP BY `collection_week`, `hospital_pk`) x";
+    $condition = "x.`max_publication_date` = c.`publication_date` AND x.`collection_week` = c.`collection_week` AND x.`hospital_pk` = c.`hospital_pk`";
+    $query = "SELECT {$fields} FROM {$table} JOIN {$subquery} ON {$condition} ORDER BY {$order}";
+  }
+  // get the data from the database
+  $fields_string = array(
+    'hospital_pk',
+    'state',
+    'ccn',
+    'hospital_name',
+    'address',
+    'city',
+    'zip',
+    'hospital_subtype',
+    'fips_code',
+  );
+  $fields_int = array(
+    'publication_date',
+    'collection_week',
+    'is_metro_micro',
+    'total_beds_7_day_sum',
+    'all_adult_hospital_beds_7_day_sum',
+    'all_adult_hospital_inpatient_beds_7_day_sum',
+    'inpatient_beds_used_7_day_sum',
+    'all_adult_hospital_inpatient_bed_occupied_7_day_sum',
+    'total_adult_patients_hosp_confirmed_suspected_covid_7d_sum',
+    'total_adult_patients_hospitalized_confirmed_covid_7_day_sum',
+    'total_pediatric_patients_hosp_confirmed_suspected_covid_7d_sum',
+    'total_pediatric_patients_hospitalized_confirmed_covid_7_day_sum',
+    'inpatient_beds_7_day_sum',
+    'total_icu_beds_7_day_sum',
+    'total_staffed_adult_icu_beds_7_day_sum',
+    'icu_beds_used_7_day_sum',
+    'staffed_adult_icu_bed_occupancy_7_day_sum',
+    'staffed_icu_adult_patients_confirmed_suspected_covid_7d_sum',
+    'staffed_icu_adult_patients_confirmed_covid_7_day_sum',
+    'total_patients_hospitalized_confirmed_influenza_7_day_sum',
+    'icu_patients_confirmed_influenza_7_day_sum',
+    'total_patients_hosp_confirmed_influenza_and_covid_7d_sum',
+    'total_beds_7_day_coverage',
+    'all_adult_hospital_beds_7_day_coverage',
+    'all_adult_hospital_inpatient_beds_7_day_coverage',
+    'inpatient_beds_used_7_day_coverage',
+    'all_adult_hospital_inpatient_bed_occupied_7_day_coverage',
+    'total_adult_patients_hosp_confirmed_suspected_covid_7d_cov',
+    'total_adult_patients_hospitalized_confirmed_covid_7_day_coverage',
+    'total_pediatric_patients_hosp_confirmed_suspected_covid_7d_cov',
+    'total_pediatric_patients_hosp_confirmed_covid_7d_cov',
+    'inpatient_beds_7_day_coverage',
+    'total_icu_beds_7_day_coverage',
+    'total_staffed_adult_icu_beds_7_day_coverage',
+    'icu_beds_used_7_day_coverage',
+    'staffed_adult_icu_bed_occupancy_7_day_coverage',
+    'staffed_icu_adult_patients_confirmed_suspected_covid_7d_cov',
+    'staffed_icu_adult_patients_confirmed_covid_7_day_coverage',
+    'total_patients_hospitalized_confirmed_influenza_7_day_coverage',
+    'icu_patients_confirmed_influenza_7_day_coverage',
+    'total_patients_hosp_confirmed_influenza_and_covid_7d_cov',
+    'previous_day_admission_adult_covid_confirmed_7_day_sum',
+    'previous_day_admission_adult_covid_confirmed_18_19_7_day_sum',
+    'previous_day_admission_adult_covid_confirmed_20_29_7_day_sum',
+    'previous_day_admission_adult_covid_confirmed_30_39_7_day_sum',
+    'previous_day_admission_adult_covid_confirmed_40_49_7_day_sum',
+    'previous_day_admission_adult_covid_confirmed_50_59_7_day_sum',
+    'previous_day_admission_adult_covid_confirmed_60_69_7_day_sum',
+    'previous_day_admission_adult_covid_confirmed_70_79_7_day_sum',
+    'previous_day_admission_adult_covid_confirmed_80plus_7_day_sum',
+    'previous_day_admission_adult_covid_confirmed_unknown_7_day_sum',
+    'previous_day_admission_pediatric_covid_confirmed_7_day_sum',
+    'previous_day_covid_ed_visits_7_day_sum',
+    'previous_day_admission_adult_covid_suspected_7_day_sum',
+    'previous_day_admission_adult_covid_suspected_18_19_7_day_sum',
+    'previous_day_admission_adult_covid_suspected_20_29_7_day_sum',
+    'previous_day_admission_adult_covid_suspected_30_39_7_day_sum',
+    'previous_day_admission_adult_covid_suspected_40_49_7_day_sum',
+    'previous_day_admission_adult_covid_suspected_50_59_7_day_sum',
+    'previous_day_admission_adult_covid_suspected_60_69_7_day_sum',
+    'previous_day_admission_adult_covid_suspected_70_79_7_day_sum',
+    'previous_day_admission_adult_covid_suspected_80plus_7_day_sum',
+    'previous_day_admission_adult_covid_suspected_unknown_7_day_sum',
+    'previous_day_admission_pediatric_covid_suspected_7_day_sum',
+    'previous_day_total_ed_visits_7_day_sum',
+    'previous_day_admission_influenza_confirmed_7_day_sum',
+  );
+  $fields_float = array(
+    'total_beds_7_day_avg',
+    'all_adult_hospital_beds_7_day_avg',
+    'all_adult_hospital_inpatient_beds_7_day_avg',
+    'inpatient_beds_used_7_day_avg',
+    'all_adult_hospital_inpatient_bed_occupied_7_day_avg',
+    'total_adult_patients_hosp_confirmed_suspected_covid_7d_avg',
+    'total_adult_patients_hospitalized_confirmed_covid_7_day_avg',
+    'total_pediatric_patients_hosp_confirmed_suspected_covid_7d_avg',
+    'total_pediatric_patients_hospitalized_confirmed_covid_7_day_avg',
+    'inpatient_beds_7_day_avg',
+    'total_icu_beds_7_day_avg',
+    'total_staffed_adult_icu_beds_7_day_avg',
+    'icu_beds_used_7_day_avg',
+    'staffed_adult_icu_bed_occupancy_7_day_avg',
+    'staffed_icu_adult_patients_confirmed_suspected_covid_7d_avg',
+    'staffed_icu_adult_patients_confirmed_covid_7_day_avg',
+    'total_patients_hospitalized_confirmed_influenza_7_day_avg',
+    'icu_patients_confirmed_influenza_7_day_avg',
+    'total_patients_hosp_confirmed_influenza_and_covid_7d_avg',
+  );
+  execute_query($query, $epidata, $fields_string, $fields_int, $fields_float);
+  // return the data
+  return count($epidata) === 0 ? null : $epidata;
+}
+
 // queries a bunch of epidata tables
 function get_meta() {
   // query and return metadata
@@ -1717,6 +1944,16 @@ if(database_connect()) {
       $issues = isset($_REQUEST['issues']) ? extract_values($_REQUEST['issues'], 'int') : null;
       // get the data
       $epidata = get_covid_hosp_state_timeseries($states, $dates, $issues);
+      store_result($data, $epidata);
+    }
+  } else if($source === 'covid_hosp_facility') {
+    if(require_all($data, array('hospital_pks', 'collection_weeks'))) {
+      // parse the request
+      $hospital_pks = extract_values($_REQUEST['hospital_pks'], 'str');
+      $collection_weeks = extract_values($_REQUEST['collection_weeks'], 'int');
+      $publication_dates = isset($_REQUEST['publication_dates']) ? extract_values($_REQUEST['publication_dates'], 'int') : null;
+      // get the data
+      $epidata = get_covid_hosp_facility($hospital_pks, $collection_weeks, $publication_dates);
       store_result($data, $epidata);
     }
   } else {


### PR DESCRIPTION
- api udpated
- all clients updated
- added integration test which exercises the new endpoint in server and 
python client

next pr will add another endpoint for hospital discovery. (e.g. answer "what hospitals are in PA?". then use that info to query `covid_hosp_facility` with a specific `hospital_pk` of interest.)

all unit and integrations pass