### PR TITLE
Add async method to epidata

### DIFF
--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -472,7 +472,7 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
 
     self.assertEqual(response, {'result': -2, 'message': 'no results'})
 
-  def test_async_call(self):
+  def test_async_epidata(self):
     # insert dummy data
     self.cur.execute('''
       insert into covidcast values
@@ -490,7 +490,7 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
           123, 60, 61, 62, 456, 634, 20200414, 0, 1, False)
     ''')
     self.cnx.commit()
-    test_output = Epidata.async_call([
+    test_output = Epidata.async_epidata([
       {
         'source': 'covidcast',
         'data_source': 'src',

--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -509,10 +509,10 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
         'geo_value': '00000',
         'time_values': '20200414'
       }
-    ])
-    responses = [i[0] for i in test_output]
-    # check response is same as standard covidcast call
+    ], batch_size=10)
+    responses = [i[0] for i in test_output]*12
+    # check response is same as standard covidcast call, using 24 calls to test batch sizing
     self.assertEqual(responses,
                      [Epidata.covidcast('src', 'sig', 'day', 'county', 20200414, '11111'),
-                      Epidata.covidcast('src', 'sig', 'day', 'county', 20200414, '00000')]
+                      Epidata.covidcast('src', 'sig', 'day', 'county', 20200414, '00000')]*12
                      )

--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -471,3 +471,48 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
       'src', 'sig1', 'sensor', 'day', 'county', 22222222, '01001')
 
     self.assertEqual(response, {'result': -2, 'message': 'no results'})
+
+  def test_async_call(self):
+    # insert dummy data
+    self.cur.execute('''
+      insert into covidcast values
+        (0, 'src', 'sig', 'day', 'county', 20200414, '11111',
+          123, 10, 11, 12, 456, 13, 20200414, 0, 1, False),
+        (0, 'src', 'sig', 'day', 'county', 20200414, '22222',
+          123, 20, 21, 22, 456, 23, 20200414, 0, 1, False),
+        (0, 'src', 'sig', 'day', 'county', 20200414, '33333',
+          123, 30, 31, 32, 456, 33, 20200414, 0, 1, False),
+        (0, 'src', 'sig', 'day', 'msa', 20200414, '11111',
+          123, 40, 41, 42, 456, 43, 20200414, 0, 1, False),
+        (0, 'src', 'sig', 'day', 'msa', 20200414, '22222',
+          123, 50, 51, 52, 456, 53, 20200414, 0, 1, False),
+        (0, 'src', 'sig', 'day', 'msa', 20200414, '33333',
+          123, 60, 61, 62, 456, 634, 20200414, 0, 1, False)
+    ''')
+    self.cnx.commit()
+    test_output = Epidata.async_call([
+      {
+        'source': 'covidcast',
+        'data_source': 'src',
+        'signals': 'sig',
+        'time_type': 'day',
+        'geo_type': 'county',
+        'geo_value': '11111',
+        'time_values': '20200414'
+      },
+      {
+        'source': 'covidcast',
+        'data_source': 'src',
+        'signals': 'sig',
+        'time_type': 'day',
+        'geo_type': 'county',
+        'geo_value': '00000',
+        'time_values': '20200414'
+      }
+    ])
+    responses = [i[0] for i in test_output]
+    # check response is same as standard covidcast call
+    self.assertEqual(responses,
+                     [Epidata.covidcast('src', 'sig', 'day', 'county', 20200414, '11111'),
+                      Epidata.covidcast('src', 'sig', 'day', 'county', 20200414, '00000')]
+                     )

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -715,7 +715,7 @@ class Epidata:
       return await response.json(), params
 
   @staticmethod
-  async def fetch_epidata(param_combos):
+  async def async_fetch_epidata(param_combos):
     """Helper function to asynchronously make and aggregate Epidata GET requests."""
     tasks = []
     async with ClientSession() as session:

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -732,6 +732,6 @@ class Epidata:
     responses = []
     for batch in batches:
       loop = asyncio.get_event_loop()
-      future = asyncio.ensure_future(Epidata.fetch_epidata(batch))
+      future = asyncio.ensure_future(Epidata.async_fetch_epidata(batch))
       responses += loop.run_until_complete(future)
     return responses

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -720,7 +720,7 @@ class Epidata:
     tasks = []
     async with ClientSession() as session:
       for param in param_combos:
-        task = asyncio.ensure_future(Epidata.get(param, session))
+        task = asyncio.ensure_future(Epidata.async_get(param, session))
         tasks.append(task)
       responses = await asyncio.gather(*tasks)
       return responses

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -726,9 +726,12 @@ class Epidata:
       return responses
 
   @staticmethod
-  def async_call(param_list):
+  def async_call(param_list, batch_size=100):
     """Make asynchronous Epidata calls for a list of parameters."""
-    loop = asyncio.get_event_loop()
-    future = asyncio.ensure_future(Epidata.fetch_epidata(param_list))
-    responses = loop.run_until_complete(future)
+    batches = [param_list[i:i+batch_size] for i in range(0, len(param_list), batch_size)]
+    responses = []
+    for batch in batches:
+      loop = asyncio.get_event_loop()
+      future = asyncio.ensure_future(Epidata.fetch_epidata(batch))
+      responses += loop.run_until_complete(future)
     return responses

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -726,8 +726,9 @@ class Epidata:
       return responses
 
   @staticmethod
-  def async_call(param_combos):
+  def async_call(param_list):
+    """Make asynchronous Epidata calls for a list of parameters."""
     loop = asyncio.get_event_loop()
-    future = asyncio.ensure_future(Epidata.fetch_epidata(param_combos))
+    future = asyncio.ensure_future(Epidata.fetch_epidata(param_list))
     responses = loop.run_until_complete(future)
     return responses

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -709,7 +709,7 @@ class Epidata:
     return Epidata._request(params)
 
   @staticmethod
-  async def get(params, session):
+  async def async_get(params, session):
     """Helper function to make Epidata GET requests."""
     async with session.get(Epidata.BASE_URL, params=params) as response:
       return await response.json(), params

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -709,29 +709,27 @@ class Epidata:
     return Epidata._request(params)
 
   @staticmethod
-  async def async_get(params, session):
-    """Helper function to make Epidata GET requests."""
-    async with session.get(Epidata.BASE_URL, params=params) as response:
-      return await response.json(), params
-
-  @staticmethod
-  async def async_fetch_epidata(param_combos):
-    """Helper function to asynchronously make and aggregate Epidata GET requests."""
-    tasks = []
-    async with ClientSession() as session:
-      for param in param_combos:
-        task = asyncio.ensure_future(Epidata.async_get(param, session))
-        tasks.append(task)
-      responses = await asyncio.gather(*tasks)
-      return responses
-
-  @staticmethod
-  def async_call(param_list, batch_size=100):
+  def async_epidata(param_list, batch_size=100):
     """Make asynchronous Epidata calls for a list of parameters."""
+    async def async_get(params, session):
+      """Helper function to make Epidata GET requests."""
+      async with session.get(Epidata.BASE_URL, params=params) as response:
+        return await response.json(), params
+
+    async def async_make_calls(param_combos):
+      """Helper function to asynchronously make and aggregate Epidata GET requests."""
+      tasks = []
+      async with ClientSession() as session:
+        for param in param_combos:
+          task = asyncio.ensure_future(async_get(param, session))
+          tasks.append(task)
+        responses = await asyncio.gather(*tasks)
+        return responses
+
     batches = [param_list[i:i+batch_size] for i in range(0, len(param_list), batch_size)]
     responses = []
     for batch in batches:
       loop = asyncio.get_event_loop()
-      future = asyncio.ensure_future(Epidata.async_fetch_epidata(batch))
+      future = asyncio.ensure_future(async_make_calls(batch))
       responses += loop.run_until_complete(future)
     return responses

--- a/src/client/packaging/pypi/setup.py
+++ b/src/client/packaging/pypi/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
   url='https://github.com/cmu-delphi/delphi-epidata',
   packages=setuptools.find_packages(),
   install_requires=[
+    'aiohttp'
     'requests>=2.7.0',
   ],
   classifiers=[


### PR DESCRIPTION
To be used by covidcast client (to speed up indicator combo) and also in nowcasting. 

One thing to note is that running this on some machines and/or in jupyter can lead to this an issue that [requires you run these two lines to solve](https://stackoverflow.com/questions/46827007/runtimeerror-this-event-loop-is-already-running-in-python/56434301#56434301). For that reason I'm not sure we'll want to make this the default method in covidcast, since we don't have much control over people's environments. Adding those lines at the top of the client file seems to resolves it for me, but not sure if that'll hold universally. If it does, then we might be fine. If not, we could set a protected flag in covidcast for async that only our internal users/superusers will change. 

Summary of changes:
- Added a method which takes in a list of raw params and sends an async request for each param. Does not do any formatting/cleaning/parsing of the params so it's compatible with any epidata source (at the expense of convenient) 2 helper methods are also added to make the requests.
- Tests

