### PR TITLE
facility fix and new endpoint

### DIFF
--- a/src/acquisition/covid_hosp/common/utils.py
+++ b/src/acquisition/covid_hosp/common/utils.py
@@ -37,6 +37,36 @@ class Utils:
 
     return int(date.replace('-', ''))
 
+  def parse_bool(value):
+    """Convert a string to a boolean.
+
+    Parameters
+    ----------
+    value : str
+      Boolean-like value, like "true" or "false".
+
+    Returns
+    -------
+    bool
+      If the string contains some version of "true" or "false".
+    None
+      If the string is None or empty.
+
+    Raises
+    ------
+    CovidHospException
+      If the string constains something other than a version of "true" or
+      "false".
+    """
+
+    if not value:
+      return None
+    if value.lower() == 'true':
+      return True
+    if value.lower() == 'false':
+      return False
+    raise CovidHospException(f'cannot convert "{value}" to bool')
+
   def get_entry(obj, *path):
     """Get a deeply nested field from an arbitrary object.
 

--- a/src/acquisition/covid_hosp/facility/database.py
+++ b/src/acquisition/covid_hosp/facility/database.py
@@ -23,7 +23,7 @@ class Database(BaseDatabase):
     ('zip', str),
     ('hospital_subtype', str),
     ('fips_code', str),
-    ('is_metro_micro', bool),
+    ('is_metro_micro', Utils.parse_bool),
     ('total_beds_7_day_avg', float),
     ('all_adult_hospital_beds_7_day_avg', float),
     ('all_adult_hospital_inpatient_beds_7_day_avg', float),

--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -585,6 +585,27 @@ Epidata <- (function() {
     return(.request(params))
   }
 
+  # Lookup COVID hospitalization facility identifiers
+  covid_hosp_facility_lookup <- function(state, ccn, city, zip, fips_code) {
+    # Set up request
+    params <- list(source = 'covid_hosp_facility_lookup')
+    if(!missing(state)) {
+      params$state <- state
+    } else if(!missing(ccn)) {
+      params$ccn <- ccn
+    } else if(!missing(city)) {
+      params$city <- city
+    } else if(!missing(zip)) {
+      params$zip <- zip
+    } else if(!missing(fips_code)) {
+      params$fips_code <- fips_code
+    } else {
+      stop('one of `state`, `ccn`, `city`, `zip`, or `fips_code` is required')
+    }
+    # Make the API call
+    return(.request(params))
+  }
+
   # Export the public methods
   return(list(
     range = range,
@@ -613,6 +634,7 @@ Epidata <- (function() {
     covidcast = covidcast,
     covidcast_meta = covidcast_meta,
     covid_hosp = covid_hosp,
-    covid_hosp_facility = covid_hosp_facility
+    covid_hosp_facility = covid_hosp_facility,
+    covid_hosp_facility_lookup = covid_hosp_facility_lookup
   ))
 })()

--- a/src/client/delphi_epidata.coffee
+++ b/src/client/delphi_epidata.coffee
@@ -419,5 +419,25 @@ class Epidata
     # Make the API call
     _request(callback, params)
 
+  # Lookup COVID hospitalization facility identifiers
+  @covid_hosp_facility_lookup: (state, ccn, city, zip, fips_code) ->
+    # Set up request
+    params =
+      'source': 'covid_hosp_facility'
+    if state?
+      params.state = state
+    else if ccn?
+      params.ccn = ccn
+    else if city?
+      params.city = city
+    else if zip?
+      params.zip = zip
+    else if fips_code?
+      params.fips_code = fips_code
+    else
+      throw { msg: 'one of `state`, `ccn`, `city`, `zip`, or `fips_code` is required' }
+    # Make the API call
+    _request(callback, params)
+
 # Export the API to the global environment
 (exports ? window).Epidata = Epidata

--- a/src/client/delphi_epidata.js
+++ b/src/client/delphi_epidata.js
@@ -662,6 +662,35 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
 
 
           return _request(callback, params);
+        } // Lookup COVID hospitalization facility identifiers
+
+      }, {
+        key: "covid_hosp_facility_lookup",
+        value: function covid_hosp_facility_lookup(state, ccn, city, zip, fips_code) {
+          var params; // Set up request
+
+          params = {
+            'source': 'covid_hosp_facility'
+          };
+
+          if (state != null) {
+            params.state = state;
+          } else if (ccn != null) {
+            params.ccn = ccn;
+          } else if (city != null) {
+            params.city = city;
+          } else if (zip != null) {
+            params.zip = zip;
+          } else if (fips_code != null) {
+            params.fips_code = fips_code;
+          } else {
+            throw {
+              msg: 'one of `state`, `ccn`, `city`, `zip`, or `fips_code` is required'
+            };
+          } // Make the API call
+
+
+          return _request(callback, params);
         }
       }]);
 

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -643,3 +643,25 @@ class Epidata:
       params['publication_dates'] = Epidata._list(publication_dates)
     # Make the API call
     return Epidata._request(params)
+
+  # Lookup COVID hospitalization facility identifiers
+  @staticmethod
+  def covid_hosp_facility_lookup(
+      state=None, ccn=None, city=None, zip=None, fips_code=None):
+    """Lookup COVID hospitalization facility identifiers."""
+    # Set up request
+    params = {'source': 'covid_hosp_facility_lookup'}
+    if state is not None:
+      params['state'] = state
+    elif ccn is not None:
+      params['ccn'] = ccn
+    elif city is not None:
+      params['city'] = city
+    elif zip is not None:
+      params['zip'] = zip
+    elif fips_code is not None:
+      params['fips_code'] = fips_code
+    else:
+      raise Exception('one of `state`, `ccn`, `city`, `zip`, or `fips_code` is required')
+    # Make the API call
+    return Epidata._request(params)

--- a/src/ddl/covid_hosp.sql
+++ b/src/ddl/covid_hosp.sql
@@ -1043,6 +1043,10 @@ CREATE TABLE `covid_hosp_facility` (
   UNIQUE KEY (`hospital_pk`, `collection_week`, `publication_date`),
   -- for fast lookup of a time-series for a given hospital and publication date
   KEY (`publication_date`, `hospital_pk`, `collection_week`),
-  -- for fast lookup of all hospital identifiers in a given state
-  KEY (`state`, `hospital_pk`)
+  -- for fast lookup of hospitals in a given location
+  KEY (`state`, `hospital_pk`),
+  KEY (`ccn`, `hospital_pk`),
+  KEY (`city`, `hospital_pk`),
+  KEY (`zip`, `hospital_pk`),
+  KEY (`fips_code`, `hospital_pk`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/tests/acquisition/covid_hosp/common/test_utils.py
+++ b/tests/acquisition/covid_hosp/common/test_utils.py
@@ -43,6 +43,29 @@ class UtilsTests(unittest.TestCase):
 
     self.assertEqual(Utils.int_from_date('2020-11-17'), 20201117)
 
+  def test_parse_bool(self):
+    """Parse a boolean value from a string."""
+
+    with self.subTest(name='None'):
+      self.assertIsNone(Utils.parse_bool(None))
+
+    with self.subTest(name='empty'):
+      self.assertIsNone(Utils.parse_bool(''))
+
+    with self.subTest(name='true'):
+      self.assertTrue(Utils.parse_bool('true'))
+      self.assertTrue(Utils.parse_bool('True'))
+      self.assertTrue(Utils.parse_bool('tRuE'))
+
+    with self.subTest(name='false'):
+      self.assertFalse(Utils.parse_bool('false'))
+      self.assertFalse(Utils.parse_bool('False'))
+      self.assertFalse(Utils.parse_bool('fAlSe'))
+
+    with self.subTest(name='exception'):
+      with self.assertRaises(CovidHospException):
+        Utils.parse_bool('maybe')
+
   def test_get_entry_success(self):
     """Get a deeply nested field from an arbitrary object."""
 


### PR DESCRIPTION
- `bool('false')` is `True`
- add a helper function to parse bool from str, allowing missing and 
empty values

note that prod database needs to be backfilled since previous 
acquisitions incorrectly casted 'false' and 'true' both to `True`

---

- the hhs covid hosp dataset is keyed by `hospital_pk`, which is a 
unique identifier for healthcare facilities.
- the key is not generally well-known, but querying the 
`covid_hosp_facility` dataset requires key(s)
- the new endpoint returns facility information (including key) for 
given regions (e.g. city, state, zip, ccn, fips)
- users would be expected to lookup hospitals of interest e.g. by state 
or city. then query `covid_hosp_facility` with the key for those 
hospitals.
- server and clients updated
- all unit and integrations pass

note that new indexes are added to the database to facilitate fast 
lookups. otherwise it would be a full table scan each time, which does 
not scale well. indexes are expected to be very small.