### PR TITLE
Covidcast upload early exit

### DIFF
--- a/src/acquisition/covidcast/csv_to_database.py
+++ b/src/acquisition/covidcast/csv_to_database.py
@@ -145,7 +145,7 @@ def main(
 
   if args.is_wip_override and args.not_wip_override:
     print('conflicting overrides for forcing WIP option!  exiting...')
-    exit()
+    return
   wip_override = None
   if args.is_wip_override:
     wip_override = True
@@ -156,7 +156,7 @@ def main(
   path_details = collect_files_impl(args.data_dir, args.specific_issue_date)
   if not path_details:
     print('nothing to do; exiting...')
-    exit()
+    return
     
   database = database_impl()
   database.connect()

--- a/src/acquisition/covidcast/csv_to_database.py
+++ b/src/acquisition/covidcast/csv_to_database.py
@@ -32,107 +32,70 @@ def get_argument_parser():
     help='overrides all signals to mark them as *not* WIP.  NOTE: specify neither or only one of --is_wip_override and --not_wip_override.')
   return parser
 
-def scan_issue_specific(data_dir, database, is_wip_override=None, csv_importer_impl=CsvImporter, file_archiver_impl=FileArchiver):
-  """  is_wip_override: None (default) for standard 'wip_' prefix processing, True for forcing all as WIP, False for forcing all as not WIP"
-  """ # TODO: better docstring
+def collect_files(data_dir, specific_issue_date, csv_importer_impl=CsvImporter):
+  """Fetch path and data profile details for each file to upload."""
 
-  # TODO: this has *A LOT* of copypasta from scan_upload_archive() ... make it less so
-  
-  # collect files
-  results = list(csv_importer_impl.find_issue_specific_csv_files(data_dir))
-  print('found %d files' % len(results))
+  if specific_issue_date:
+    results = list(csv_importer_impl.find_issue_specific_csv_files(data_dir))
+  else:
+    results = list(csv_importer_impl.find_csv_files(os.path.join(data_dir, 'receiving')))
+  print(f'found {len(results)} files')
+  return results
 
-  # iterate over each file
-  for path, details in results:
-    print('handling ', path)
-    path_src, filename = os.path.split(path)
+def make_handlers(data_dir, specific_issue_date, file_archiver_impl=FileArchiver):
+  if specific_issue_date:
+    # issue-specific uploads are always one-offs, so we can leave all
+    # files in place without worrying about cleaning up
+    def handle_failed(path_src, filename, source):
+      print(f'leaving failed file alone - {source}')
 
-    if not details:
-      # file path or name was invalid, source is unknown
-      print('unknown file, leaving alone:', path)
-      continue
-
-    (source, signal, time_type, geo_type, time_value, issue, lag) = details
-
-    if is_wip_override is None:
-      is_wip = signal[:4].lower() == "wip_"
-    else:
-      is_wip = is_wip_override
-      # we are overriding, so remove prefix if it exists
-      if signal[:4].lower() == "wip_":
-        signal = signal[4:]
-      # prepend (or put back) prefix if we are forcing as WIP
-      if is_wip:
-        signal = "wip_" + signal
-
-    csv_rows = csv_importer_impl.load_csv(path, geo_type)
-
-    cc_rows = CovidcastRow.fromCsvRows(csv_rows, source, signal, time_type, geo_type, time_value, issue, lag, is_wip)
-    rows_list = list(cc_rows)
-    all_rows_valid = rows_list and all(r is not None for r in rows_list)
-    if all_rows_valid:
-      try:
-        result = database.insert_or_update_bulk(rows_list)
-        print(f"insert_or_update_bulk {filename} returned {result}")
-        if result is None or result: # else would indicate zero rows inserted
-          database.commit()
-      except Exception as e:
-        all_rows_valid = False
-        print('exception while inserting rows:', e)
-        database.rollback()
-
-    # archive the current file based on validation results
-    if all_rows_valid:
+    def handle_successful(path_src, filename, source):
       print('archiving as successful')
       file_archiver_impl.archive_inplace(path_src, filename)
-    else:
-      print('unsuccessful - not archiving file')
+  else:
+    # normal automation runs require some shuffling to remove files
+    # from receiving and place them in the archive
+    archive_successful_dir = os.path.join(data_dir, 'archive', 'successful')
+    archive_failed_dir = os.path.join(data_dir, 'archive', 'failed')
 
-# TODO: consider extending is_wip_override behavior option to this method
-def scan_upload_archive(
-    data_dir,
+    # helper to archive a failed file without compression
+    def handle_failed(path_src, filename, source):
+      print('archiving as failed - '+source)
+      path_dst = os.path.join(archive_failed_dir, source)
+      compress = False
+      file_archiver_impl.archive_file(path_src, path_dst, filename, compress)
+
+    # helper to archive a successful file with compression
+    def handle_successful(path_src, filename, source):
+      print('archiving as successful')
+      path_dst = os.path.join(archive_successful_dir, source)
+      compress = True
+      file_archiver_impl.archive_file(path_src, path_dst, filename, compress)
+  return handle_successful, handle_failed
+
+def upload_archive(
+    path_details,
     database,
-    csv_importer_impl=CsvImporter,
-    file_archiver_impl=FileArchiver):
-  """Find CSVs, upload them to the database, and archive them.
+    handlers,
+    is_wip_override=None,
+    csv_importer_impl=CsvImporter):
+  """Upload CSVs to the database and archive them using the specified handlers.
 
-  data_dir: top-level directory where CSVs are stored
-  database: an open connection to the epidata database
+  :path_details: output from CsvImporter.find*_csv_files 
+  
+  :database: an open connection to the epidata database
 
-  The CSV storage layout is assumed to be as follows:
+  :handlers: functions for archiving (successful, failed) files
+  
+  :is_wip_override: default None (detect WIP status using
+  filename). If boolean, whether to force WIP status (True) or
+  production status (False) regardless of what the filename says
 
-  - Receiving: <data_dir>/receiving/<source name>/*.csv
-  - Archival: <data_dir>/archive/<status>/<source name>/*.csv[.gz]
-
-  Status above is one of `successful` or `failed`. See the accompanying readme
-  for further details.
   """
-
-  receiving_dir = os.path.join(data_dir, 'receiving')
-  archive_successful_dir = os.path.join(data_dir, 'archive', 'successful')
-  archive_failed_dir = os.path.join(data_dir, 'archive', 'failed')
-
-  # helper to archive a failed file without compression
-  def archive_as_failed(path_src, filename, source):
-    print('archiving as failed - '+source)
-    path_dst = os.path.join(archive_failed_dir, source)
-    compress = False
-    file_archiver_impl.archive_file(path_src, path_dst, filename, compress)
-
-  # helper to archive a successful file with compression
-  def archive_as_successful(path_src, filename, source):
-    print('archiving as successful')
-    path_dst = os.path.join(archive_successful_dir, source)
-    compress = True
-    file_archiver_impl.archive_file(path_src, path_dst, filename, compress)
-
-
-  # collect files
-  results = list(csv_importer_impl.find_csv_files(receiving_dir))
-  print('found %d files' % len(results))
-
+  archive_as_successful, archive_as_failed = handlers
+  
   # iterate over each file
-  for path, details in results:
+  for path, details in path_details:
     print('handling ', path)
     path_src, filename = os.path.split(path)
 
@@ -143,7 +106,13 @@ def scan_upload_archive(
 
     (source, signal, time_type, geo_type, time_value, issue, lag) = details
 
-    is_wip = signal[:4].lower() == "wip_"
+    if is_wip_override is None:
+      is_wip = signal[:4].lower() == "wip_"
+    else:
+      is_wip = is_wip_override
+      # strip wip from signal name if we're forcing production status
+      if signal[:4].lower() == "wip_" and not is_wip:
+        signal = signal[4:]
 
     csv_rows = csv_importer_impl.load_csv(path, geo_type)
 
@@ -167,12 +136,11 @@ def scan_upload_archive(
     else:
       archive_as_failed(path_src, filename, source)
 
-
 def main(
     args,
     database_impl=Database,
-    scan_upload_archive_impl=scan_upload_archive,
-    scan_issue_specific_impl=scan_issue_specific):
+    collect_files_impl=collect_files,
+    upload_archive_impl=upload_archive):
   """Find, parse, and upload covidcast signals."""
 
   if args.is_wip_override and args.not_wip_override:
@@ -184,16 +152,22 @@ def main(
   if args.not_wip_override:
     wip_override = False
 
+  # shortcut escape without hitting db if nothing to do
+  path_details = collect_files_impl(args.data_dir, args.specific_issue_date)
+  if not path_details:
+    print('nothing to do; exiting...')
+    exit()
+    
   database = database_impl()
   database.connect()
   num_starting_rows = database.count_all_rows()
 
-
   try:
-    if args.specific_issue_date:
-      scan_issue_specific_impl(args.data_dir, database, is_wip_override=wip_override)
-    else:
-      scan_upload_archive_impl(args.data_dir, database)
+    upload_archive_impl(
+      path_details,
+      database,
+      make_handlers(args.data_dir, args.specific_issue_date),
+      is_wip_override=wip_override)
   finally:
     # no catch block so that an exception above will cause the program to fail
     # after the following cleanup
@@ -203,7 +177,6 @@ def main(
     finally:
       # unconditionally commit database changes since CSVs have been archived
       database.disconnect(True)
-
 
 if __name__ == '__main__':
   main(get_argument_parser().parse_args())

--- a/src/ddl/covid_hosp.sql
+++ b/src/ddl/covid_hosp.sql
@@ -23,7 +23,7 @@ surfaced through the Epidata API.
 | id                   | int(11)       | NO   | PRI | NULL    | auto_increment |
 | dataset_name         | varchar(64)   | NO   | MUL | NULL    |                |
 | publication_date     | int(11)       | NO   |     | NULL    |                |
-| revision_timestamp   | varchar(1024) | NO   |     | NULL    |                |
+| revision_timestamp   | varchar(512)  | NO   |     | NULL    |                |
 | metadata_json        | longtext      | NO   |     | NULL    |                |
 | acquisition_datetime | datetime      | NO   |     | NULL    |                |
 +----------------------+---------------+------+-----+---------+----------------+
@@ -48,7 +48,7 @@ CREATE TABLE `covid_hosp_meta` (
   `id` INT NOT NULL AUTO_INCREMENT,
   `dataset_name` VARCHAR(64) NOT NULL,
   `publication_date` INT NOT NULL,
-  `revision_timestamp` VARCHAR(1024) NOT NULL,
+  `revision_timestamp` VARCHAR(512) NOT NULL,
   `metadata_json` JSON NOT NULL,
   `acquisition_datetime` DATETIME NOT NULL,
   PRIMARY KEY (`id`),

--- a/tests/acquisition/covidcast/test_csv_to_database.py
+++ b/tests/acquisition/covidcast/test_csv_to_database.py
@@ -161,6 +161,32 @@ class UnitTests(unittest.TestCase):
     self.assertTrue(mock_database.disconnect.called)
     self.assertTrue(mock_database.disconnect.call_args[0][0])
 
+  def test_main_early_exit(self):
+    """Run the main program with an empty receiving directory."""
+
+    # TODO: use an actual argparse object for the args instead of a MagicMock
+    args = MagicMock(data_dir='data', is_wip_override=False, not_wip_override=False, specific_issue_date=False)
+    mock_database = MagicMock()
+    mock_database.count_all_rows.return_value = 0
+    fake_database_impl = lambda: mock_database
+    mock_collect_files = MagicMock()
+    mock_collect_files.return_value = []
+    mock_upload_archive = MagicMock()
+
+    main(
+        args,
+        database_impl=fake_database_impl,
+        collect_files_impl=mock_collect_files,
+        upload_archive_impl=mock_upload_archive)
+
+    self.assertTrue(mock_collect_files.called)
+    self.assertEqual(mock_collect_files.call_args[0][0], 'data')
+
+    self.assertFalse(mock_upload_archive.called)
+
+    self.assertFalse(mock_database.connect.called)
+    self.assertFalse(mock_database.disconnect.called)
+
   def test_database_exception_is_handled(self):
     """Gracefully handle database exceptions."""
 

--- a/tests/acquisition/covidcast/test_csv_to_database.py
+++ b/tests/acquisition/covidcast/test_csv_to_database.py
@@ -17,8 +17,31 @@ class UnitTests(unittest.TestCase):
 
     self.assertIsInstance(get_argument_parser(), argparse.ArgumentParser)
 
-  def test_scan_upload_archive(self):
-    """Scan the data directory, upload to the database, and archive."""
+  def _path_details(self):
+    return [
+      # a good file
+      ('path/a.csv', ('src_a', 'sig_a', 'day', 'hrr', 20200419, 20200420, 1)),
+      # a file with a data error
+      ('path/b.csv', ('src_b', 'sig_b', 'week', 'msa', 202016, 202017, 1)),
+      # emulate a file that's named incorrectly
+      ('path/c.csv', None),
+      # another good file w/ wip
+      ('path/d.csv', ('src_d', 'wip_sig_d', 'week', 'msa', 202016, 202017, 1)),
+    ]
+
+  def test_collect_files(self):
+    """Scan the data directory."""
+
+    mock_csv_importer = MagicMock()
+    mock_csv_importer.find_csv_files.return_value = self._path_details()
+    collect_files(
+      "fake_data_dir",
+      False, # no specific issue
+      csv_importer_impl=mock_csv_importer)
+    self.assertEqual(mock_csv_importer.find_csv_files.call_count, 1)
+    
+  def test_upload_archive(self):
+    """Upload to the database, and archive."""
 
     def make_row(value):
       return MagicMock(
@@ -48,24 +71,15 @@ class UnitTests(unittest.TestCase):
     data_dir = 'data_dir'
     mock_database = MagicMock()
     mock_csv_importer = MagicMock()
-    mock_csv_importer.find_csv_files.return_value = [
-      # a good file
-      ('path/a.csv', ('src_a', 'sig_a', 'day', 'hrr', 20200419, 20200420, 1)),
-      # a file with a data error
-      ('path/b.csv', ('src_b', 'sig_b', 'week', 'msa', 202016, 202017, 1)),
-      # emulate a file that's named incorrectly
-      ('path/c.csv', None),
-      # another good file w/ wip
-      ('path/d.csv', ('src_d', 'wip_sig_d', 'week', 'msa', 202016, 202017, 1)),
-    ]
     mock_csv_importer.load_csv = load_csv_impl
     mock_file_archiver = MagicMock()
 
-    scan_upload_archive(
-        data_dir,
-        mock_database,
-        csv_importer_impl=mock_csv_importer,
-        file_archiver_impl=mock_file_archiver)
+    upload_archive(
+      self._path_details(),
+      mock_database,
+      make_handlers(data_dir, False,
+                    file_archiver_impl=mock_file_archiver),
+      csv_importer_impl=mock_csv_importer)
 
     # verify that appropriate rows were added to the database
     self.assertEqual(mock_database.insert_or_update_bulk.call_count, 2)
@@ -101,15 +115,21 @@ class UnitTests(unittest.TestCase):
     mock_database = MagicMock()
     mock_database.count_all_rows.return_value = 0
     fake_database_impl = lambda: mock_database
-    mock_scan_upload_archive = MagicMock()
+    mock_collect_files = MagicMock()
+    mock_collect_files.return_value = [("a",False)]
+    mock_upload_archive = MagicMock()
 
     main(
         args,
         database_impl=fake_database_impl,
-        scan_upload_archive_impl=mock_scan_upload_archive)
+        collect_files_impl=mock_collect_files,
+        upload_archive_impl=mock_upload_archive)
 
-    self.assertTrue(mock_scan_upload_archive.called)
-    self.assertEqual(mock_scan_upload_archive.call_args[0][0], 'data')
+    self.assertTrue(mock_collect_files.called)
+    self.assertEqual(mock_collect_files.call_args[0][0], 'data')
+    
+    self.assertTrue(mock_upload_archive.called)
+    self.assertEqual(mock_upload_archive.call_args[0][0], [("a",False)])
 
     self.assertTrue(mock_database.connect.called)
     self.assertTrue(mock_database.disconnect.called)
@@ -123,16 +143,19 @@ class UnitTests(unittest.TestCase):
     mock_database = MagicMock()
     mock_database.count_all_rows.return_value = 0
     fake_database_impl = lambda: mock_database
-    mock_scan_upload_archive = MagicMock(side_effect=Exception('testing'))
+    mock_upload_archive = MagicMock(side_effect=Exception('testing'))
+    mock_collect_files = MagicMock()
+    mock_collect_files.return_value=[("a",False)]
 
     with self.assertRaises(Exception):
       main(
           args,
           database_impl=fake_database_impl,
-          scan_upload_archive_impl=mock_scan_upload_archive)
+          collect_files_impl=mock_collect_files,
+          upload_archive_impl=mock_upload_archive)
 
-    self.assertTrue(mock_scan_upload_archive.called)
-    self.assertEqual(mock_scan_upload_archive.call_args[0][0], 'data')
+    self.assertTrue(mock_upload_archive.called)
+    self.assertEqual(mock_upload_archive.call_args[0][0], [("a",False)])
 
     self.assertTrue(mock_database.connect.called)
     self.assertTrue(mock_database.disconnect.called)
@@ -153,11 +176,12 @@ class UnitTests(unittest.TestCase):
     ]
     mock_file_archiver = MagicMock()
 
-    scan_upload_archive(
-        data_dir,
+    upload_archive(
+        collect_files(data_dir, False, csv_importer_impl=mock_csv_importer),
         mock_database,
+        make_handlers(data_dir, False, file_archiver_impl=mock_file_archiver),
         csv_importer_impl=mock_csv_importer,
-        file_archiver_impl=mock_file_archiver)
+        )
 
     # verify that insertions were attempted
     self.assertTrue(mock_database.insert_or_update_bulk.called)


### PR DESCRIPTION
**WARNING** this PR includes a commit reducing the size of the covid_hosp_meta.revision_timestamp column from 1024 to 512. Nothing depends on that change except compliance with MariaDB maximum key length, but once this is merged we should make that change in prod. No value in that column is presently more than 23 characters, so shouldn't be an issue.

**Actual purpose:** Covidcast Acquisition currently counts the number of rows in the `covidcast` table regardless of whether the `receiving` directory is empty. This operation now takes upwards of 40 minutes, which is silly.

This PR rearranges the upload script somewhat so that it first checks `receiving`, then exits as a no-op if it finds no files.

In the process, I merged the default and with-specific-issue routines.

Unit tests updated and pass.

~Integration tests I seem to have forgot about. I'll update here when they're ready.~

Integration tests work automagically because they use no mocks.

Added a test to verify early-exit.