### PR TITLE
Describe survey credits and citation requirements more clearly

### DIFF
--- a/docs/symptom-survey/index.md
+++ b/docs/symptom-survey/index.md
@@ -24,3 +24,25 @@ getting [data access](data-access.md).
 
 If you have questions about the survey or getting access to data, contact us at
 <delphi-survey-info@lists.andrew.cmu.edu>.
+
+## Citing the Survey
+
+Researchers who use the survey microdata for research are asked to credit and
+cite the survey in publications based on the data. Specifically, we ask that
+you:
+
+1. Include the acknowledgment "This research is based on survey results from
+   Carnegie Mellon University’s Delphi Group."
+2. Cite our publication describing the survey and its methods. This publication
+   is currently in preparation, and we will update this page when it is
+   available. Until it is available, we recommend you provide a link to this
+   page.
+3. Send a copy of your publication, once it appears publicly as a preprint or
+   journal article, to <delphi-survey-info@lists.andrew.cmu.edu>.
+
+Additionally, please note that the data use agreement requires that if you
+disclose survey microdata, we must agree on the aggregation method that you will
+use to ensure reported estimates to not identify or disclose any individual
+identifiable information, including individual survey results. If you are unsure
+whether a particular aggregation will prevent disclosure of individual survey
+results, please email us at <delphi-survey-info@lists.andrew.cmu.edu>.

--- a/docs/symptom-survey/index.md
+++ b/docs/symptom-survey/index.md
@@ -6,12 +6,12 @@ nav_order: 2
 
 # COVID Symptom Survey
 
-Delphi conducts a voluntary COVID-19 symptom survey, distributed daily via a
-partnership with Facebook. This survey asks respondents about COVID-like
-symptoms, their behavior (such as social distancing), mental health, and
-economic and health impacts they have experienced as a result of the pandemic. A
-high-level overview of the survey is posted [on the COVIDcast
-website](https://covidcast.cmu.edu/surveys.html).
+Since April 2020, Delphi has conducted a voluntary COVID-19 symptom survey,
+distributed daily to users in the United States via a partnership with Facebook.
+This survey asks respondents about COVID-like symptoms, their behavior (such as
+social distancing), mental health, and economic and health impacts they have
+experienced as a result of the pandemic. A high-level overview of the survey is
+posted [on the COVIDcast website](https://delphi.cmu.edu/covidcast/surveys/).
 
 Aggregate data from this survey is available through the [COVIDcast API](../api/covidcast.md)
 as the [`fb-survey` data source](../api/covidcast-signals/fb-survey.md).
@@ -25,6 +25,28 @@ getting [data access](data-access.md).
 If you have questions about the survey or getting access to data, contact us at
 <delphi-survey-info@lists.andrew.cmu.edu>.
 
+## Credits
+
+The COVID Symptom Survey is a project of the [Delphi
+Group](https://delphi.cmu.edu/) at Carnegie Mellon University. The Principal
+Investigator is [Alex Reinhart](https://www.refsmmat.com/); Wichada La
+Motte-Kerr is Survey Coordinator. The survey protocol is reviewed by the
+Carnegie Mellon University Institutional Review Board.
+
+The support of several institutions makes the survey possible. Facebook supports
+the survey through recruitment (participants are invited via their News Feed),
+survey sampling and weighting procedures, technical assistance in survey design
+and implementation, and coordination with researchers and public health
+officials. The University of Maryland's Joint Program in Survey Methodology
+conducts an [international version of the survey](https://covidmap.umd.edu/),
+and we coordinate closely on survey design and implementation. Delphi collects,
+aggregates, and distributes the US survey data, and retains ultimate
+responsibility for the US survey instrument and data.
+
+We develop the survey collaboratively with data users, public health officials,
+and others. If you are interested in getting involved, see our
+[collaboration and survey revision information](collaboration-revision.md).
+
 ## Citing the Survey
 
 Researchers who use the survey microdata for research are asked to credit and
@@ -33,16 +55,21 @@ you:
 
 1. Include the acknowledgment "This research is based on survey results from
    Carnegie Mellon University’s Delphi Group."
-2. Cite our publication describing the survey and its methods. This publication
-   is currently in preparation, and we will update this page when it is
-   available. Until it is available, we recommend you provide a link to this
-   page.
+2. Cite this web page for details about the survey. For example, you may cite it
+   as
+
+    > Delphi Group (2020). COVID Symptom Survey.
+    > <https://cmu-delphi.github.io/delphi-epidata/symptom-survey/>
+
+    A journal article describing the survey and its methods is currently in
+    preparation, and we will update this page when it is available so that you
+    can cite it instead.
 3. Send a copy of your publication, once it appears publicly as a preprint or
    journal article, to <delphi-survey-info@lists.andrew.cmu.edu>.
 
 Additionally, please note that the data use agreement requires that if you
-disclose survey microdata, we must agree on the aggregation method that you will
-use to ensure reported estimates to not identify or disclose any individual
+disclose survey microdata, Delphi must agree on the aggregation method that you
+will use to ensure reported estimates do not disclose any individual
 identifiable information, including individual survey results. If you are unsure
 whether a particular aggregation will prevent disclosure of individual survey
 results, please email us at <delphi-survey-info@lists.andrew.cmu.edu>.


### PR DESCRIPTION
Our site didn't clearly explain who runs the survey and Delphi's role, and it did not tell data users how to cite the survey in publications.