### PR TITLE
Update state daily dataset ID

### DIFF
--- a/src/acquisition/covid_hosp/state_daily/network.py
+++ b/src/acquisition/covid_hosp/state_daily/network.py
@@ -4,7 +4,7 @@ from delphi.epidata.acquisition.covid_hosp.common.network import Network as Base
 
 class Network(BaseNetwork):
 
-  DATASET_ID = '823dd0e-c8c4-4206-953e-c6d2f451d6ed'
+  DATASET_ID = '7823dd0e-c8c4-4206-953e-c6d2f451d6ed'
 
   def fetch_metadata(*args, **kwags):
     """Download and return metadata.


### PR DESCRIPTION
For some reason it's changed. I'm using the [metadata json](https://healthdata.gov/api/3/action/package_show?id=7823dd0e-c8c4-4206-953e-c6d2f451d6ed&page=0) from [this page](https://healthdata.gov/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state)

EDIT: apparently I'm really bad at copy pasting