### PR TITLE
Document upcoming COVID vaccine acceptance signal

### DIFF
--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -321,11 +321,13 @@ also available. These have names beginning `smoothed_w`, such as
 
 | Signal | Description | Survey Item |
 | --- | --- | --- |
-| `smoothed_accept_covid_vaccine` | Estimated percentage of respondents who would definitely or probably choose to get vaccinated, if a COVID-19 vaccine were offered to them today | V3 |
+| `smoothed_accept_covid_vaccine` | Estimated percentage of respondents who would definitely or probably choose to get vaccinated, if a COVID-19 vaccine were offered to them today. **Note:** Until January 6, 2021, all respondents answered this question; beginning on that date, only respondents who said they have not received a COVID vaccine are asked this question. | V3 |
 
 This indicator is based on questions added in Wave 6 of the survey, introduced
 on December 19, 2020. **Note:** As of January 2021, vaccination items on the
-survey are being revised in preparation for Wave 7. We may replace the signal above with a new signal (with a different name) if the underlying survey item changes significantly.
+survey are being revised in preparation for Wave 7. We may replace the signal
+above with a new signal (with a different name) if the underlying survey item
+changes significantly.
 
 A weighted version of this signal, using the [survey weighting described
 below](#survey-weighting) to be more representative of state demographics, is

--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -325,11 +325,9 @@ also available. These have names beginning `smoothed_w`, such as
 
 This indicator is based on questions added in Wave 6 of the survey, introduced
 on December 19, 2020. **Note:** As of January 2021, vaccination items on the
-survey are being revised in preparation for Wave 7. The signal above may be
-replaced with a new signal (with different name) if the underlying survey item
-changes significantly.
+survey are being revised in preparation for Wave 7. We may replace the signal above with a new signal (with a different name) if the underlying survey item changes significantly.
 
-A weighted versions of this signal, using the [survey weighting described
+A weighted version of this signal, using the [survey weighting described
 below](#survey-weighting) to be more representative of state demographics, is
 also available. It is `smoothed_waccept_covid_vaccine`.
 

--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -31,6 +31,8 @@ described in the sections below:
    traveling, and activities outside the home
 3. [Testing indicators](#testing-indicators) based on respondent reporting of
    their COVID test results
+4. [Vaccination indicators](#vaccination-indicators), based on respondent
+   reporting of COVID vaccinations and whether they would accept a vaccine
 4. [Mental health indicators](#mental-health-indicators), based on self-reports
    of anxiety, depression, isolation, and worry about COVID
 
@@ -313,6 +315,20 @@ Weighted versions of these signals, using the [survey weighting described
 below](#survey-weighting) to be more representative of state demographics, are
 also available. These have names beginning `smoothed_w`, such as
 `smoothed_wtested_14d`.
+
+
+## Vaccination Indicators
+
+| Signal | Description | Survey Item |
+| --- | --- | --- |
+| `smoothed_accept_covid_vaccine` | Estimated percentage of respondents who would definitely or probably choose to get vaccinated, if a COVID-19 vaccine were offered to them today | V3 |
+
+This indicator is based on questions added in Wave 6 of the survey, introduced
+on December 19, 2020.
+
+A weighted versions of this signal, using the [survey weighting described
+below](#survey-weighting) to be more representative of state demographics, is
+also available. It is `smoothed_waccept_covid_vaccine`.
 
 
 ## Mental Health Indicators

--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -324,7 +324,10 @@ also available. These have names beginning `smoothed_w`, such as
 | `smoothed_accept_covid_vaccine` | Estimated percentage of respondents who would definitely or probably choose to get vaccinated, if a COVID-19 vaccine were offered to them today | V3 |
 
 This indicator is based on questions added in Wave 6 of the survey, introduced
-on December 19, 2020.
+on December 19, 2020. **Note:** As of January 2021, vaccination items on the
+survey are being revised in preparation for Wave 7. The signal above may be
+replaced with a new signal (with different name) if the underlying survey item
+changes significantly.
 
 A weighted versions of this signal, using the [survey weighting described
 below](#survey-weighting) to be more representative of state demographics, is


### PR DESCRIPTION
Currently preparing this signal for public release, so I'd like the docs to be ready when that happens (perhaps Wed Jan 6).