### PR TITLE
Correct nowcast parameter spelling in requests

### DIFF
--- a/integrations/server/test_covidcast_nowcast.py
+++ b/integrations/server/test_covidcast_nowcast.py
@@ -52,7 +52,7 @@ class CovidcastTests(unittest.TestCase):
     response = requests.get(BASE_URL, params={
       'source': 'covidcast_nowcast',
       'data_source': 'src',
-      'signal': 'sig',
+      'signals': 'sig',
       'time_type': 'day',
       'geo_type': 'county',
       'time_values': 20200101,
@@ -78,7 +78,7 @@ class CovidcastTests(unittest.TestCase):
     response = requests.get(BASE_URL, params={
       'source': 'covidcast_nowcast',
       'data_source': 'src',
-      'signal': 'sig',
+      'signals': 'sig',
       'time_type': 'day',
       'geo_type': 'county',
       'time_values': 20200101,
@@ -103,7 +103,7 @@ class CovidcastTests(unittest.TestCase):
     response = requests.get(BASE_URL, params={
       'source': 'covidcast_nowcast',
       'data_source': 'src',
-      'signal': 'sig',
+      'signals': 'sig',
       'time_type': 'day',
       'geo_type': 'county',
       'time_values': 20200101,


### PR DESCRIPTION
This got missed when we removed the backwards-compatible `signal` parameter that had been copy-pasted from covidcast