### PR TITLE
Add vaccination uptake signal

### DIFF
--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -327,13 +327,13 @@ also available. These have names beginning `smoothed_w`, such as
 | `smoothed_covid_vaccinated` | Estimated percentage of respondents who have already received a vaccine for COVID-19. **Note:** The Centers for Disease Control compiles data on vaccine administration across the United States. This signal may differ from CDC data because of survey biases and should not be treated as authoritative. However, the survey signal is not subject to the lags and reporting problems in official vaccination data. | V1 |
 
 These indicators are based on questions added in Wave 6 of the survey,
-introduced on December 19, 2020; however, item V1 was only enabled beginning
+introduced on December 19, 2020; however, Delphi only enabled item V1 beginning
 January 6, 2021. **Note:** As of January 2021, vaccination items on the survey
 are being revised in preparation for Wave 7. We may replace the signals above
 with new signals (with different names) if the underlying survey items change
 significantly.
 
-A weighted version of these signal, using the [survey weighting described
+Weighted versions of these signals, using the [survey weighting described
 below](#survey-weighting) to be more representative of state demographics, are
 also available. They have names beginning with `smoothed_w`, such as
 `smoothed_waccept_covid_vaccine`.

--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -10,7 +10,7 @@ grand_parent: COVIDcast Epidata API
 * **Source name:** `fb-survey`
 * **Number of data revisions since 19 May 2020:** 1
 * **Date of last change:** [3 June 2020](../covidcast_changelog.md#fb-survey)
-* **Available for:** county, hrr, msa, state (see [geography coding docs](../covidcast_geography.md))
+* **Available for:** county, hrr, msa, state, nation (see [geography coding docs](../covidcast_geography.md))
 * **Time type:** day (see [date format docs](../covidcast_times.md))
 * **License:** [CC BY](../covidcast_licensing.md#creative-commons-attribution)
 

--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -324,16 +324,19 @@ also available. These have names beginning `smoothed_w`, such as
 | Signal | Description | Survey Item |
 | --- | --- | --- |
 | `smoothed_accept_covid_vaccine` | Estimated percentage of respondents who would definitely or probably choose to get vaccinated, if a COVID-19 vaccine were offered to them today. **Note:** Until January 6, 2021, all respondents answered this question; beginning on that date, only respondents who said they have not received a COVID vaccine are asked this question. | V3 |
+| `smoothed_covid_vaccinated` | Estimated percentage of respondents who have already received a vaccine for COVID-19. **Note:** The Centers for Disease Control compiles data on vaccine administration across the United States. This signal may differ from CDC data because of survey biases and should not be treated as authoritative. However, the survey signal is not subject to the lags and reporting problems in official vaccination data. | V1 |
 
-This indicator is based on questions added in Wave 6 of the survey, introduced
-on December 19, 2020. **Note:** As of January 2021, vaccination items on the
-survey are being revised in preparation for Wave 7. We may replace the signal
-above with a new signal (with a different name) if the underlying survey item
-changes significantly.
+These indicators are based on questions added in Wave 6 of the survey,
+introduced on December 19, 2020; however, item V1 was only enabled beginning
+January 6, 2021. **Note:** As of January 2021, vaccination items on the survey
+are being revised in preparation for Wave 7. We may replace the signals above
+with new signals (with different names) if the underlying survey items change
+significantly.
 
-A weighted version of this signal, using the [survey weighting described
-below](#survey-weighting) to be more representative of state demographics, is
-also available. It is `smoothed_waccept_covid_vaccine`.
+A weighted version of these signal, using the [survey weighting described
+below](#survey-weighting) to be more representative of state demographics, are
+also available. They have names beginning with `smoothed_w`, such as
+`smoothed_waccept_covid_vaccine`.
 
 
 ## Mental Health Indicators

--- a/docs/api/covidcast_geography.md
+++ b/docs/api/covidcast_geography.md
@@ -34,7 +34,7 @@ whose estimate is being reported. Estimates are available for several possible
 * `state`: The 50 states, identified by their two-digit postal abbreviation (in
   lower case). Estimates for Puerto Rico are available as state `pr`;
   Washington, D.C. is available as state `dc`.
-  * `nation`: accepted values are the ISO 3166-1 alpha-2 [country codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Currently the only nation we have data on is `us`.
+* `nation`: accepted values are the ISO 3166-1 alpha-2 [country codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). Currently the only nation we have data on is `us`.
 
 Some signals are not available for all `geo_type`s since they may be reported
 by their original sources at geographic resolutions which are too coarse.


### PR DESCRIPTION
This signal is already in the API, so this can be merged as soon as it's ready.

Note I've tried to explain that this signal differs from the CDC reporting -- currently it reports vaccination rates nearly twice as high as the CDC does. It's unclear why this disparity exists; the CDC data clearly lags behind actual vaccinations, but I don't know how much, and meanwhile the survey probably has biases and I don't know how big they are. Hopefully the note makes that clear.

Also I fixed a minor formatting problem in the geography docs.