### PR TITLE
HHS hosp docs: clarify handling of timeseries vs daily updates

### DIFF
--- a/docs/api/covid_hosp.md
+++ b/docs/api/covid_hosp.md
@@ -1,13 +1,14 @@
 ---
-title: COVID-19 Reported Patient Impact and Hospital Capacity by State Timeseries
+title: COVID-19 Reported Patient Impact and Hospital Capacity by State
 parent: Epidata API (Other Diseases)
 ---
 
 # COVID-19 Hospitalization by State
 
 This data source is a mirror of the "COVID-19 Reported Patient Impact and
-Hospital Capacity by State Timeseries" dataset provided by the US Department of
-Health & Human Services via healthdata.gov.
+Hospital Capacity by State" and "COVID-19 Reported Patient Impact and Hospital
+Capacity by State Timeseries" datasets provided by the US Department of Health &
+Human Services via healthdata.gov.
 
 See the
 [official description at healthdata.gov](https://healthdata.gov/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state-timeseries)
@@ -26,8 +27,13 @@ This data source provides various measures of COVID-19 burden on patients and he
 - Spatial Resolution: US States plus DC, PR, and VI
 - Open access via [Open Data Commons Open Database License (ODbL)](https://opendatacommons.org/licenses/odbl/1.0/)
 - Versioned by Delphi according to "issue" date, which is the date that the
-dataset was published by HHS. New issues are expected to be released roughly
-weekly.
+dataset was published by HHS. We ingest two kinds of updates from HHS:
+timeseries and daily snapshots. Timeseries updates are published by HHS roughly
+weekly, while daily snapshots are published in batches every 1-9 days. Delphi
+keys the issue date to the timestamp of each file in the batch, not the date
+when the batch was posted. When both a daily and a timeseries update are issued
+on the same day, Delphi stores both versions but returns the values from the
+daily update.
 
 # The API
 

--- a/docs/api/covidcast-signals/hhs.md
+++ b/docs/api/covidcast-signals/hhs.md
@@ -78,7 +78,10 @@ Agency (DHA) facilities, and religious non-medical facilities.
 ## Lag and Backfill
 
 HHS issues updates to this timeseries once a week, and occasionally more
-often. We check for updates daily. Lag varies from 0 to 6 days.
+often. There is a separate update stream recording daily updates to figures in
+this timeseries, though these daily snapshots are released in irregular batches,
+about twice a week on average. We check for updates daily from both streams. Lag
+varies from 0 to 6 days.
 
 Occasionally a value published in an early issue will be changed in a subsequent
 issue when additional data becomes known. This effect is known as


### PR DESCRIPTION
It's not currently clear in the docs how Delphi merges data from the timeseries and daily updates published by HHS. This PR aims to do that.

Before merging we should make sure this is all accurate, and decide whether to fix the code or the docs if not.