### PR TITLE
covid_hosp: fetch all files from daily batches

### DIFF
--- a/integrations/acquisition/covid_hosp/state_daily/test_scenarios.py
+++ b/integrations/acquisition/covid_hosp/state_daily/test_scenarios.py
@@ -3,6 +3,10 @@
 # standard library
 import unittest
 from unittest.mock import MagicMock
+from unittest.mock import patch
+
+# third party
+import requests
 
 # first party
 from delphi.epidata.acquisition.covid_hosp.common.database import Database
@@ -40,12 +44,6 @@ class AcquisitionTests(unittest.TestCase):
   def test_acquire_dataset(self):
     """Acquire a new dataset."""
 
-    # only mock out network calls to external hosts
-    mock_network = MagicMock()
-    mock_network.fetch_metadata.return_value = \
-        self.test_utils.load_sample_metadata()
-    mock_network.fetch_dataset.return_value = \
-        self.test_utils.load_sample_dataset()
 
     # make sure the data does not yet exist
     with self.subTest(name='no data yet'):
@@ -53,9 +51,15 @@ class AcquisitionTests(unittest.TestCase):
       self.assertEqual(response['result'], -2)
 
     # acquire sample data into local database
-    with self.subTest(name='first acquisition'):
-      acquired = Update.run(network=mock_network)
+    # mock out network calls to external hosts
+    with self.subTest(name='first acquisition'), \
+         patch.object(requests, 'get', side_effect=
+                      [MagicMock(json=lambda: self.test_utils.load_sample_metadata())] +
+                       list(self.test_utils.load_sample_revisions())) as mock_requests_get, \
+         patch.object(Network, 'fetch_dataset', return_value=self.test_utils.load_sample_dataset()) as mock_fetch:
+      acquired = Update.run()
       self.assertTrue(acquired)
+      self.assertEqual(mock_requests_get.call_count, 6)
 
     # make sure the data now exists
     with self.subTest(name='initial data checks'):
@@ -76,8 +80,12 @@ class AcquisitionTests(unittest.TestCase):
       self.assertEqual(len(row), 61)
 
     # re-acquisition of the same dataset should be a no-op
-    with self.subTest(name='second acquisition'):
-      acquired = Update.run(network=mock_network)
+    with self.subTest(name='second acquisition'), \
+         patch.object(requests, 'get', side_effect=
+                      [MagicMock(json=lambda: self.test_utils.load_sample_metadata())] +
+                       list(self.test_utils.load_sample_revisions())) as mock_requests_get, \
+         patch.object(Network, 'fetch_dataset', return_value=self.test_utils.load_sample_dataset()) as mock_fetch:
+      acquired = Update.run()
       self.assertFalse(acquired)
 
     # make sure the data still exists

--- a/src/acquisition/covid_hosp/common/test_utils.py
+++ b/src/acquisition/covid_hosp/common/test_utils.py
@@ -11,6 +11,7 @@ dir, hence the existence of this file.
 # standard library
 import json
 from pathlib import Path
+from unittest.mock import Mock
 
 # third party
 import pandas
@@ -55,3 +56,9 @@ class TestUtils:
 
   def load_sample_dataset(self):
     return pandas.read_csv(self.data_dir / 'dataset.csv', dtype=str)
+
+  def load_sample_revisions(self):
+    for filename in [f"revision{x}.html" for x in
+                     ["s", "_0130", "_0129", "_0128", "_0127"]]:
+      with open(self.data_dir / filename, 'rb') as f:
+        yield Mock(content=f.read().decode('utf-8'))

--- a/src/acquisition/covid_hosp/common/test_utils.py
+++ b/src/acquisition/covid_hosp/common/test_utils.py
@@ -63,7 +63,7 @@ class TestUtils:
     These are scraped by state_daily to ensure we capture all files, not just the
     most recent in each batch uploaded by HHS.
     """
-    for filename in [f"revision{x}.html" for x in
-                     ["s", "_0130", "_0129", "_0128", "_0127"]]:
+    for filename in [f'revision{x}.html' for x in
+                     ['s', '_0130', '_0129', '_0128', '_0127']]:
       with open(self.data_dir / filename, 'rb') as f:
         yield Mock(content=f.read().decode('utf-8'))

--- a/src/acquisition/covid_hosp/common/test_utils.py
+++ b/src/acquisition/covid_hosp/common/test_utils.py
@@ -58,6 +58,11 @@ class TestUtils:
     return pandas.read_csv(self.data_dir / 'dataset.csv', dtype=str)
 
   def load_sample_revisions(self):
+    """Pretend to serve pages from the HHS revisions site.
+
+    These are scraped by state_daily to ensure we capture all files, not just the
+    most recent in each batch uploaded by HHS.
+    """
     for filename in [f"revision{x}.html" for x in
                      ["s", "_0130", "_0129", "_0128", "_0127"]]:
       with open(self.data_dir / filename, 'rb') as f:

--- a/src/acquisition/covid_hosp/state_daily/database.py
+++ b/src/acquisition/covid_hosp/state_daily/database.py
@@ -116,6 +116,10 @@ class Database(BaseDatabase):
         additional_fields=[('D', 'record_type')])
 
   def get_max_issue(self):
+    """Fetch the most recent state-daily issue.
+
+    This is used to bookend what links we scrape from the HHS revisions page.
+    """
     with self.new_cursor() as cursor:
       cursor.execute(f'''
         SELECT

--- a/src/acquisition/covid_hosp/state_daily/database.py
+++ b/src/acquisition/covid_hosp/state_daily/database.py
@@ -114,3 +114,19 @@ class Database(BaseDatabase):
         table_name=Database.TABLE_NAME,
         columns_and_types=Database.ORDERED_CSV_COLUMNS,
         additional_fields=[('D', 'record_type')])
+
+  def get_max_issue(self):
+    with self.new_cursor() as cursor:
+      cursor.execute(f'''
+        SELECT
+          max(issue)
+        from
+          `{self.table_name}`
+        WHERE
+          `record_type` = "D"
+      ''')
+      for (result,) in cursor:
+        if result is not None:
+          return int(result)
+      # if empty, return beginning of time
+      return 0

--- a/src/acquisition/covid_hosp/state_daily/network.py
+++ b/src/acquisition/covid_hosp/state_daily/network.py
@@ -1,10 +1,16 @@
+# third party
+from bs4 import BeautifulSoup
+import requests
+
 # first party
 from delphi.epidata.acquisition.covid_hosp.common.network import Network as BaseNetwork
-
+from delphi.epidata.acquisition.covid_hosp.common.utils import Utils
 
 class Network(BaseNetwork):
 
   DATASET_ID = '7823dd0e-c8c4-4206-953e-c6d2f451d6ed'
+  ROOT = "https://healthdata.gov"
+  REVISIONS = '/node/3281086/revisions'
 
   def fetch_metadata(*args, **kwags):
     """Download and return metadata.
@@ -14,3 +20,15 @@ class Network(BaseNetwork):
 
     return Network.fetch_metadata_for_dataset(
         *args, **kwags, dataset_id=Network.DATASET_ID)
+
+  def fetch_revisions(newer_than):
+    urls = []
+    soup = BeautifulSoup(requests.get(Network.ROOT + Network.REVISIONS).content, "html.parser")
+    views = [
+      a['href'] for a in soup.select("tr.diff-revision a[href^='/node']")
+      if Utils.get_issue_from_revision(a.text) > newer_than
+    ]
+    for view in views:
+      view_soup = BeautifulSoup(requests.get(Network.ROOT + view).content, "html.parser")
+      urls.append(view_soup.select_one(".download a")['href'])
+    return urls

--- a/src/acquisition/covid_hosp/state_daily/network.py
+++ b/src/acquisition/covid_hosp/state_daily/network.py
@@ -9,9 +9,10 @@ from delphi.epidata.acquisition.covid_hosp.common.utils import Utils
 class Network(BaseNetwork):
 
   DATASET_ID = '7823dd0e-c8c4-4206-953e-c6d2f451d6ed'
-  ROOT = "https://healthdata.gov"
+  ROOT = 'https://healthdata.gov'
   REVISIONS = '/node/3281086/revisions'
 
+  @staticmethod
   def fetch_metadata(*args, **kwags):
     """Download and return metadata.
 
@@ -21,12 +22,16 @@ class Network(BaseNetwork):
     return Network.fetch_metadata_for_dataset(
         *args, **kwags, dataset_id=Network.DATASET_ID)
 
+  @staticmethod
   def fetch_revisions(newer_than):
     """Scrape CSV urls from the HHS revisions pages.
 
+    newer_than : int YYYYMMDD
+      issue date of the most recent daily files already in the database.
+
     The revisions page is a big table showing recent revisions to the state
     daily dataset. Each row represents a single revision with a link to a
-    separate page where a download is available for that revision. 
+    separate page where a download is available for that revision.
 
     The first row is different, and links directly back to the main dataset
     page. Since this row represents the current published version, and the URL
@@ -34,8 +39,8 @@ class Network(BaseNetwork):
 
     The link for each revision is a date in the same format as
     `revision_timestamp` from the metadata, so we bookend which links we retrieve
-    by checking against the issue code (YYYYMMDD) for the last issue we
-    imported. 
+    by checking against the issue code (newer_than) for the last issue we
+    imported.
 
     This approach will break under the following conditions:
      - Automation starts the update routine after the first file of a batch is
@@ -47,12 +52,12 @@ class Network(BaseNetwork):
        same date in the link from the revisions page)
     """
     urls = []
-    soup = BeautifulSoup(requests.get(Network.ROOT + Network.REVISIONS).content, "html.parser")
+    soup = BeautifulSoup(requests.get(Network.ROOT + Network.REVISIONS).content, 'html.parser')
     views = [
-      a['href'] for a in soup.select("tr.diff-revision a[href^='/node']")
+      a['href'] for a in soup.select('tr.diff-revision a[href^="/node"]')
       if Utils.get_issue_from_revision(a.text) > newer_than
     ]
     for view in views:
-      view_soup = BeautifulSoup(requests.get(Network.ROOT + view).content, "html.parser")
-      urls.append(view_soup.select_one(".download a")['href'])
+      view_soup = BeautifulSoup(requests.get(Network.ROOT + view).content, 'html.parser')
+      urls.append(view_soup.select_one('.download a')['href'])
     return urls

--- a/src/acquisition/covid_hosp/state_daily/update.py
+++ b/src/acquisition/covid_hosp/state_daily/update.py
@@ -27,7 +27,8 @@ class Update:
 
     # can't use Utils here because daily files are posted in batches and we want
     # all files in the batch. These have to be scraped from the Revisions page,
-    # since they aren't surfaced in metadata. :,(
+    # since they aren't surfaced in metadata. :(
+    # then we merge them into an issue based on their publish date.
 
     # get dataset details from metadata
     metadata = network.fetch_metadata()

--- a/src/acquisition/covid_hosp/state_daily/update.py
+++ b/src/acquisition/covid_hosp/state_daily/update.py
@@ -3,8 +3,11 @@ Acquires the "COVID-19 Reported Patient Impact and Hospital Capacity by State"
 dataset provided by the US Department of Health & Human Services
 via healthdata.gov.
 """
-
+# standard library
 import json
+
+# third party
+import pandas as pd
 
 # first party
 from delphi.epidata.acquisition.covid_hosp.common.utils import Utils
@@ -14,6 +17,7 @@ from delphi.epidata.acquisition.covid_hosp.state_daily.network import Network
 
 class Update:
 
+  @staticmethod
   def run(network=Network):
     """Acquire the most recent dataset, unless it was previously acquired.
 
@@ -46,28 +50,50 @@ class Update:
         return False
 
       max_issue = db.get_max_issue()
-      
+
       # add metadata to the database
       metadata_json = json.dumps(metadata)
       db.insert_metadata(issue, revision, metadata_json)
 
       urls = network.fetch_revisions(max_issue) + [url]
       print(f'acquiring {len(urls)} daily updates')
-      n = 0
-      dataset = None
-      for url in urls:
-        # download the dataset and add it to the database
-        # overwrite older files with data from newer files
-        new = network.fetch_dataset(url)
-        if dataset is None:
-          dataset = new
-        else:
-          dataset.update(new)
-          
+      dataset = Update.merge_by_state_date(
+        [network.fetch_dataset(url) for url in urls]
+      )
+
       db.insert_dataset(issue, dataset)
 
       print(f'successfully acquired {len(dataset)} rows (not excluding overlap)')
     return True
+
+  @staticmethod
+  def merge_by_state_date(dfs):
+    """Merge a list of data frames as a series of updates.
+
+    Parameters:
+    -----------
+      dfs : list(pd.DataFrame)
+        Data frames to merge, ordered from earliest to latest.
+
+    Returns a single data frame containing the most recent data for each state+date.
+    """
+    key_cols = ['state', 'reporting_cutoff_start']
+    dfs = [df.set_index(key_cols) for df in dfs
+           if not all(k in df.index.names for k in key_cols)]
+    result = dfs[0]
+
+    for df in dfs[1:]:
+      # update values for existing keys
+      result.update(df)
+      # add any new keys.
+      ## repeated concatenation in pandas is expensive, but (1) we don't expect
+      ## batch sizes to be terribly large (7 files max) and (2) this way we can
+      ## more easily capture the next iteration's updates to any new keys
+      new_rows = df.loc[[i for i in df.index.to_list() if i not in result.index.to_list()]]
+      result = pd.concat([result, new_rows])
+
+    # convert the index rows back to columns
+    return result.reset_index(level=key_cols)
 
 
 # main entry point

--- a/src/acquisition/covid_hosp/state_daily/update.py
+++ b/src/acquisition/covid_hosp/state_daily/update.py
@@ -4,6 +4,8 @@ dataset provided by the US Department of Health & Human Services
 via healthdata.gov.
 """
 
+import json
+
 # first party
 from delphi.epidata.acquisition.covid_hosp.common.utils import Utils
 from delphi.epidata.acquisition.covid_hosp.state_daily.database import Database
@@ -21,7 +23,50 @@ class Update:
       Whether a new dataset was acquired.
     """
 
-    return Utils.update_dataset(Database, network)
+    #return Utils.update_dataset(Database, network)
+
+    # can't use Utils here because daily files are posted in batches and we want
+    # all files in the batch. These have to be scraped from the Revisions page,
+    # since they aren't surfaced in metadata. :,(
+
+    # get dataset details from metadata
+    metadata = network.fetch_metadata()
+    url, revision = Utils.extract_resource_details(metadata)
+    issue = Utils.get_issue_from_revision(revision)
+    print(f'issue: {issue}')
+    print(f'revision: {revision}')
+
+    # connect to the database
+    with Database.connect() as db:
+
+      # bail if the dataset has already been acquired
+      if db.contains_revision(revision):
+        print('already have this revision, nothing to do')
+        return False
+
+      max_issue = db.get_max_issue()
+      
+      # add metadata to the database
+      metadata_json = json.dumps(metadata)
+      db.insert_metadata(issue, revision, metadata_json)
+
+      urls = network.fetch_revisions(max_issue) + [url]
+      print(f'acquiring {len(urls)} daily updates')
+      n = 0
+      dataset = None
+      for url in urls:
+        # download the dataset and add it to the database
+        # overwrite older files with data from newer files
+        new = network.fetch_dataset(url)
+        if dataset is None:
+          dataset = new
+        else:
+          dataset.update(new)
+          
+      db.insert_dataset(issue, dataset)
+
+      print(f'successfully acquired {len(dataset)} rows (not excluding overlap)')
+    return True
 
 
 # main entry point

--- a/testdata/acquisition/covid_hosp/state_daily/revision_0127.html
+++ b/testdata/acquisition/covid_hosp/state_daily/revision_0127.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
+  "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">
+<html lang="en" dir="ltr">
+<head profile="http://www.w3.org/1999/xhtml/vocab">
+
+  <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
+
+    {'gtm.start': new Date().getTime(),event:'gtm.js'}
+    );var f=d.getElementsByTagName(s)[0],
+
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+
+    })(window,document,'script','dataLayer','GTM-K8VG67T');</script>
+  <!-- End Google Tag Manager -->
+
+  <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
+  <meta charset="utf-8"><script type="text/javascript">(window.NREUM||(NREUM={})).loader_config={licenseKey:"b7126202e5",applicationID:"65779789"};window.NREUM||(NREUM={}),__nr_require=function(e,t,n){function r(n){if(!t[n]){var i=t[n]={exports:{}};e[n][0].call(i.exports,function(t){var i=e[n][1][t];return r(i||t)},i,i.exports)}return t[n].exports}if("function"==typeof __nr_require)return __nr_require;for(var i=0;i<n.length;i++)r(n[i]);return r}({1:[function(e,t,n){function r(){}function i(e,t,n){return function(){return o(e,[u.now()].concat(c(arguments)),t?null:this,n),t?void 0:this}}var o=e("handle"),a=e(6),c=e(7),f=e("ee").get("tracer"),u=e("loader"),s=NREUM;"undefined"==typeof window.newrelic&&(newrelic=s);var d=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],p="api-",l=p+"ixn-";a(d,function(e,t){s[t]=i(p+t,!0,"api")}),s.addPageAction=i(p+"addPageAction",!0),s.setCurrentRouteName=i(p+"routeName",!0),t.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,t){var n={},r=this,i="function"==typeof t;return o(l+"tracer",[u.now(),e,n],r),function(){if(f.emit((i?"":"no-")+"fn-start",[u.now(),r,i],n),i)try{return t.apply(this,arguments)}catch(e){throw f.emit("fn-err",[arguments,this,e],n),e}finally{f.emit("fn-end",[u.now()],n)}}}};a("actionText,setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(e,t){m[t]=i(l+t)}),newrelic.noticeError=function(e,t){"string"==typeof e&&(e=new Error(e)),o("err",[e,u.now(),!1,t])}},{}],2:[function(e,t,n){function r(){return c.exists&&performance.now?Math.round(performance.now()):(o=Math.max((new Date).getTime(),o))-a}function i(){return o}var o=(new Date).getTime(),a=o,c=e(8);t.exports=r,t.exports.offset=a,t.exports.getLastTimestamp=i},{}],3:[function(e,t,n){function r(e,t){var n=e.getEntries();n.forEach(function(e){"first-paint"===e.name?d("timing",["fp",Math.floor(e.startTime)]):"first-contentful-paint"===e.name&&d("timing",["fcp",Math.floor(e.startTime)])})}function i(e,t){var n=e.getEntries();n.length>0&&d("lcp",[n[n.length-1]])}function o(e){e.getEntries().forEach(function(e){e.hadRecentInput||d("cls",[e])})}function a(e){if(e instanceof m&&!g){var t=Math.round(e.timeStamp),n={type:e.type};t<=p.now()?n.fid=p.now()-t:t>p.offset&&t<=Date.now()?(t-=p.offset,n.fid=p.now()-t):t=p.now(),g=!0,d("timing",["fi",t,n])}}function c(e){d("pageHide",[p.now(),e])}if(!("init"in NREUM&&"page_view_timing"in NREUM.init&&"enabled"in NREUM.init.page_view_timing&&NREUM.init.page_view_timing.enabled===!1)){var f,u,s,d=e("handle"),p=e("loader"),l=e(5),m=NREUM.o.EV;if("PerformanceObserver"in window&&"function"==typeof window.PerformanceObserver){f=new PerformanceObserver(r);try{f.observe({entryTypes:["paint"]})}catch(v){}u=new PerformanceObserver(i);try{u.observe({entryTypes:["largest-contentful-paint"]})}catch(v){}s=new PerformanceObserver(o);try{s.observe({type:"layout-shift",buffered:!0})}catch(v){}}if("addEventListener"in document){var g=!1,w=["click","keydown","mousedown","pointerdown","touchstart"];w.forEach(function(e){document.addEventListener(e,a,!1)})}l(c)}},{}],4:[function(e,t,n){function r(e,t){if(!i)return!1;if(e!==i)return!1;if(!t)return!0;if(!o)return!1;for(var n=o.split("."),r=t.split("."),a=0;a<r.length;a++)if(r[a]!==n[a])return!1;return!0}var i=null,o=null,a=/Version\/(\S+)\s+Safari/;if(navigator.userAgent){var c=navigator.userAgent,f=c.match(a);f&&c.indexOf("Chrome")===-1&&c.indexOf("Chromium")===-1&&(i="Safari",o=f[1])}t.exports={agent:i,version:o,match:r}},{}],5:[function(e,t,n){function r(e){function t(){e(a&&document[a]?document[a]:document[i]?"hidden":"visible")}"addEventListener"in document&&o&&document.addEventListener(o,t,!1)}t.exports=r;var i,o,a;"undefined"!=typeof document.hidden?(i="hidden",o="visibilitychange",a="visibilityState"):"undefined"!=typeof document.msHidden?(i="msHidden",o="msvisibilitychange"):"undefined"!=typeof document.webkitHidden&&(i="webkitHidden",o="webkitvisibilitychange",a="webkitVisibilityState")},{}],6:[function(e,t,n){function r(e,t){var n=[],r="",o=0;for(r in e)i.call(e,r)&&(n[o]=t(r,e[r]),o+=1);return n}var i=Object.prototype.hasOwnProperty;t.exports=r},{}],7:[function(e,t,n){function r(e,t,n){t||(t=0),"undefined"==typeof n&&(n=e?e.length:0);for(var r=-1,i=n-t||0,o=Array(i<0?0:i);++r<i;)o[r]=e[t+r];return o}t.exports=r},{}],8:[function(e,t,n){t.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,t,n){function r(){}function i(e){function t(e){return e&&e instanceof r?e:e?u(e,f,a):a()}function n(n,r,i,o,a){if(a!==!1&&(a=!0),!l.aborted||o){e&&a&&e(n,r,i);for(var c=t(i),f=v(n),u=f.length,s=0;s<u;s++)f[s].apply(c,r);var p=d[h[n]];return p&&p.push([b,n,r,c]),c}}function o(e,t){y[e]=v(e).concat(t)}function m(e,t){var n=y[e];if(n)for(var r=0;r<n.length;r++)n[r]===t&&n.splice(r,1)}function v(e){return y[e]||[]}function g(e){return p[e]=p[e]||i(n)}function w(e,t){s(e,function(e,n){t=t||"feature",h[n]=t,t in d||(d[t]=[])})}var y={},h={},b={on:o,addEventListener:o,removeEventListener:m,emit:n,get:g,listeners:v,context:t,buffer:w,abort:c,aborted:!1};return b}function o(e){return u(e,f,a)}function a(){return new r}function c(){(d.api||d.feature)&&(l.aborted=!0,d=l.backlog={})}var f="nr@context",u=e("gos"),s=e(6),d={},p={},l=t.exports=i();t.exports.getOrSetContext=o,l.backlog=d},{}],gos:[function(e,t,n){function r(e,t,n){if(i.call(e,t))return e[t];var r=n();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,t,{value:r,writable:!0,enumerable:!1}),r}catch(o){}return e[t]=r,r}var i=Object.prototype.hasOwnProperty;t.exports=r},{}],handle:[function(e,t,n){function r(e,t,n,r){i.buffer([e],r),i.emit(e,t,n)}var i=e("ee").get("handle");t.exports=r,r.ee=i},{}],id:[function(e,t,n){function r(e){var t=typeof e;return!e||"object"!==t&&"function"!==t?-1:e===window?0:a(e,o,function(){return i++})}var i=1,o="nr@id",a=e("gos");t.exports=r},{}],loader:[function(e,t,n){function r(){if(!x++){var e=b.info=NREUM.info,t=p.getElementsByTagName("script")[0];if(setTimeout(u.abort,3e4),!(e&&e.licenseKey&&e.applicationID&&t))return u.abort();f(y,function(t,n){e[t]||(e[t]=n)});var n=a();c("mark",["onload",n+b.offset],null,"api"),c("timing",["load",n]);var r=p.createElement("script");r.src="https://"+e.agent,t.parentNode.insertBefore(r,t)}}function i(){"complete"===p.readyState&&o()}function o(){c("mark",["domContent",a()+b.offset],null,"api")}var a=e(2),c=e("handle"),f=e(6),u=e("ee"),s=e(4),d=window,p=d.document,l="addEventListener",m="attachEvent",v=d.XMLHttpRequest,g=v&&v.prototype;NREUM.o={ST:setTimeout,SI:d.setImmediate,CT:clearTimeout,XHR:v,REQ:d.Request,EV:d.Event,PR:d.Promise,MO:d.MutationObserver};var w=""+location,y={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-1194.min.js"},h=v&&g&&g[l]&&!/CriOS/.test(navigator.userAgent),b=t.exports={offset:a.getLastTimestamp(),now:a,origin:w,features:{},xhrWrappable:h,userAgent:s};e(1),e(3),p[l]?(p[l]("DOMContentLoaded",o,!1),d[l]("load",r,!1)):(p[m]("onreadystatechange",i),d[m]("onload",r)),c("mark",["firstbyte",a.getLastTimestamp()],null,"api");var x=0},{}],"wrap-function":[function(e,t,n){function r(e,t){function n(t,n,r,f,u){function nrWrapper(){var o,a,s,p;try{a=this,o=d(arguments),s="function"==typeof r?r(o,a):r||{}}catch(l){i([l,"",[o,a,f],s],e)}c(n+"start",[o,a,f],s,u);try{return p=t.apply(a,o)}catch(m){throw c(n+"err",[o,a,m],s,u),m}finally{c(n+"end",[o,a,p],s,u)}}return a(t)?t:(n||(n=""),nrWrapper[p]=t,o(t,nrWrapper,e),nrWrapper)}function r(e,t,r,i,o){r||(r="");var c,f,u,s="-"===r.charAt(0);for(u=0;u<t.length;u++)f=t[u],c=e[f],a(c)||(e[f]=n(c,s?f+r:r,i,f,o))}function c(n,r,o,a){if(!m||t){var c=m;m=!0;try{e.emit(n,r,o,t,a)}catch(f){i([f,n,r,o],e)}m=c}}return e||(e=s),n.inPlace=r,n.flag=p,n}function i(e,t){t||(t=s);try{t.emit("internal-error",e)}catch(n){}}function o(e,t,n){if(Object.defineProperty&&Object.keys)try{var r=Object.keys(e);return r.forEach(function(n){Object.defineProperty(t,n,{get:function(){return e[n]},set:function(t){return e[n]=t,t}})}),t}catch(o){i([o],n)}for(var a in e)l.call(e,a)&&(t[a]=e[a]);return t}function a(e){return!(e&&e instanceof Function&&e.apply&&!e[p])}function c(e,t){var n=t(e);return n[p]=e,o(e,n,s),n}function f(e,t,n){var r=e[t];e[t]=c(r,n)}function u(){for(var e=arguments.length,t=new Array(e),n=0;n<e;++n)t[n]=arguments[n];return t}var s=e("ee"),d=e(7),p="nr@original",l=Object.prototype.hasOwnProperty,m=!1;t.exports=r,t.exports.wrapFunction=c,t.exports.wrapInPlace=f,t.exports.argsToArray=u},{}]},{},["loader"]);</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="Generator" content="Drupal 7 (http://drupal.org)" />
+<link rel="canonical" href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749" />
+<link rel="shortlink" href="/node/3281086" />
+<link rel="shortcut icon" href="https://healthdata.gov/sites/all/themes/custom/nuhealthdata/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>COVID-19 Reported Patient Impact and Hospital Capacity by State - COVID-19 Reported Patient Impact and Hospital Capacity by State | HealthData.gov</title>
+  <link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_kShW4RPmRstZ3SpIC-ZvVGNFVAi0WEMuCnI0ZkYIaFw.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_zWS33JphQ8354vADCrYEXghZq-7dBSX_GVE0h2a882o.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_PclrG84jul3FzOPY6aecmDD2k_CB0QT-xKgHJqBcCek.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_aQiRaGwrQLA1xsKXFyh_7NruQm-7hS0jN00qLp0n4To.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans::400,300,700" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_M3GDWqGTIjDW5ochjX8aHUFPH81l8L3gWPBBCgGLTKk.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css__n9YKsq7xsXwEwMrfJhLwruizLxg3Cb0WQoeIyW7aQ0.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_E5LxTHvotstXfBsPxcRlLKjEwjXPfi49JcaYB4zerlY.css" media="print" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/colorizer/nuhealthdata-bd90ffba.css" media="all" />
+
+<!--[if lte IE 9]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_afrXmziPY13Y9oUhiVMbLllpNaAnF9oeeqCoWSAcphU.css" media="all" />
+<![endif]-->
+
+<!--[if IE 9]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_qpzT6Nla_9qnBw9yFCNlaMSx-mR1C2PUztgmhLWV6Xc.css" media="all" />
+<![endif]-->
+
+<!--[if IE 8]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_niVepbI1pyCvJmhl54aXP4kQl1P0eSi3jLWf68uRmCU.css" media="all" />
+<![endif]-->
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_PxsPpITToy8ZnO0bJDA1TEC6bbFpGTfSWr2ZP8LuFYo.css" media="all" />
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <link href="/css/ie.css" media="screen" rel="stylesheet" type="text/css" />
+  <![endif]-->
+  <script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_mOx0WHl6cNZI0fqrVldT0Ay6Zv7VRFDm9LexZoNN_NI.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.migrateMute=true;jQuery.migrateTrace=false;
+//--><!]]>
+</script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_KfaBLR-BltoahyKqWl-Gti4gX3P_ywCrBhJzxOpwENQ.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/profiles/dkan/themes/contrib/nuboot_radix/assets/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js__Bnv-OxH3VuVfkYMQRgUHa3xCAKCmG7XimGQPEMs8CY.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_MhcB1FN2UMLPCnR-GfDjthX1HNPWMcDaupqqkDbY3yI.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_gnAxee1bR7uyP3sjkMimmwHC8nKs6Zp8c_Ru3SHrTLA.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+L.Icon.Default.imagePath = "/profiles/dkan/libraries/recline/vendor/leaflet/1.0.2/images/"
+//--><!]]>
+</script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_REbMwQ6tX2snu6GJRSFgsJqXzTwQiAF0Hu4pjCqc0cE.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_yZom1RMJVpo8-qmlGUMfpdJmnX169UZ2gK75qjeIJLs.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"nuhealthdata","theme_token":"Vv-TYDyPqg3URaQRQSYCMtgqY-lUkY3DLHZflegE3lI","js":{"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets.js":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets-spotlight.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/jquery\/1.12\/jquery.min.js":1,"0":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/jquery-migrate\/1\/jquery-migrate.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"https:\/\/healthdata.gov\/profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/js\/bootstrap.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.widget.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.mouse.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.sortable.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.tabs.min.js":1,"misc\/form.js":1,"misc\/states.js":1,"profiles\/dkan\/modules\/contrib\/panopoly_images\/panopoly-images.js":1,"profiles\/dkan\/modules\/dkan\/dkan_plugins\/js\/colorPicker.behavior.js":1,"profiles\/dkan\/modules\/contrib\/recline\/js\/jsondataview.js":1,"profiles\/dkan\/modules\/contrib\/recline\/js\/restdataview.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"profiles\/dkan\/libraries\/jquery.imagesloaded\/jquery.imagesloaded.min.js":1,"misc\/tableheader.js":1,"sites\/all\/modules\/contrib\/comment_goodness\/comment_goodness.js":1,"sites\/all\/modules\/contrib\/captcha\/captcha.js":1,"profiles\/dkan\/libraries\/lodash\/dist\/lodash.compat.min.js":1,"profiles\/dkan\/libraries\/backbone\/backbone-min.js":1,"profiles\/dkan\/libraries\/recline\/dist\/recline.js":1,"profiles\/dkan\/libraries\/csv\/csv.js":1,"profiles\/dkan\/libraries\/jsxlsx\/dist\/xlsx.core.min.js":1,"profiles\/dkan\/libraries\/xls\/dist\/recline.backend.xlsx.min.js":1,"profiles\/dkan\/libraries\/mustache\/mustache.min.js":1,"profiles\/dkan\/libraries\/moment\/min\/moment.min.js":1,"profiles\/dkan\/libraries\/slickgrid\/lib\/jquery.event.drag-2.2.js":1,"profiles\/dkan\/libraries\/slickgrid\/lib\/jquery.event.drop-2.2.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.core.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.formatters.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.editors.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.grid.js":1,"profiles\/dkan\/libraries\/slickgrid\/lib\/jquery-ui-1.8.16.custom.min.js":1,"profiles\/dkan\/libraries\/slickgrid\/plugins\/slick.rowselectionmodel.js":1,"profiles\/dkan\/libraries\/slickgrid\/plugins\/slick.rowmovemanager.js":1,"profiles\/dkan\/libraries\/leaflet\/dist\/leaflet.js":1,"profiles\/dkan\/libraries\/flot\/jquery.flot.js":1,"profiles\/dkan\/libraries\/deep_diff\/releases\/deep-diff-0.3.0.min.js":1,"profiles\/dkan\/libraries\/recline_deeplink\/dist\/recline.deeplink.min.js":1,"profiles\/dkan\/libraries\/leaflet_markercluster\/dist\/leaflet.markercluster.js":1,"profiles\/dkan\/modules\/contrib\/recline\/backend.ckan_get.js":1,"profiles\/dkan\/modules\/contrib\/recline\/recline.js":1,"1":1,"misc\/textarea.js":1,"modules\/filter\/filter.js":1,"profiles\/dkan\/modules\/dkan\/dkan_dataset\/js\/dkan_tooltip.js":1,"profiles\/dkan\/themes\/contrib\/radix\/assets\/js\/radix.script.js":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/js\/nuboot_radix.script.js":1,"sites\/all\/themes\/custom\/nuhealthdata\/assets\/js\/nuhealthdata.script.js":1},"css":{"modules\/system\/system.base.css":1,"modules\/system\/system.messages.css":1,"modules\/system\/system.theme.css":1,"misc\/ui\/jquery.ui.core.css":1,"misc\/ui\/jquery.ui.theme.css":1,"misc\/ui\/jquery.ui.tabs.css":1,"modules\/comment\/comment.css":1,"profiles\/dkan\/modules\/contrib\/date\/date_api\/date.css":1,"profiles\/dkan\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css":1,"profiles\/dkan\/modules\/dkan\/dkan_data_story\/css\/dkan_data_story.css":1,"profiles\/dkan\/modules\/dkan\/dkan_harvest\/modules\/dkan_harvest_dashboard\/css\/dkan_harvest_dashboard.css":1,"modules\/field\/theme\/field.css":1,"profiles\/dkan\/modules\/contrib\/field_hidden\/field_hidden.css":1,"modules\/node\/node.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets-spotlight.css":1,"profiles\/dkan\/modules\/contrib\/radix_layouts\/radix_layouts.css":1,"modules\/user\/user.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"profiles\/dkan\/modules\/contrib\/views\/css\/views.css":1,"profiles\/dkan\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/debut_blog\/debut_blog.css":1,"profiles\/dkan\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/modules\/contrib\/rate\/rate.css":1,"sites\/all\/modules\/contrib\/comment_goodness\/css\/disabled_actions.css":1,"profiles\/dkan\/libraries\/recline\/css\/grid.css":1,"profiles\/dkan\/libraries\/recline\/css\/slickgrid.css":1,"profiles\/dkan\/libraries\/recline\/css\/flot.css":1,"profiles\/dkan\/libraries\/recline\/css\/map.css":1,"profiles\/dkan\/libraries\/recline\/css\/multiview.css":1,"profiles\/dkan\/libraries\/recline\/css-site\/pygments.css":1,"profiles\/dkan\/libraries\/slickgrid\/slick.grid.css":1,"profiles\/dkan\/libraries\/leaflet\/dist\/leaflet.css":1,"profiles\/dkan\/libraries\/leaflet_markercluster\/dist\/MarkerCluster.css":1,"profiles\/dkan\/libraries\/leaflet_markercluster\/dist\/MarkerCluster.Default.css":1,"profiles\/dkan\/modules\/contrib\/recline\/recline.css":1,"modules\/filter\/filter.css":1,"sites\/all\/modules\/contrib\/dkan_feedback\/templates\/feedback\/feedback.css":1,"profiles\/dkan\/modules\/dkan\/dkan_topics\/theme\/dkan_topics.css":1,"\/\/fonts.googleapis.com\/css?family=Open+Sans::400,300,700":1,"public:\/\/font-icon-select-general-generated-1.css":1,"profiles\/dkan\/modules\/dkan\/dkan_dataset\/css\/dkan_dataset.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/nuboot_radix.style.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/dkan-flaticon.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/dkan-topics.css":1,"sites\/all\/themes\/custom\/nuhealthdata\/assets\/css\/nuhealthdata.style.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/print.css":1,"https:\/\/healthdata.gov\/sites\/default\/files\/colorizer\/nuhealthdata-bd90ffba.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie9.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie8.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_images\/panopoly-images.css":1}},"recline":{"file":"https:\/\/healthdata.gov\/sites\/default\/files\/reported_hospital_utilization_20210127_2205.csv","fileType":"text\/csv","fileSize":18814,"delimiter":",","grid":1,"graph":0,"map":0,"embed":0,"uuid":"38e07d07-40a2-4749-bfd3-68fefa42a61f","datastoreStatus":"dkan_datastore_3281086","maxSizePreview":3000000},"states":{"#edit-submit":{"disabled":{"textarea[name=\u0022comment_body[und][0][value]\u0022]":{"empty":true}}},"#edit-preview":{"disabled":{"textarea[name=\u0022comment_body[und][0][value]\u0022]":{"empty":true}}}},"urlIsAjaxTrusted":{"\/comment\/reply\/3281086":true,"\/node\/3281086\/revisions\/7491031\/view":true},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":0,"extSubdomains":1,"extExclude":"(healthdata\\.gov)|(localtest\\.me)","extInclude":"(twitter\\.com)|(facebook\\.com)|(linkedin\\.com)|(plus\\.google\\.com)|(www\\.reddit\\.com)","extCssExclude":"","extCssExplicit":"","extAlert":"_blank","extAlertText":"Endorsement Disclaimer - Links to Other Sites\n\nOur web site has links to many other federal agencies, and in a few cases we link to private organizations. You are subject to that site\u0027s privacy policy when you leave our site. We are not responsible for Section 508 compliance (accessibility) on other federal or private Web sites.\n\nReference in this web site to any specific commercial products, process, service, manufacturer, or company does not constitute its endorsement or recommendation by the U.S. Government or HHS. HHS is not responsible for the contents of any \u0022off-site\u0022 web page referenced from this server.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"}});
+//--><!]]>
+</script>
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-3281086 page-node-revisions page-node-revisions- page-node-revisions-7491031 page-node-revisions-view node-type-resource panel-layout-radix_sutro panel-region-column1 panel-region-column2 panel-region-header" >
+  <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K8VG67T"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+
+<!-- start USWDS BANNER -->
+  <section class="usa-banner" aria-label="Official government website">
+  <div class="container">
+    <header data-toggle="collapse" href="#gov-banner-default" role="button" aria-expanded="false" aria-controls="gov-banner-default">
+      <div class="usa-banner-inner">
+        <div class="usa-banner__header-flag"><img class="usa-banner__header-flag" src="/sites/all/themes/custom/nuhealthdata/assets/images/us_flag_small.png" alt="U.S. flag"></div>
+        <div class="usa-banner__header-text">An official website of the United States government</div>
+        <a class="usa-banner-link" aria-expanded="true" aria-controls="gov-banner-default">
+          Here’s how you know
+        </a>
+      </div>
+    </header>
+    <div class="collapse" id="gov-banner-default">
+      <div class="row clearfix">
+        <div class="guidance col-md-6">
+          <img class="usa-banner__icon" src="/sites/all/themes/custom/nuhealthdata/assets/images/icon-dot-gov.svg" role="img" alt="Dot gov">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Official websites use .gov</strong>
+              <br>
+              A <strong>.gov</strong> website belongs to an official government organization in the United States.
+            </p>
+          </div>
+        </div>
+        <div class="guidance col-md-6">
+          <img class="usa-banner__icon usa-media-block__img" src="/sites/all/themes/custom/nuhealthdata/assets/images/icon-https.svg" role="img" alt="Https">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Secure .gov websites use HTTPS</strong>
+              <br>
+              A <strong>lock</strong> (
+<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="18" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title-default banner-lock-description-default"><title id="banner-lock-title-default">Lock</title><desc id="banner-lock-description-default">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path></svg></span>
+) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+</section>
+<!-- end USWDS BANNER -->
+    <header id="header" class="header">
+  <div class="branding container">
+          <a class="logo navbar-btn pull-left" href="/" title="Home">
+        <img src="https://healthdata.gov/sites/default/files/logo.png" alt="Home" />
+      </a>
+            <!-- views exposed search -->
+    <section id="block-dkan-sitewide-dkan-sitewide-search-bar" class="block block-dkan-sitewide block-- clearfix">
+
+        <div class="content">
+    <form action="/node/3281086/revisions/7491031/view" method="post" id="dkan-sitewide-dataset-search-form" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-search form-group">
+  <label for="edit-search">Search </label>
+ <input placeholder="search" class="form-control form-text" type="text" id="edit-search" name="search" value="" size="30" maxlength="128" />
+</div>
+<input type="submit" id="edit-submit--2" name="op" value="" class="form-submit btn btn-default btn-primary" /><input type="hidden" name="form_build_id" value="form-d4kLcrX2ZZ1XHlhUmR2nbjuZSpGzhQg_-mcd67es14w" />
+<input type="hidden" name="form_id" value="dkan_sitewide_dataset_search_form" />
+</div></form>  </div>
+
+</section>
+  </div>
+  <div class="navigation-wrapper">
+    <div class="container">
+      <nav class="navbar navbar-default" role="navigation">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+        </div> <!-- /.navbar-header -->
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="navbar-collapse">
+                      <ul id="main-menu" class="menu nav navbar-nav">
+              <li class="first leaf menu-link-about"><a href="/content/about">About</a></li>
+<li class="leaf menu-link-datasets"><a href="/search/type/dataset" title="">Datasets</a></li>
+<li class="expanded dropdown menu-link-developers-"><a href="/node/86" class="dropdown-toggle" data-toggle="dropdown" data-target="#">Developers <span class="fa fa-caret-down"></span></a><ul class="dropdown-menu"><li class="first last leaf menu-link-healthdatagov-api"><a href="/api">HealthData.gov API</a></li>
+</ul></li>
+<li class="leaf menu-link-feedback"><a href="/feedback">Feedback</a></li>
+<li class="last leaf menu-link-covid-19-datasets"><a href="/search/type/dataset?query=covid-19&amp;sort_by=changed&amp;sort_order=DESC" title="Search for HHS COVID-19 data">COVID-19 Datasets</a></li>
+            </ul>
+          
+          <!-- user menu -->
+          <section id="block-dkan-sitewide-dkan-sitewide-user-menu" class="block block-dkan-sitewide block-- clearfix">
+
+        <div class="content">
+    <span class="links"><a href="/user/login">Log in</a></span>  </div>
+
+</section>
+        </div><!-- /.navbar-collapse -->
+      </nav><!-- /.navbar -->
+    </div><!-- /.container -->
+  </div> <!-- /.navigation -->
+</header>
+
+<div id="main-wrapper">
+  <div id="main" class="main container">
+
+    <ul class="breadcrumb"><li class="home-link"><a href="/"><i class="fa fa fa-home" aria-hidden="true"></i><span> Home</span></a></li><li><a href="/">Home</a></li><li><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749">COVID-19 Reported Patient Impact and Hospital Capacity by State</a></li><li><a href="/node/3281086/revisions">Revisions</a></li><li><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state">COVID-19 Reported Patient Impact and Hospital Capacity by State</a></li><li class="active-trail">COVID-19 Reported Patient Impact and Hospital Capacity by State - COVID-19 Reported Patient Impact and Hospital Capacity by State</li></ul>                <div class="region region-help">
+    <section id="block-system-help" class="block block-system block-- clearfix">
+
+        <div class="content">
+    <p>Revisions allow you to track differences between multiple versions of your content, and revert back to older versions.</p>
+  </div>
+
+</section>
+  </div>
+    
+
+    <div id="main-content" class="main-row">
+
+      <section>
+                                                  <div class="region region-content">
+    
+<div class="panel-display sutro clearfix radix-sutro" >
+
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12 radix-layouts-header panel-panel">
+        <div class="panel-panel-inner">
+          <div class="panel-pane pane-node-content"  >
+  
+        <h2 class="pane-title">
+      COVID-19 Reported Patient Impact and Hospital Capacity by State    </h2>
+    
+  
+  <div class="pane-content">
+    <article class="node node-resource clearfix">
+
+  
+      
+  
+  <div class="content">
+    <div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even"><p><strong>Updated: January 28, 2021 11:38 PM</strong></p>
+</div></div></div><div class="field field-name-field-upload field-type-recline-field field-label-hidden"><div class="field-items"><div class="field-item even"><div class="download"><a href="https://healthdata.gov/sites/default/files/reported_hospital_utilization_20210127_2205.csv" type="text/csv; length=18814" data-format="csv" class="format-label" title="reported_hospital_utilization_20210127_2205.csv">reported_hospital_utilization_20210127_2205.csv</a></div><div class="data-explorer-help"><i class="fa fa-info-circle" aria-hidden="true"></i> <strong>Data Preview:</strong> Note that by default the preview only displays up to 100 records. Use the pager to flip through more records or adjust the start and end fields to display the number of records you wish to see.</div><span class="data-explorer"></span></div></div></div>  </div>
+
+  
+  <div id="comments" class="comment-wrapper">
+  
+  
+  
+            <h2 class="title comment-form">Post new comment</h2>
+      <form class="comment-form" action="/comment/reply/3281086" method="post" id="comment-form" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-name form-group">
+  <label for="edit-name">Your name </label>
+ <input class="form-control form-text" type="text" id="edit-name" name="name" value="" size="30" maxlength="60" />
+</div>
+<div class="form-item form-type-textfield form-item-subject form-group">
+  <label for="edit-subject">Subject </label>
+ <input class="form-control form-text" type="text" id="edit-subject" name="subject" value="" size="60" maxlength="64" />
+</div>
+<div class="field-type-text-long field-name-comment-body field-widget-text-textarea form-wrapper" id="edit-comment-body"><div id="comment-body-add-more-wrapper"><div class="text-format-wrapper"><div class="form-item form-type-textarea form-item-comment-body-und-0-value form-group">
+  <label for="edit-comment-body-und-0-value">Comment <span class="form-required" title="This field is required.">*</span></label>
+ <div class="form-textarea-wrapper resizable"><textarea class="text-full form-textarea required" id="edit-comment-body-und-0-value" name="comment_body[und][0][value]" cols="60" rows="5"></textarea></div>
+</div>
+<fieldset class="filter-wrapper form-wrapper panel panel-default" id="edit-comment-body-und-0-format"><div class="panel-body fieldset-wrapper"><div class="filter-help form-wrapper" id="edit-comment-body-und-0-format-help"><p><a href="/filter/tips" target="_blank">More information about text formats</a></p></div><div class="filter-guidelines form-wrapper" id="edit-comment-body-und-0-format-guidelines"><div class="filter-guidelines-item filter-guidelines-plain_text"><h3>Plain text</h3><ul class="tips"><li>Web page addresses and e-mail addresses turn into links automatically.</li><li>Lines and paragraphs break automatically.</li></ul></div></div></div></fieldset>
+</div>
+</div></div><input type="hidden" name="form_build_id" value="form-ILHGiHlH6fe1r_jB8lwCbdX23Gi3KCHFV_6XhwVcC2w" />
+<input type="hidden" name="form_id" value="comment_node_resource_form" />
+<fieldset class="captcha form-wrapper panel panel-default"><legend class="panel-heading"><div class="panel-title fieldset-legend">CAPTCHA</div></legend><div class="panel-body fieldset-wrapper"><p class="help-block">This question is for testing whether or not you are a human visitor and to prevent automated spam submissions.</p><input type="hidden" name="captcha_sid" value="64321641" />
+<input type="hidden" name="captcha_token" value="5403d6f6e05aea45fd695d1205021e59" />
+<img src="/image_captcha?sid=64321641&amp;ts=1612381792" width="180" height="60" alt="Image CAPTCHA" title="Image CAPTCHA" /><div class="form-item form-type-textfield form-item-captcha-response form-group">
+  <label for="edit-captcha-response">What code is in the image? <span class="form-required" title="This field is required.">*</span></label>
+ <input class="form-control form-text required" type="text" id="edit-captcha-response" name="captcha_response" value="" size="15" maxlength="128" />
+<span class="help-block">Enter the characters shown in the image.</span>
+</div>
+</div></fieldset>
+<div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit" name="op" value="Save" class="form-submit btn btn-default btn-primary" /><input type="submit" id="edit-preview" name="op" value="Preview" class="form-submit btn btn-default" /></div></div></form>      </div>
+
+</article>
+  </div>
+
+  
+  </div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="row">
+      <div class="col-md-6 radix-layouts-column1 panel-panel">
+        <div class="panel-panel-inner">
+          <div class="panel-pane pane-block pane-dkan-dataset-dkan-dataset-resource-nodes"  >
+  
+        <h2 class="pane-title">
+      Resources    </h2>
+    
+  
+  <div class="pane-content">
+    <div class="item-list"><ul class="list-group"><li class="first last"><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749" class="list-group-item"><span>COVID-19 Reported Patient Impact and Hospital Capacity by State</span></a></li>
+</ul></div>  </div>
+
+  
+  </div>
+        </div>
+      </div>
+      <div class="col-md-6 radix-layouts-column2 panel-panel">
+        <div class="panel-panel-inner">
+          <div class="panel-pane pane-block pane-dkan-sitewide-dkan-sitewide-resource-add"  >
+  
+        <h2 class="pane-title">
+      Additional Information    </h2>
+    
+  
+  <div class="pane-content">
+    <div class="table-responsive"><table class="table table-striped table-bordered sticky-enabled">
+ <thead><tr><th>Field</th><th>Value</th> </tr></thead>
+<tbody>
+ <tr class="odd"><td>mimetype</td><td>text/csv</td> </tr>
+ <tr class="even"><td>filesize</td><td>18.37 KB</td> </tr>
+ <tr class="odd"><td>resource type</td><td>file upload</td> </tr>
+ <tr class="even"><td>timestamp</td><td>Jan 28, 2021</td> </tr>
+</tbody>
+</table>
+</div>  </div>
+
+  
+  </div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="row">
+      <div class="col-md-12 radix-layouts-footer panel-panel">
+        <div class="panel-panel-inner">
+                  </div>
+      </div>
+    </div>
+  </div>
+ 
+</div><!-- /.sutro -->
+  </div>
+      </section>
+
+    </div>
+
+  </div> <!-- /#main -->
+</div> <!-- /#main-wrapper -->
+
+<footer id="footer" class="footer">
+  <div class="container">
+          <small class="copyright pull-left"><p>A federal government website managed by the  <a href="https://www.hhs.gov/">U.S. Department of Health &amp; Human Services</a><br />200 Independence Avenue, S.W. - Washington, D.C. 20201</p>
+<ul class="links">
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://healthdata.gov/content/about">About Us</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/accessibility.html">Accessibilty</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/privacy.html">Privacy Policy</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/open/plain-writing/index.html">Plain Writing</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/disclaimer.html">Disclaimers</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/asa/eeo/resources/index.html">No FEAR</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/open">HHS.gov/Open</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/foia/">FOIA</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/">HHS.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="https://www.whitehouse.gov/">WhiteHouse.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.usa.gov/">USA.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.usa.gov/gobiernousa/">GobiernoUSA.gov</a></li>
+</ul>
+</small>
+        <small class="pull-right"></small>
+  </div>
+</footer>
+  <script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_29qYXJz8NLGg8Aomg-RZPjJcj9yEdEst1BMZ9gZbs-4.js"></script>
+<script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"b7126202e5","applicationID":"65779789","transactionName":"NlQDNRNTXkJTBxBcVg8eIAIVW19fHRQFUlw+XAAPAFVVQ20KC1FcPkcIBBZtQFBVAQ==","queueTime":0,"applicationTime":305,"atts":"GhMAQ1tJTUw=","errorBeacon":"bam.nr-data.net","agent":""}</script></body>
+</html>

--- a/testdata/acquisition/covid_hosp/state_daily/revision_0128.html
+++ b/testdata/acquisition/covid_hosp/state_daily/revision_0128.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
+  "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">
+<html lang="en" dir="ltr">
+<head profile="http://www.w3.org/1999/xhtml/vocab">
+
+  <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
+
+    {'gtm.start': new Date().getTime(),event:'gtm.js'}
+    );var f=d.getElementsByTagName(s)[0],
+
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+
+    })(window,document,'script','dataLayer','GTM-K8VG67T');</script>
+  <!-- End Google Tag Manager -->
+
+  <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
+  <meta charset="utf-8"><script type="text/javascript">(window.NREUM||(NREUM={})).loader_config={licenseKey:"b7126202e5",applicationID:"65779789"};window.NREUM||(NREUM={}),__nr_require=function(e,t,n){function r(n){if(!t[n]){var i=t[n]={exports:{}};e[n][0].call(i.exports,function(t){var i=e[n][1][t];return r(i||t)},i,i.exports)}return t[n].exports}if("function"==typeof __nr_require)return __nr_require;for(var i=0;i<n.length;i++)r(n[i]);return r}({1:[function(e,t,n){function r(){}function i(e,t,n){return function(){return o(e,[u.now()].concat(c(arguments)),t?null:this,n),t?void 0:this}}var o=e("handle"),a=e(6),c=e(7),f=e("ee").get("tracer"),u=e("loader"),s=NREUM;"undefined"==typeof window.newrelic&&(newrelic=s);var d=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],p="api-",l=p+"ixn-";a(d,function(e,t){s[t]=i(p+t,!0,"api")}),s.addPageAction=i(p+"addPageAction",!0),s.setCurrentRouteName=i(p+"routeName",!0),t.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,t){var n={},r=this,i="function"==typeof t;return o(l+"tracer",[u.now(),e,n],r),function(){if(f.emit((i?"":"no-")+"fn-start",[u.now(),r,i],n),i)try{return t.apply(this,arguments)}catch(e){throw f.emit("fn-err",[arguments,this,e],n),e}finally{f.emit("fn-end",[u.now()],n)}}}};a("actionText,setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(e,t){m[t]=i(l+t)}),newrelic.noticeError=function(e,t){"string"==typeof e&&(e=new Error(e)),o("err",[e,u.now(),!1,t])}},{}],2:[function(e,t,n){function r(){return c.exists&&performance.now?Math.round(performance.now()):(o=Math.max((new Date).getTime(),o))-a}function i(){return o}var o=(new Date).getTime(),a=o,c=e(8);t.exports=r,t.exports.offset=a,t.exports.getLastTimestamp=i},{}],3:[function(e,t,n){function r(e,t){var n=e.getEntries();n.forEach(function(e){"first-paint"===e.name?d("timing",["fp",Math.floor(e.startTime)]):"first-contentful-paint"===e.name&&d("timing",["fcp",Math.floor(e.startTime)])})}function i(e,t){var n=e.getEntries();n.length>0&&d("lcp",[n[n.length-1]])}function o(e){e.getEntries().forEach(function(e){e.hadRecentInput||d("cls",[e])})}function a(e){if(e instanceof m&&!g){var t=Math.round(e.timeStamp),n={type:e.type};t<=p.now()?n.fid=p.now()-t:t>p.offset&&t<=Date.now()?(t-=p.offset,n.fid=p.now()-t):t=p.now(),g=!0,d("timing",["fi",t,n])}}function c(e){d("pageHide",[p.now(),e])}if(!("init"in NREUM&&"page_view_timing"in NREUM.init&&"enabled"in NREUM.init.page_view_timing&&NREUM.init.page_view_timing.enabled===!1)){var f,u,s,d=e("handle"),p=e("loader"),l=e(5),m=NREUM.o.EV;if("PerformanceObserver"in window&&"function"==typeof window.PerformanceObserver){f=new PerformanceObserver(r);try{f.observe({entryTypes:["paint"]})}catch(v){}u=new PerformanceObserver(i);try{u.observe({entryTypes:["largest-contentful-paint"]})}catch(v){}s=new PerformanceObserver(o);try{s.observe({type:"layout-shift",buffered:!0})}catch(v){}}if("addEventListener"in document){var g=!1,w=["click","keydown","mousedown","pointerdown","touchstart"];w.forEach(function(e){document.addEventListener(e,a,!1)})}l(c)}},{}],4:[function(e,t,n){function r(e,t){if(!i)return!1;if(e!==i)return!1;if(!t)return!0;if(!o)return!1;for(var n=o.split("."),r=t.split("."),a=0;a<r.length;a++)if(r[a]!==n[a])return!1;return!0}var i=null,o=null,a=/Version\/(\S+)\s+Safari/;if(navigator.userAgent){var c=navigator.userAgent,f=c.match(a);f&&c.indexOf("Chrome")===-1&&c.indexOf("Chromium")===-1&&(i="Safari",o=f[1])}t.exports={agent:i,version:o,match:r}},{}],5:[function(e,t,n){function r(e){function t(){e(a&&document[a]?document[a]:document[i]?"hidden":"visible")}"addEventListener"in document&&o&&document.addEventListener(o,t,!1)}t.exports=r;var i,o,a;"undefined"!=typeof document.hidden?(i="hidden",o="visibilitychange",a="visibilityState"):"undefined"!=typeof document.msHidden?(i="msHidden",o="msvisibilitychange"):"undefined"!=typeof document.webkitHidden&&(i="webkitHidden",o="webkitvisibilitychange",a="webkitVisibilityState")},{}],6:[function(e,t,n){function r(e,t){var n=[],r="",o=0;for(r in e)i.call(e,r)&&(n[o]=t(r,e[r]),o+=1);return n}var i=Object.prototype.hasOwnProperty;t.exports=r},{}],7:[function(e,t,n){function r(e,t,n){t||(t=0),"undefined"==typeof n&&(n=e?e.length:0);for(var r=-1,i=n-t||0,o=Array(i<0?0:i);++r<i;)o[r]=e[t+r];return o}t.exports=r},{}],8:[function(e,t,n){t.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,t,n){function r(){}function i(e){function t(e){return e&&e instanceof r?e:e?u(e,f,a):a()}function n(n,r,i,o,a){if(a!==!1&&(a=!0),!l.aborted||o){e&&a&&e(n,r,i);for(var c=t(i),f=v(n),u=f.length,s=0;s<u;s++)f[s].apply(c,r);var p=d[h[n]];return p&&p.push([b,n,r,c]),c}}function o(e,t){y[e]=v(e).concat(t)}function m(e,t){var n=y[e];if(n)for(var r=0;r<n.length;r++)n[r]===t&&n.splice(r,1)}function v(e){return y[e]||[]}function g(e){return p[e]=p[e]||i(n)}function w(e,t){s(e,function(e,n){t=t||"feature",h[n]=t,t in d||(d[t]=[])})}var y={},h={},b={on:o,addEventListener:o,removeEventListener:m,emit:n,get:g,listeners:v,context:t,buffer:w,abort:c,aborted:!1};return b}function o(e){return u(e,f,a)}function a(){return new r}function c(){(d.api||d.feature)&&(l.aborted=!0,d=l.backlog={})}var f="nr@context",u=e("gos"),s=e(6),d={},p={},l=t.exports=i();t.exports.getOrSetContext=o,l.backlog=d},{}],gos:[function(e,t,n){function r(e,t,n){if(i.call(e,t))return e[t];var r=n();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,t,{value:r,writable:!0,enumerable:!1}),r}catch(o){}return e[t]=r,r}var i=Object.prototype.hasOwnProperty;t.exports=r},{}],handle:[function(e,t,n){function r(e,t,n,r){i.buffer([e],r),i.emit(e,t,n)}var i=e("ee").get("handle");t.exports=r,r.ee=i},{}],id:[function(e,t,n){function r(e){var t=typeof e;return!e||"object"!==t&&"function"!==t?-1:e===window?0:a(e,o,function(){return i++})}var i=1,o="nr@id",a=e("gos");t.exports=r},{}],loader:[function(e,t,n){function r(){if(!x++){var e=b.info=NREUM.info,t=p.getElementsByTagName("script")[0];if(setTimeout(u.abort,3e4),!(e&&e.licenseKey&&e.applicationID&&t))return u.abort();f(y,function(t,n){e[t]||(e[t]=n)});var n=a();c("mark",["onload",n+b.offset],null,"api"),c("timing",["load",n]);var r=p.createElement("script");r.src="https://"+e.agent,t.parentNode.insertBefore(r,t)}}function i(){"complete"===p.readyState&&o()}function o(){c("mark",["domContent",a()+b.offset],null,"api")}var a=e(2),c=e("handle"),f=e(6),u=e("ee"),s=e(4),d=window,p=d.document,l="addEventListener",m="attachEvent",v=d.XMLHttpRequest,g=v&&v.prototype;NREUM.o={ST:setTimeout,SI:d.setImmediate,CT:clearTimeout,XHR:v,REQ:d.Request,EV:d.Event,PR:d.Promise,MO:d.MutationObserver};var w=""+location,y={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-1194.min.js"},h=v&&g&&g[l]&&!/CriOS/.test(navigator.userAgent),b=t.exports={offset:a.getLastTimestamp(),now:a,origin:w,features:{},xhrWrappable:h,userAgent:s};e(1),e(3),p[l]?(p[l]("DOMContentLoaded",o,!1),d[l]("load",r,!1)):(p[m]("onreadystatechange",i),d[m]("onload",r)),c("mark",["firstbyte",a.getLastTimestamp()],null,"api");var x=0},{}],"wrap-function":[function(e,t,n){function r(e,t){function n(t,n,r,f,u){function nrWrapper(){var o,a,s,p;try{a=this,o=d(arguments),s="function"==typeof r?r(o,a):r||{}}catch(l){i([l,"",[o,a,f],s],e)}c(n+"start",[o,a,f],s,u);try{return p=t.apply(a,o)}catch(m){throw c(n+"err",[o,a,m],s,u),m}finally{c(n+"end",[o,a,p],s,u)}}return a(t)?t:(n||(n=""),nrWrapper[p]=t,o(t,nrWrapper,e),nrWrapper)}function r(e,t,r,i,o){r||(r="");var c,f,u,s="-"===r.charAt(0);for(u=0;u<t.length;u++)f=t[u],c=e[f],a(c)||(e[f]=n(c,s?f+r:r,i,f,o))}function c(n,r,o,a){if(!m||t){var c=m;m=!0;try{e.emit(n,r,o,t,a)}catch(f){i([f,n,r,o],e)}m=c}}return e||(e=s),n.inPlace=r,n.flag=p,n}function i(e,t){t||(t=s);try{t.emit("internal-error",e)}catch(n){}}function o(e,t,n){if(Object.defineProperty&&Object.keys)try{var r=Object.keys(e);return r.forEach(function(n){Object.defineProperty(t,n,{get:function(){return e[n]},set:function(t){return e[n]=t,t}})}),t}catch(o){i([o],n)}for(var a in e)l.call(e,a)&&(t[a]=e[a]);return t}function a(e){return!(e&&e instanceof Function&&e.apply&&!e[p])}function c(e,t){var n=t(e);return n[p]=e,o(e,n,s),n}function f(e,t,n){var r=e[t];e[t]=c(r,n)}function u(){for(var e=arguments.length,t=new Array(e),n=0;n<e;++n)t[n]=arguments[n];return t}var s=e("ee"),d=e(7),p="nr@original",l=Object.prototype.hasOwnProperty,m=!1;t.exports=r,t.exports.wrapFunction=c,t.exports.wrapInPlace=f,t.exports.argsToArray=u},{}]},{},["loader"]);</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="Generator" content="Drupal 7 (http://drupal.org)" />
+<link rel="canonical" href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749" />
+<link rel="shortlink" href="/node/3281086" />
+<link rel="shortcut icon" href="https://healthdata.gov/sites/all/themes/custom/nuhealthdata/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>COVID-19 Reported Patient Impact and Hospital Capacity by State - COVID-19 Reported Patient Impact and Hospital Capacity by State | HealthData.gov</title>
+  <link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_kShW4RPmRstZ3SpIC-ZvVGNFVAi0WEMuCnI0ZkYIaFw.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_zWS33JphQ8354vADCrYEXghZq-7dBSX_GVE0h2a882o.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_PclrG84jul3FzOPY6aecmDD2k_CB0QT-xKgHJqBcCek.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_aQiRaGwrQLA1xsKXFyh_7NruQm-7hS0jN00qLp0n4To.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans::400,300,700" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_M3GDWqGTIjDW5ochjX8aHUFPH81l8L3gWPBBCgGLTKk.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css__n9YKsq7xsXwEwMrfJhLwruizLxg3Cb0WQoeIyW7aQ0.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_E5LxTHvotstXfBsPxcRlLKjEwjXPfi49JcaYB4zerlY.css" media="print" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/colorizer/nuhealthdata-bd90ffba.css" media="all" />
+
+<!--[if lte IE 9]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_afrXmziPY13Y9oUhiVMbLllpNaAnF9oeeqCoWSAcphU.css" media="all" />
+<![endif]-->
+
+<!--[if IE 9]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_qpzT6Nla_9qnBw9yFCNlaMSx-mR1C2PUztgmhLWV6Xc.css" media="all" />
+<![endif]-->
+
+<!--[if IE 8]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_niVepbI1pyCvJmhl54aXP4kQl1P0eSi3jLWf68uRmCU.css" media="all" />
+<![endif]-->
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_PxsPpITToy8ZnO0bJDA1TEC6bbFpGTfSWr2ZP8LuFYo.css" media="all" />
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <link href="/css/ie.css" media="screen" rel="stylesheet" type="text/css" />
+  <![endif]-->
+  <script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_mOx0WHl6cNZI0fqrVldT0Ay6Zv7VRFDm9LexZoNN_NI.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.migrateMute=true;jQuery.migrateTrace=false;
+//--><!]]>
+</script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_KfaBLR-BltoahyKqWl-Gti4gX3P_ywCrBhJzxOpwENQ.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/profiles/dkan/themes/contrib/nuboot_radix/assets/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js__Bnv-OxH3VuVfkYMQRgUHa3xCAKCmG7XimGQPEMs8CY.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_MhcB1FN2UMLPCnR-GfDjthX1HNPWMcDaupqqkDbY3yI.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_gnAxee1bR7uyP3sjkMimmwHC8nKs6Zp8c_Ru3SHrTLA.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+L.Icon.Default.imagePath = "/profiles/dkan/libraries/recline/vendor/leaflet/1.0.2/images/"
+//--><!]]>
+</script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_REbMwQ6tX2snu6GJRSFgsJqXzTwQiAF0Hu4pjCqc0cE.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_yZom1RMJVpo8-qmlGUMfpdJmnX169UZ2gK75qjeIJLs.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"nuhealthdata","theme_token":"JLagsmTvHSlF7HBMAl-VbDhbG-3D9k1Yg2eZFpVVeP0","js":{"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets.js":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets-spotlight.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/jquery\/1.12\/jquery.min.js":1,"0":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/jquery-migrate\/1\/jquery-migrate.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"https:\/\/healthdata.gov\/profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/js\/bootstrap.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.widget.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.mouse.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.sortable.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.tabs.min.js":1,"misc\/form.js":1,"misc\/states.js":1,"profiles\/dkan\/modules\/contrib\/panopoly_images\/panopoly-images.js":1,"profiles\/dkan\/modules\/dkan\/dkan_plugins\/js\/colorPicker.behavior.js":1,"profiles\/dkan\/modules\/contrib\/recline\/js\/jsondataview.js":1,"profiles\/dkan\/modules\/contrib\/recline\/js\/restdataview.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"profiles\/dkan\/libraries\/jquery.imagesloaded\/jquery.imagesloaded.min.js":1,"misc\/tableheader.js":1,"sites\/all\/modules\/contrib\/comment_goodness\/comment_goodness.js":1,"sites\/all\/modules\/contrib\/captcha\/captcha.js":1,"profiles\/dkan\/libraries\/lodash\/dist\/lodash.compat.min.js":1,"profiles\/dkan\/libraries\/backbone\/backbone-min.js":1,"profiles\/dkan\/libraries\/recline\/dist\/recline.js":1,"profiles\/dkan\/libraries\/csv\/csv.js":1,"profiles\/dkan\/libraries\/jsxlsx\/dist\/xlsx.core.min.js":1,"profiles\/dkan\/libraries\/xls\/dist\/recline.backend.xlsx.min.js":1,"profiles\/dkan\/libraries\/mustache\/mustache.min.js":1,"profiles\/dkan\/libraries\/moment\/min\/moment.min.js":1,"profiles\/dkan\/libraries\/slickgrid\/lib\/jquery.event.drag-2.2.js":1,"profiles\/dkan\/libraries\/slickgrid\/lib\/jquery.event.drop-2.2.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.core.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.formatters.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.editors.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.grid.js":1,"profiles\/dkan\/libraries\/slickgrid\/lib\/jquery-ui-1.8.16.custom.min.js":1,"profiles\/dkan\/libraries\/slickgrid\/plugins\/slick.rowselectionmodel.js":1,"profiles\/dkan\/libraries\/slickgrid\/plugins\/slick.rowmovemanager.js":1,"profiles\/dkan\/libraries\/leaflet\/dist\/leaflet.js":1,"profiles\/dkan\/libraries\/flot\/jquery.flot.js":1,"profiles\/dkan\/libraries\/deep_diff\/releases\/deep-diff-0.3.0.min.js":1,"profiles\/dkan\/libraries\/recline_deeplink\/dist\/recline.deeplink.min.js":1,"profiles\/dkan\/libraries\/leaflet_markercluster\/dist\/leaflet.markercluster.js":1,"profiles\/dkan\/modules\/contrib\/recline\/backend.ckan_get.js":1,"profiles\/dkan\/modules\/contrib\/recline\/recline.js":1,"1":1,"misc\/textarea.js":1,"modules\/filter\/filter.js":1,"profiles\/dkan\/modules\/dkan\/dkan_dataset\/js\/dkan_tooltip.js":1,"profiles\/dkan\/themes\/contrib\/radix\/assets\/js\/radix.script.js":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/js\/nuboot_radix.script.js":1,"sites\/all\/themes\/custom\/nuhealthdata\/assets\/js\/nuhealthdata.script.js":1},"css":{"modules\/system\/system.base.css":1,"modules\/system\/system.messages.css":1,"modules\/system\/system.theme.css":1,"misc\/ui\/jquery.ui.core.css":1,"misc\/ui\/jquery.ui.theme.css":1,"misc\/ui\/jquery.ui.tabs.css":1,"modules\/comment\/comment.css":1,"profiles\/dkan\/modules\/contrib\/date\/date_api\/date.css":1,"profiles\/dkan\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css":1,"profiles\/dkan\/modules\/dkan\/dkan_data_story\/css\/dkan_data_story.css":1,"profiles\/dkan\/modules\/dkan\/dkan_harvest\/modules\/dkan_harvest_dashboard\/css\/dkan_harvest_dashboard.css":1,"modules\/field\/theme\/field.css":1,"profiles\/dkan\/modules\/contrib\/field_hidden\/field_hidden.css":1,"modules\/node\/node.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets-spotlight.css":1,"profiles\/dkan\/modules\/contrib\/radix_layouts\/radix_layouts.css":1,"modules\/user\/user.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"profiles\/dkan\/modules\/contrib\/views\/css\/views.css":1,"profiles\/dkan\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/debut_blog\/debut_blog.css":1,"profiles\/dkan\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/modules\/contrib\/rate\/rate.css":1,"sites\/all\/modules\/contrib\/comment_goodness\/css\/disabled_actions.css":1,"profiles\/dkan\/libraries\/recline\/css\/grid.css":1,"profiles\/dkan\/libraries\/recline\/css\/slickgrid.css":1,"profiles\/dkan\/libraries\/recline\/css\/flot.css":1,"profiles\/dkan\/libraries\/recline\/css\/map.css":1,"profiles\/dkan\/libraries\/recline\/css\/multiview.css":1,"profiles\/dkan\/libraries\/recline\/css-site\/pygments.css":1,"profiles\/dkan\/libraries\/slickgrid\/slick.grid.css":1,"profiles\/dkan\/libraries\/leaflet\/dist\/leaflet.css":1,"profiles\/dkan\/libraries\/leaflet_markercluster\/dist\/MarkerCluster.css":1,"profiles\/dkan\/libraries\/leaflet_markercluster\/dist\/MarkerCluster.Default.css":1,"profiles\/dkan\/modules\/contrib\/recline\/recline.css":1,"modules\/filter\/filter.css":1,"sites\/all\/modules\/contrib\/dkan_feedback\/templates\/feedback\/feedback.css":1,"profiles\/dkan\/modules\/dkan\/dkan_topics\/theme\/dkan_topics.css":1,"\/\/fonts.googleapis.com\/css?family=Open+Sans::400,300,700":1,"public:\/\/font-icon-select-general-generated-1.css":1,"profiles\/dkan\/modules\/dkan\/dkan_dataset\/css\/dkan_dataset.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/nuboot_radix.style.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/dkan-flaticon.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/dkan-topics.css":1,"sites\/all\/themes\/custom\/nuhealthdata\/assets\/css\/nuhealthdata.style.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/print.css":1,"https:\/\/healthdata.gov\/sites\/default\/files\/colorizer\/nuhealthdata-bd90ffba.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie9.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie8.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_images\/panopoly-images.css":1}},"recline":{"file":"https:\/\/healthdata.gov\/sites\/default\/files\/reported_hospital_utilization_20210128_2205.csv","fileType":"text\/csv","fileSize":18803,"delimiter":",","grid":1,"graph":0,"map":0,"embed":0,"uuid":"38e07d07-40a2-4749-bfd3-68fefa42a61f","datastoreStatus":"dkan_datastore_3281086","maxSizePreview":3000000},"states":{"#edit-submit":{"disabled":{"textarea[name=\u0022comment_body[und][0][value]\u0022]":{"empty":true}}},"#edit-preview":{"disabled":{"textarea[name=\u0022comment_body[und][0][value]\u0022]":{"empty":true}}}},"urlIsAjaxTrusted":{"\/comment\/reply\/3281086":true,"\/node\/3281086\/revisions\/7498686\/view":true},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":0,"extSubdomains":1,"extExclude":"(healthdata\\.gov)|(localtest\\.me)","extInclude":"(twitter\\.com)|(facebook\\.com)|(linkedin\\.com)|(plus\\.google\\.com)|(www\\.reddit\\.com)","extCssExclude":"","extCssExplicit":"","extAlert":"_blank","extAlertText":"Endorsement Disclaimer - Links to Other Sites\n\nOur web site has links to many other federal agencies, and in a few cases we link to private organizations. You are subject to that site\u0027s privacy policy when you leave our site. We are not responsible for Section 508 compliance (accessibility) on other federal or private Web sites.\n\nReference in this web site to any specific commercial products, process, service, manufacturer, or company does not constitute its endorsement or recommendation by the U.S. Government or HHS. HHS is not responsible for the contents of any \u0022off-site\u0022 web page referenced from this server.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"}});
+//--><!]]>
+</script>
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-3281086 page-node-revisions page-node-revisions- page-node-revisions-7498686 page-node-revisions-view node-type-resource panel-layout-radix_sutro panel-region-column1 panel-region-column2 panel-region-header" >
+  <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K8VG67T"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+
+<!-- start USWDS BANNER -->
+  <section class="usa-banner" aria-label="Official government website">
+  <div class="container">
+    <header data-toggle="collapse" href="#gov-banner-default" role="button" aria-expanded="false" aria-controls="gov-banner-default">
+      <div class="usa-banner-inner">
+        <div class="usa-banner__header-flag"><img class="usa-banner__header-flag" src="/sites/all/themes/custom/nuhealthdata/assets/images/us_flag_small.png" alt="U.S. flag"></div>
+        <div class="usa-banner__header-text">An official website of the United States government</div>
+        <a class="usa-banner-link" aria-expanded="true" aria-controls="gov-banner-default">
+          Here’s how you know
+        </a>
+      </div>
+    </header>
+    <div class="collapse" id="gov-banner-default">
+      <div class="row clearfix">
+        <div class="guidance col-md-6">
+          <img class="usa-banner__icon" src="/sites/all/themes/custom/nuhealthdata/assets/images/icon-dot-gov.svg" role="img" alt="Dot gov">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Official websites use .gov</strong>
+              <br>
+              A <strong>.gov</strong> website belongs to an official government organization in the United States.
+            </p>
+          </div>
+        </div>
+        <div class="guidance col-md-6">
+          <img class="usa-banner__icon usa-media-block__img" src="/sites/all/themes/custom/nuhealthdata/assets/images/icon-https.svg" role="img" alt="Https">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Secure .gov websites use HTTPS</strong>
+              <br>
+              A <strong>lock</strong> (
+<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="18" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title-default banner-lock-description-default"><title id="banner-lock-title-default">Lock</title><desc id="banner-lock-description-default">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path></svg></span>
+) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+</section>
+<!-- end USWDS BANNER -->
+    <header id="header" class="header">
+  <div class="branding container">
+          <a class="logo navbar-btn pull-left" href="/" title="Home">
+        <img src="https://healthdata.gov/sites/default/files/logo.png" alt="Home" />
+      </a>
+            <!-- views exposed search -->
+    <section id="block-dkan-sitewide-dkan-sitewide-search-bar" class="block block-dkan-sitewide block-- clearfix">
+
+        <div class="content">
+    <form action="/node/3281086/revisions/7498686/view" method="post" id="dkan-sitewide-dataset-search-form" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-search form-group">
+  <label for="edit-search">Search </label>
+ <input placeholder="search" class="form-control form-text" type="text" id="edit-search" name="search" value="" size="30" maxlength="128" />
+</div>
+<input type="submit" id="edit-submit--2" name="op" value="" class="form-submit btn btn-default btn-primary" /><input type="hidden" name="form_build_id" value="form-uRHnOLr2Wy34MidNiLhDVGKgb1HdOOoKAKZfPfRkW0A" />
+<input type="hidden" name="form_id" value="dkan_sitewide_dataset_search_form" />
+</div></form>  </div>
+
+</section>
+  </div>
+  <div class="navigation-wrapper">
+    <div class="container">
+      <nav class="navbar navbar-default" role="navigation">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+        </div> <!-- /.navbar-header -->
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="navbar-collapse">
+                      <ul id="main-menu" class="menu nav navbar-nav">
+              <li class="first leaf menu-link-about"><a href="/content/about">About</a></li>
+<li class="leaf menu-link-datasets"><a href="/search/type/dataset" title="">Datasets</a></li>
+<li class="expanded dropdown menu-link-developers-"><a href="/node/86" class="dropdown-toggle" data-toggle="dropdown" data-target="#">Developers <span class="fa fa-caret-down"></span></a><ul class="dropdown-menu"><li class="first last leaf menu-link-healthdatagov-api"><a href="/api">HealthData.gov API</a></li>
+</ul></li>
+<li class="leaf menu-link-feedback"><a href="/feedback">Feedback</a></li>
+<li class="last leaf menu-link-covid-19-datasets"><a href="/search/type/dataset?query=covid-19&amp;sort_by=changed&amp;sort_order=DESC" title="Search for HHS COVID-19 data">COVID-19 Datasets</a></li>
+            </ul>
+          
+          <!-- user menu -->
+          <section id="block-dkan-sitewide-dkan-sitewide-user-menu" class="block block-dkan-sitewide block-- clearfix">
+
+        <div class="content">
+    <span class="links"><a href="/user/login">Log in</a></span>  </div>
+
+</section>
+        </div><!-- /.navbar-collapse -->
+      </nav><!-- /.navbar -->
+    </div><!-- /.container -->
+  </div> <!-- /.navigation -->
+</header>
+
+<div id="main-wrapper">
+  <div id="main" class="main container">
+
+    <ul class="breadcrumb"><li class="home-link"><a href="/"><i class="fa fa fa-home" aria-hidden="true"></i><span> Home</span></a></li><li><a href="/">Home</a></li><li><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749">COVID-19 Reported Patient Impact and Hospital Capacity by State</a></li><li><a href="/node/3281086/revisions">Revisions</a></li><li><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state">COVID-19 Reported Patient Impact and Hospital Capacity by State</a></li><li class="active-trail">COVID-19 Reported Patient Impact and Hospital Capacity by State - COVID-19 Reported Patient Impact and Hospital Capacity by State</li></ul>                <div class="region region-help">
+    <section id="block-system-help" class="block block-system block-- clearfix">
+
+        <div class="content">
+    <p>Revisions allow you to track differences between multiple versions of your content, and revert back to older versions.</p>
+  </div>
+
+</section>
+  </div>
+    
+
+    <div id="main-content" class="main-row">
+
+      <section>
+                                                  <div class="region region-content">
+    
+<div class="panel-display sutro clearfix radix-sutro" >
+
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12 radix-layouts-header panel-panel">
+        <div class="panel-panel-inner">
+          <div class="panel-pane pane-node-content"  >
+  
+        <h2 class="pane-title">
+      COVID-19 Reported Patient Impact and Hospital Capacity by State    </h2>
+    
+  
+  <div class="pane-content">
+    <article class="node node-resource clearfix">
+
+  
+      
+  
+  <div class="content">
+    <div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even"><p><strong>Updated: January 30, 2021 11:59 PM</strong></p>
+</div></div></div><div class="field field-name-field-upload field-type-recline-field field-label-hidden"><div class="field-items"><div class="field-item even"><div class="download"><a href="https://healthdata.gov/sites/default/files/reported_hospital_utilization_20210128_2205.csv" type="text/csv; length=18803" data-format="csv" class="format-label" title="reported_hospital_utilization_20210128_2205.csv">reported_hospital_utilization_20210128_2205.csv</a></div><div class="data-explorer-help"><i class="fa fa-info-circle" aria-hidden="true"></i> <strong>Data Preview:</strong> Note that by default the preview only displays up to 100 records. Use the pager to flip through more records or adjust the start and end fields to display the number of records you wish to see.</div><span class="data-explorer"></span></div></div></div>  </div>
+
+  
+  <div id="comments" class="comment-wrapper">
+  
+  
+  
+            <h2 class="title comment-form">Post new comment</h2>
+      <form class="comment-form" action="/comment/reply/3281086" method="post" id="comment-form" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-name form-group">
+  <label for="edit-name">Your name </label>
+ <input class="form-control form-text" type="text" id="edit-name" name="name" value="" size="30" maxlength="60" />
+</div>
+<div class="form-item form-type-textfield form-item-subject form-group">
+  <label for="edit-subject">Subject </label>
+ <input class="form-control form-text" type="text" id="edit-subject" name="subject" value="" size="60" maxlength="64" />
+</div>
+<div class="field-type-text-long field-name-comment-body field-widget-text-textarea form-wrapper" id="edit-comment-body"><div id="comment-body-add-more-wrapper"><div class="text-format-wrapper"><div class="form-item form-type-textarea form-item-comment-body-und-0-value form-group">
+  <label for="edit-comment-body-und-0-value">Comment <span class="form-required" title="This field is required.">*</span></label>
+ <div class="form-textarea-wrapper resizable"><textarea class="text-full form-textarea required" id="edit-comment-body-und-0-value" name="comment_body[und][0][value]" cols="60" rows="5"></textarea></div>
+</div>
+<fieldset class="filter-wrapper form-wrapper panel panel-default" id="edit-comment-body-und-0-format"><div class="panel-body fieldset-wrapper"><div class="filter-help form-wrapper" id="edit-comment-body-und-0-format-help"><p><a href="/filter/tips" target="_blank">More information about text formats</a></p></div><div class="filter-guidelines form-wrapper" id="edit-comment-body-und-0-format-guidelines"><div class="filter-guidelines-item filter-guidelines-plain_text"><h3>Plain text</h3><ul class="tips"><li>Web page addresses and e-mail addresses turn into links automatically.</li><li>Lines and paragraphs break automatically.</li></ul></div></div></div></fieldset>
+</div>
+</div></div><input type="hidden" name="form_build_id" value="form-R1t3yDvzojUp7IXj15v622v8RELydq1amoWZx_6DalQ" />
+<input type="hidden" name="form_id" value="comment_node_resource_form" />
+<fieldset class="captcha form-wrapper panel panel-default"><legend class="panel-heading"><div class="panel-title fieldset-legend">CAPTCHA</div></legend><div class="panel-body fieldset-wrapper"><p class="help-block">This question is for testing whether or not you are a human visitor and to prevent automated spam submissions.</p><input type="hidden" name="captcha_sid" value="64312616" />
+<input type="hidden" name="captcha_token" value="3c89b420179d73e85e5268c1640f13dc" />
+<img src="/image_captcha?sid=64312616&amp;ts=1612364411" width="180" height="60" alt="Image CAPTCHA" title="Image CAPTCHA" /><div class="form-item form-type-textfield form-item-captcha-response form-group">
+  <label for="edit-captcha-response">What code is in the image? <span class="form-required" title="This field is required.">*</span></label>
+ <input class="form-control form-text required" type="text" id="edit-captcha-response" name="captcha_response" value="" size="15" maxlength="128" />
+<span class="help-block">Enter the characters shown in the image.</span>
+</div>
+</div></fieldset>
+<div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit" name="op" value="Save" class="form-submit btn btn-default btn-primary" /><input type="submit" id="edit-preview" name="op" value="Preview" class="form-submit btn btn-default" /></div></div></form>      </div>
+
+</article>
+  </div>
+
+  
+  </div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="row">
+      <div class="col-md-6 radix-layouts-column1 panel-panel">
+        <div class="panel-panel-inner">
+          <div class="panel-pane pane-block pane-dkan-dataset-dkan-dataset-resource-nodes"  >
+  
+        <h2 class="pane-title">
+      Resources    </h2>
+    
+  
+  <div class="pane-content">
+    <div class="item-list"><ul class="list-group"><li class="first last"><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749" class="list-group-item"><span>COVID-19 Reported Patient Impact and Hospital Capacity by State</span></a></li>
+</ul></div>  </div>
+
+  
+  </div>
+        </div>
+      </div>
+      <div class="col-md-6 radix-layouts-column2 panel-panel">
+        <div class="panel-panel-inner">
+          <div class="panel-pane pane-block pane-dkan-sitewide-dkan-sitewide-resource-add"  >
+  
+        <h2 class="pane-title">
+      Additional Information    </h2>
+    
+  
+  <div class="pane-content">
+    <div class="table-responsive"><table class="table table-striped table-bordered sticky-enabled">
+ <thead><tr><th>Field</th><th>Value</th> </tr></thead>
+<tbody>
+ <tr class="odd"><td>mimetype</td><td>text/csv</td> </tr>
+ <tr class="even"><td>filesize</td><td>18.36 KB</td> </tr>
+ <tr class="odd"><td>resource type</td><td>file upload</td> </tr>
+ <tr class="even"><td>timestamp</td><td>Jan 30, 2021</td> </tr>
+</tbody>
+</table>
+</div>  </div>
+
+  
+  </div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="row">
+      <div class="col-md-12 radix-layouts-footer panel-panel">
+        <div class="panel-panel-inner">
+                  </div>
+      </div>
+    </div>
+  </div>
+ 
+</div><!-- /.sutro -->
+  </div>
+      </section>
+
+    </div>
+
+  </div> <!-- /#main -->
+</div> <!-- /#main-wrapper -->
+
+<footer id="footer" class="footer">
+  <div class="container">
+          <small class="copyright pull-left"><p>A federal government website managed by the  <a href="https://www.hhs.gov/">U.S. Department of Health &amp; Human Services</a><br />200 Independence Avenue, S.W. - Washington, D.C. 20201</p>
+<ul class="links">
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://healthdata.gov/content/about">About Us</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/accessibility.html">Accessibilty</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/privacy.html">Privacy Policy</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/open/plain-writing/index.html">Plain Writing</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/disclaimer.html">Disclaimers</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/asa/eeo/resources/index.html">No FEAR</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/open">HHS.gov/Open</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/foia/">FOIA</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/">HHS.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="https://www.whitehouse.gov/">WhiteHouse.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.usa.gov/">USA.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.usa.gov/gobiernousa/">GobiernoUSA.gov</a></li>
+</ul>
+</small>
+        <small class="pull-right"></small>
+  </div>
+</footer>
+  <script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_29qYXJz8NLGg8Aomg-RZPjJcj9yEdEst1BMZ9gZbs-4.js"></script>
+<script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"b7126202e5","applicationID":"65779789","transactionName":"NlQDNRNTXkJTBxBcVg8eIAIVW19fHRQFUlw+XAAPAFVVQ20KC1FcPkcIBBZtQFBVAQ==","queueTime":0,"applicationTime":230,"atts":"GhMAQ1tJTUw=","errorBeacon":"bam.nr-data.net","agent":""}</script></body>
+</html>

--- a/testdata/acquisition/covid_hosp/state_daily/revision_0129.html
+++ b/testdata/acquisition/covid_hosp/state_daily/revision_0129.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
+  "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">
+<html lang="en" dir="ltr">
+<head profile="http://www.w3.org/1999/xhtml/vocab">
+
+  <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
+
+    {'gtm.start': new Date().getTime(),event:'gtm.js'}
+    );var f=d.getElementsByTagName(s)[0],
+
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+
+    })(window,document,'script','dataLayer','GTM-K8VG67T');</script>
+  <!-- End Google Tag Manager -->
+
+  <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
+  <meta charset="utf-8"><script type="text/javascript">(window.NREUM||(NREUM={})).loader_config={licenseKey:"b7126202e5",applicationID:"65779789"};window.NREUM||(NREUM={}),__nr_require=function(e,t,n){function r(n){if(!t[n]){var i=t[n]={exports:{}};e[n][0].call(i.exports,function(t){var i=e[n][1][t];return r(i||t)},i,i.exports)}return t[n].exports}if("function"==typeof __nr_require)return __nr_require;for(var i=0;i<n.length;i++)r(n[i]);return r}({1:[function(e,t,n){function r(){}function i(e,t,n){return function(){return o(e,[u.now()].concat(c(arguments)),t?null:this,n),t?void 0:this}}var o=e("handle"),a=e(6),c=e(7),f=e("ee").get("tracer"),u=e("loader"),s=NREUM;"undefined"==typeof window.newrelic&&(newrelic=s);var d=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],p="api-",l=p+"ixn-";a(d,function(e,t){s[t]=i(p+t,!0,"api")}),s.addPageAction=i(p+"addPageAction",!0),s.setCurrentRouteName=i(p+"routeName",!0),t.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,t){var n={},r=this,i="function"==typeof t;return o(l+"tracer",[u.now(),e,n],r),function(){if(f.emit((i?"":"no-")+"fn-start",[u.now(),r,i],n),i)try{return t.apply(this,arguments)}catch(e){throw f.emit("fn-err",[arguments,this,e],n),e}finally{f.emit("fn-end",[u.now()],n)}}}};a("actionText,setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(e,t){m[t]=i(l+t)}),newrelic.noticeError=function(e,t){"string"==typeof e&&(e=new Error(e)),o("err",[e,u.now(),!1,t])}},{}],2:[function(e,t,n){function r(){return c.exists&&performance.now?Math.round(performance.now()):(o=Math.max((new Date).getTime(),o))-a}function i(){return o}var o=(new Date).getTime(),a=o,c=e(8);t.exports=r,t.exports.offset=a,t.exports.getLastTimestamp=i},{}],3:[function(e,t,n){function r(e,t){var n=e.getEntries();n.forEach(function(e){"first-paint"===e.name?d("timing",["fp",Math.floor(e.startTime)]):"first-contentful-paint"===e.name&&d("timing",["fcp",Math.floor(e.startTime)])})}function i(e,t){var n=e.getEntries();n.length>0&&d("lcp",[n[n.length-1]])}function o(e){e.getEntries().forEach(function(e){e.hadRecentInput||d("cls",[e])})}function a(e){if(e instanceof m&&!g){var t=Math.round(e.timeStamp),n={type:e.type};t<=p.now()?n.fid=p.now()-t:t>p.offset&&t<=Date.now()?(t-=p.offset,n.fid=p.now()-t):t=p.now(),g=!0,d("timing",["fi",t,n])}}function c(e){d("pageHide",[p.now(),e])}if(!("init"in NREUM&&"page_view_timing"in NREUM.init&&"enabled"in NREUM.init.page_view_timing&&NREUM.init.page_view_timing.enabled===!1)){var f,u,s,d=e("handle"),p=e("loader"),l=e(5),m=NREUM.o.EV;if("PerformanceObserver"in window&&"function"==typeof window.PerformanceObserver){f=new PerformanceObserver(r);try{f.observe({entryTypes:["paint"]})}catch(v){}u=new PerformanceObserver(i);try{u.observe({entryTypes:["largest-contentful-paint"]})}catch(v){}s=new PerformanceObserver(o);try{s.observe({type:"layout-shift",buffered:!0})}catch(v){}}if("addEventListener"in document){var g=!1,w=["click","keydown","mousedown","pointerdown","touchstart"];w.forEach(function(e){document.addEventListener(e,a,!1)})}l(c)}},{}],4:[function(e,t,n){function r(e,t){if(!i)return!1;if(e!==i)return!1;if(!t)return!0;if(!o)return!1;for(var n=o.split("."),r=t.split("."),a=0;a<r.length;a++)if(r[a]!==n[a])return!1;return!0}var i=null,o=null,a=/Version\/(\S+)\s+Safari/;if(navigator.userAgent){var c=navigator.userAgent,f=c.match(a);f&&c.indexOf("Chrome")===-1&&c.indexOf("Chromium")===-1&&(i="Safari",o=f[1])}t.exports={agent:i,version:o,match:r}},{}],5:[function(e,t,n){function r(e){function t(){e(a&&document[a]?document[a]:document[i]?"hidden":"visible")}"addEventListener"in document&&o&&document.addEventListener(o,t,!1)}t.exports=r;var i,o,a;"undefined"!=typeof document.hidden?(i="hidden",o="visibilitychange",a="visibilityState"):"undefined"!=typeof document.msHidden?(i="msHidden",o="msvisibilitychange"):"undefined"!=typeof document.webkitHidden&&(i="webkitHidden",o="webkitvisibilitychange",a="webkitVisibilityState")},{}],6:[function(e,t,n){function r(e,t){var n=[],r="",o=0;for(r in e)i.call(e,r)&&(n[o]=t(r,e[r]),o+=1);return n}var i=Object.prototype.hasOwnProperty;t.exports=r},{}],7:[function(e,t,n){function r(e,t,n){t||(t=0),"undefined"==typeof n&&(n=e?e.length:0);for(var r=-1,i=n-t||0,o=Array(i<0?0:i);++r<i;)o[r]=e[t+r];return o}t.exports=r},{}],8:[function(e,t,n){t.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,t,n){function r(){}function i(e){function t(e){return e&&e instanceof r?e:e?u(e,f,a):a()}function n(n,r,i,o,a){if(a!==!1&&(a=!0),!l.aborted||o){e&&a&&e(n,r,i);for(var c=t(i),f=v(n),u=f.length,s=0;s<u;s++)f[s].apply(c,r);var p=d[h[n]];return p&&p.push([b,n,r,c]),c}}function o(e,t){y[e]=v(e).concat(t)}function m(e,t){var n=y[e];if(n)for(var r=0;r<n.length;r++)n[r]===t&&n.splice(r,1)}function v(e){return y[e]||[]}function g(e){return p[e]=p[e]||i(n)}function w(e,t){s(e,function(e,n){t=t||"feature",h[n]=t,t in d||(d[t]=[])})}var y={},h={},b={on:o,addEventListener:o,removeEventListener:m,emit:n,get:g,listeners:v,context:t,buffer:w,abort:c,aborted:!1};return b}function o(e){return u(e,f,a)}function a(){return new r}function c(){(d.api||d.feature)&&(l.aborted=!0,d=l.backlog={})}var f="nr@context",u=e("gos"),s=e(6),d={},p={},l=t.exports=i();t.exports.getOrSetContext=o,l.backlog=d},{}],gos:[function(e,t,n){function r(e,t,n){if(i.call(e,t))return e[t];var r=n();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,t,{value:r,writable:!0,enumerable:!1}),r}catch(o){}return e[t]=r,r}var i=Object.prototype.hasOwnProperty;t.exports=r},{}],handle:[function(e,t,n){function r(e,t,n,r){i.buffer([e],r),i.emit(e,t,n)}var i=e("ee").get("handle");t.exports=r,r.ee=i},{}],id:[function(e,t,n){function r(e){var t=typeof e;return!e||"object"!==t&&"function"!==t?-1:e===window?0:a(e,o,function(){return i++})}var i=1,o="nr@id",a=e("gos");t.exports=r},{}],loader:[function(e,t,n){function r(){if(!x++){var e=b.info=NREUM.info,t=p.getElementsByTagName("script")[0];if(setTimeout(u.abort,3e4),!(e&&e.licenseKey&&e.applicationID&&t))return u.abort();f(y,function(t,n){e[t]||(e[t]=n)});var n=a();c("mark",["onload",n+b.offset],null,"api"),c("timing",["load",n]);var r=p.createElement("script");r.src="https://"+e.agent,t.parentNode.insertBefore(r,t)}}function i(){"complete"===p.readyState&&o()}function o(){c("mark",["domContent",a()+b.offset],null,"api")}var a=e(2),c=e("handle"),f=e(6),u=e("ee"),s=e(4),d=window,p=d.document,l="addEventListener",m="attachEvent",v=d.XMLHttpRequest,g=v&&v.prototype;NREUM.o={ST:setTimeout,SI:d.setImmediate,CT:clearTimeout,XHR:v,REQ:d.Request,EV:d.Event,PR:d.Promise,MO:d.MutationObserver};var w=""+location,y={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-1194.min.js"},h=v&&g&&g[l]&&!/CriOS/.test(navigator.userAgent),b=t.exports={offset:a.getLastTimestamp(),now:a,origin:w,features:{},xhrWrappable:h,userAgent:s};e(1),e(3),p[l]?(p[l]("DOMContentLoaded",o,!1),d[l]("load",r,!1)):(p[m]("onreadystatechange",i),d[m]("onload",r)),c("mark",["firstbyte",a.getLastTimestamp()],null,"api");var x=0},{}],"wrap-function":[function(e,t,n){function r(e,t){function n(t,n,r,f,u){function nrWrapper(){var o,a,s,p;try{a=this,o=d(arguments),s="function"==typeof r?r(o,a):r||{}}catch(l){i([l,"",[o,a,f],s],e)}c(n+"start",[o,a,f],s,u);try{return p=t.apply(a,o)}catch(m){throw c(n+"err",[o,a,m],s,u),m}finally{c(n+"end",[o,a,p],s,u)}}return a(t)?t:(n||(n=""),nrWrapper[p]=t,o(t,nrWrapper,e),nrWrapper)}function r(e,t,r,i,o){r||(r="");var c,f,u,s="-"===r.charAt(0);for(u=0;u<t.length;u++)f=t[u],c=e[f],a(c)||(e[f]=n(c,s?f+r:r,i,f,o))}function c(n,r,o,a){if(!m||t){var c=m;m=!0;try{e.emit(n,r,o,t,a)}catch(f){i([f,n,r,o],e)}m=c}}return e||(e=s),n.inPlace=r,n.flag=p,n}function i(e,t){t||(t=s);try{t.emit("internal-error",e)}catch(n){}}function o(e,t,n){if(Object.defineProperty&&Object.keys)try{var r=Object.keys(e);return r.forEach(function(n){Object.defineProperty(t,n,{get:function(){return e[n]},set:function(t){return e[n]=t,t}})}),t}catch(o){i([o],n)}for(var a in e)l.call(e,a)&&(t[a]=e[a]);return t}function a(e){return!(e&&e instanceof Function&&e.apply&&!e[p])}function c(e,t){var n=t(e);return n[p]=e,o(e,n,s),n}function f(e,t,n){var r=e[t];e[t]=c(r,n)}function u(){for(var e=arguments.length,t=new Array(e),n=0;n<e;++n)t[n]=arguments[n];return t}var s=e("ee"),d=e(7),p="nr@original",l=Object.prototype.hasOwnProperty,m=!1;t.exports=r,t.exports.wrapFunction=c,t.exports.wrapInPlace=f,t.exports.argsToArray=u},{}]},{},["loader"]);</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="Generator" content="Drupal 7 (http://drupal.org)" />
+<link rel="canonical" href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749" />
+<link rel="shortlink" href="/node/3281086" />
+<link rel="shortcut icon" href="https://healthdata.gov/sites/all/themes/custom/nuhealthdata/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>COVID-19 Reported Patient Impact and Hospital Capacity by State - COVID-19 Reported Patient Impact and Hospital Capacity by State | HealthData.gov</title>
+  <link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_kShW4RPmRstZ3SpIC-ZvVGNFVAi0WEMuCnI0ZkYIaFw.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_zWS33JphQ8354vADCrYEXghZq-7dBSX_GVE0h2a882o.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_PclrG84jul3FzOPY6aecmDD2k_CB0QT-xKgHJqBcCek.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_aQiRaGwrQLA1xsKXFyh_7NruQm-7hS0jN00qLp0n4To.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans::400,300,700" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_M3GDWqGTIjDW5ochjX8aHUFPH81l8L3gWPBBCgGLTKk.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css__n9YKsq7xsXwEwMrfJhLwruizLxg3Cb0WQoeIyW7aQ0.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_E5LxTHvotstXfBsPxcRlLKjEwjXPfi49JcaYB4zerlY.css" media="print" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/colorizer/nuhealthdata-bd90ffba.css" media="all" />
+
+<!--[if lte IE 9]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_afrXmziPY13Y9oUhiVMbLllpNaAnF9oeeqCoWSAcphU.css" media="all" />
+<![endif]-->
+
+<!--[if IE 9]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_qpzT6Nla_9qnBw9yFCNlaMSx-mR1C2PUztgmhLWV6Xc.css" media="all" />
+<![endif]-->
+
+<!--[if IE 8]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_niVepbI1pyCvJmhl54aXP4kQl1P0eSi3jLWf68uRmCU.css" media="all" />
+<![endif]-->
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_PxsPpITToy8ZnO0bJDA1TEC6bbFpGTfSWr2ZP8LuFYo.css" media="all" />
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <link href="/css/ie.css" media="screen" rel="stylesheet" type="text/css" />
+  <![endif]-->
+  <script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_mOx0WHl6cNZI0fqrVldT0Ay6Zv7VRFDm9LexZoNN_NI.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.migrateMute=true;jQuery.migrateTrace=false;
+//--><!]]>
+</script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_KfaBLR-BltoahyKqWl-Gti4gX3P_ywCrBhJzxOpwENQ.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/profiles/dkan/themes/contrib/nuboot_radix/assets/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js__Bnv-OxH3VuVfkYMQRgUHa3xCAKCmG7XimGQPEMs8CY.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_MhcB1FN2UMLPCnR-GfDjthX1HNPWMcDaupqqkDbY3yI.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_gnAxee1bR7uyP3sjkMimmwHC8nKs6Zp8c_Ru3SHrTLA.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+L.Icon.Default.imagePath = "/profiles/dkan/libraries/recline/vendor/leaflet/1.0.2/images/"
+//--><!]]>
+</script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_REbMwQ6tX2snu6GJRSFgsJqXzTwQiAF0Hu4pjCqc0cE.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_yZom1RMJVpo8-qmlGUMfpdJmnX169UZ2gK75qjeIJLs.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"nuhealthdata","theme_token":"2Xm74uCT2AGsSlWUOiBkgxkxX101ayRhrQGctKz8wXk","js":{"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets.js":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets-spotlight.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/jquery\/1.12\/jquery.min.js":1,"0":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/jquery-migrate\/1\/jquery-migrate.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"https:\/\/healthdata.gov\/profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/js\/bootstrap.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.widget.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.mouse.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.sortable.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.tabs.min.js":1,"misc\/form.js":1,"misc\/states.js":1,"profiles\/dkan\/modules\/contrib\/panopoly_images\/panopoly-images.js":1,"profiles\/dkan\/modules\/dkan\/dkan_plugins\/js\/colorPicker.behavior.js":1,"profiles\/dkan\/modules\/contrib\/recline\/js\/jsondataview.js":1,"profiles\/dkan\/modules\/contrib\/recline\/js\/restdataview.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"profiles\/dkan\/libraries\/jquery.imagesloaded\/jquery.imagesloaded.min.js":1,"misc\/tableheader.js":1,"sites\/all\/modules\/contrib\/comment_goodness\/comment_goodness.js":1,"sites\/all\/modules\/contrib\/captcha\/captcha.js":1,"profiles\/dkan\/libraries\/lodash\/dist\/lodash.compat.min.js":1,"profiles\/dkan\/libraries\/backbone\/backbone-min.js":1,"profiles\/dkan\/libraries\/recline\/dist\/recline.js":1,"profiles\/dkan\/libraries\/csv\/csv.js":1,"profiles\/dkan\/libraries\/jsxlsx\/dist\/xlsx.core.min.js":1,"profiles\/dkan\/libraries\/xls\/dist\/recline.backend.xlsx.min.js":1,"profiles\/dkan\/libraries\/mustache\/mustache.min.js":1,"profiles\/dkan\/libraries\/moment\/min\/moment.min.js":1,"profiles\/dkan\/libraries\/slickgrid\/lib\/jquery.event.drag-2.2.js":1,"profiles\/dkan\/libraries\/slickgrid\/lib\/jquery.event.drop-2.2.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.core.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.formatters.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.editors.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.grid.js":1,"profiles\/dkan\/libraries\/slickgrid\/lib\/jquery-ui-1.8.16.custom.min.js":1,"profiles\/dkan\/libraries\/slickgrid\/plugins\/slick.rowselectionmodel.js":1,"profiles\/dkan\/libraries\/slickgrid\/plugins\/slick.rowmovemanager.js":1,"profiles\/dkan\/libraries\/leaflet\/dist\/leaflet.js":1,"profiles\/dkan\/libraries\/flot\/jquery.flot.js":1,"profiles\/dkan\/libraries\/deep_diff\/releases\/deep-diff-0.3.0.min.js":1,"profiles\/dkan\/libraries\/recline_deeplink\/dist\/recline.deeplink.min.js":1,"profiles\/dkan\/libraries\/leaflet_markercluster\/dist\/leaflet.markercluster.js":1,"profiles\/dkan\/modules\/contrib\/recline\/backend.ckan_get.js":1,"profiles\/dkan\/modules\/contrib\/recline\/recline.js":1,"1":1,"misc\/textarea.js":1,"modules\/filter\/filter.js":1,"profiles\/dkan\/modules\/dkan\/dkan_dataset\/js\/dkan_tooltip.js":1,"profiles\/dkan\/themes\/contrib\/radix\/assets\/js\/radix.script.js":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/js\/nuboot_radix.script.js":1,"sites\/all\/themes\/custom\/nuhealthdata\/assets\/js\/nuhealthdata.script.js":1},"css":{"modules\/system\/system.base.css":1,"modules\/system\/system.messages.css":1,"modules\/system\/system.theme.css":1,"misc\/ui\/jquery.ui.core.css":1,"misc\/ui\/jquery.ui.theme.css":1,"misc\/ui\/jquery.ui.tabs.css":1,"modules\/comment\/comment.css":1,"profiles\/dkan\/modules\/contrib\/date\/date_api\/date.css":1,"profiles\/dkan\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css":1,"profiles\/dkan\/modules\/dkan\/dkan_data_story\/css\/dkan_data_story.css":1,"profiles\/dkan\/modules\/dkan\/dkan_harvest\/modules\/dkan_harvest_dashboard\/css\/dkan_harvest_dashboard.css":1,"modules\/field\/theme\/field.css":1,"profiles\/dkan\/modules\/contrib\/field_hidden\/field_hidden.css":1,"modules\/node\/node.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets-spotlight.css":1,"profiles\/dkan\/modules\/contrib\/radix_layouts\/radix_layouts.css":1,"modules\/user\/user.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"profiles\/dkan\/modules\/contrib\/views\/css\/views.css":1,"profiles\/dkan\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/debut_blog\/debut_blog.css":1,"profiles\/dkan\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/modules\/contrib\/rate\/rate.css":1,"sites\/all\/modules\/contrib\/comment_goodness\/css\/disabled_actions.css":1,"profiles\/dkan\/libraries\/recline\/css\/grid.css":1,"profiles\/dkan\/libraries\/recline\/css\/slickgrid.css":1,"profiles\/dkan\/libraries\/recline\/css\/flot.css":1,"profiles\/dkan\/libraries\/recline\/css\/map.css":1,"profiles\/dkan\/libraries\/recline\/css\/multiview.css":1,"profiles\/dkan\/libraries\/recline\/css-site\/pygments.css":1,"profiles\/dkan\/libraries\/slickgrid\/slick.grid.css":1,"profiles\/dkan\/libraries\/leaflet\/dist\/leaflet.css":1,"profiles\/dkan\/libraries\/leaflet_markercluster\/dist\/MarkerCluster.css":1,"profiles\/dkan\/libraries\/leaflet_markercluster\/dist\/MarkerCluster.Default.css":1,"profiles\/dkan\/modules\/contrib\/recline\/recline.css":1,"modules\/filter\/filter.css":1,"sites\/all\/modules\/contrib\/dkan_feedback\/templates\/feedback\/feedback.css":1,"profiles\/dkan\/modules\/dkan\/dkan_topics\/theme\/dkan_topics.css":1,"\/\/fonts.googleapis.com\/css?family=Open+Sans::400,300,700":1,"public:\/\/font-icon-select-general-generated-1.css":1,"profiles\/dkan\/modules\/dkan\/dkan_dataset\/css\/dkan_dataset.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/nuboot_radix.style.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/dkan-flaticon.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/dkan-topics.css":1,"sites\/all\/themes\/custom\/nuhealthdata\/assets\/css\/nuhealthdata.style.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/print.css":1,"https:\/\/healthdata.gov\/sites\/default\/files\/colorizer\/nuhealthdata-bd90ffba.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie9.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie8.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_images\/panopoly-images.css":1}},"recline":{"file":"https:\/\/healthdata.gov\/sites\/default\/files\/reported_hospital_utilization_20210129_1606.csv","fileType":"text\/csv","fileSize":18775,"delimiter":",","grid":1,"graph":0,"map":0,"embed":0,"uuid":"38e07d07-40a2-4749-bfd3-68fefa42a61f","datastoreStatus":"dkan_datastore_3281086","maxSizePreview":3000000},"states":{"#edit-submit":{"disabled":{"textarea[name=\u0022comment_body[und][0][value]\u0022]":{"empty":true}}},"#edit-preview":{"disabled":{"textarea[name=\u0022comment_body[und][0][value]\u0022]":{"empty":true}}}},"urlIsAjaxTrusted":{"\/comment\/reply\/3281086":true,"\/node\/3281086\/revisions\/7498721\/view":true},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":0,"extSubdomains":1,"extExclude":"(healthdata\\.gov)|(localtest\\.me)","extInclude":"(twitter\\.com)|(facebook\\.com)|(linkedin\\.com)|(plus\\.google\\.com)|(www\\.reddit\\.com)","extCssExclude":"","extCssExplicit":"","extAlert":"_blank","extAlertText":"Endorsement Disclaimer - Links to Other Sites\n\nOur web site has links to many other federal agencies, and in a few cases we link to private organizations. You are subject to that site\u0027s privacy policy when you leave our site. We are not responsible for Section 508 compliance (accessibility) on other federal or private Web sites.\n\nReference in this web site to any specific commercial products, process, service, manufacturer, or company does not constitute its endorsement or recommendation by the U.S. Government or HHS. HHS is not responsible for the contents of any \u0022off-site\u0022 web page referenced from this server.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"}});
+//--><!]]>
+</script>
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-3281086 page-node-revisions page-node-revisions- page-node-revisions-7498721 page-node-revisions-view node-type-resource panel-layout-radix_sutro panel-region-column1 panel-region-column2 panel-region-header" >
+  <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K8VG67T"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+
+<!-- start USWDS BANNER -->
+  <section class="usa-banner" aria-label="Official government website">
+  <div class="container">
+    <header data-toggle="collapse" href="#gov-banner-default" role="button" aria-expanded="false" aria-controls="gov-banner-default">
+      <div class="usa-banner-inner">
+        <div class="usa-banner__header-flag"><img class="usa-banner__header-flag" src="/sites/all/themes/custom/nuhealthdata/assets/images/us_flag_small.png" alt="U.S. flag"></div>
+        <div class="usa-banner__header-text">An official website of the United States government</div>
+        <a class="usa-banner-link" aria-expanded="true" aria-controls="gov-banner-default">
+          Here’s how you know
+        </a>
+      </div>
+    </header>
+    <div class="collapse" id="gov-banner-default">
+      <div class="row clearfix">
+        <div class="guidance col-md-6">
+          <img class="usa-banner__icon" src="/sites/all/themes/custom/nuhealthdata/assets/images/icon-dot-gov.svg" role="img" alt="Dot gov">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Official websites use .gov</strong>
+              <br>
+              A <strong>.gov</strong> website belongs to an official government organization in the United States.
+            </p>
+          </div>
+        </div>
+        <div class="guidance col-md-6">
+          <img class="usa-banner__icon usa-media-block__img" src="/sites/all/themes/custom/nuhealthdata/assets/images/icon-https.svg" role="img" alt="Https">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Secure .gov websites use HTTPS</strong>
+              <br>
+              A <strong>lock</strong> (
+<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="18" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title-default banner-lock-description-default"><title id="banner-lock-title-default">Lock</title><desc id="banner-lock-description-default">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path></svg></span>
+) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+</section>
+<!-- end USWDS BANNER -->
+    <header id="header" class="header">
+  <div class="branding container">
+          <a class="logo navbar-btn pull-left" href="/" title="Home">
+        <img src="https://healthdata.gov/sites/default/files/logo.png" alt="Home" />
+      </a>
+            <!-- views exposed search -->
+    <section id="block-dkan-sitewide-dkan-sitewide-search-bar" class="block block-dkan-sitewide block-- clearfix">
+
+        <div class="content">
+    <form action="/node/3281086/revisions/7498721/view" method="post" id="dkan-sitewide-dataset-search-form" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-search form-group">
+  <label for="edit-search">Search </label>
+ <input placeholder="search" class="form-control form-text" type="text" id="edit-search" name="search" value="" size="30" maxlength="128" />
+</div>
+<input type="submit" id="edit-submit--2" name="op" value="" class="form-submit btn btn-default btn-primary" /><input type="hidden" name="form_build_id" value="form-pTOoUaZy4NY9uTs6eYBfQtT89Xd7KhsKN7ijxjhlVkI" />
+<input type="hidden" name="form_id" value="dkan_sitewide_dataset_search_form" />
+</div></form>  </div>
+
+</section>
+  </div>
+  <div class="navigation-wrapper">
+    <div class="container">
+      <nav class="navbar navbar-default" role="navigation">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+        </div> <!-- /.navbar-header -->
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="navbar-collapse">
+                      <ul id="main-menu" class="menu nav navbar-nav">
+              <li class="first leaf menu-link-about"><a href="/content/about">About</a></li>
+<li class="leaf menu-link-datasets"><a href="/search/type/dataset" title="">Datasets</a></li>
+<li class="expanded dropdown menu-link-developers-"><a href="/node/86" class="dropdown-toggle" data-toggle="dropdown" data-target="#">Developers <span class="fa fa-caret-down"></span></a><ul class="dropdown-menu"><li class="first last leaf menu-link-healthdatagov-api"><a href="/api">HealthData.gov API</a></li>
+</ul></li>
+<li class="leaf menu-link-feedback"><a href="/feedback">Feedback</a></li>
+<li class="last leaf menu-link-covid-19-datasets"><a href="/search/type/dataset?query=covid-19&amp;sort_by=changed&amp;sort_order=DESC" title="Search for HHS COVID-19 data">COVID-19 Datasets</a></li>
+            </ul>
+          
+          <!-- user menu -->
+          <section id="block-dkan-sitewide-dkan-sitewide-user-menu" class="block block-dkan-sitewide block-- clearfix">
+
+        <div class="content">
+    <span class="links"><a href="/user/login">Log in</a></span>  </div>
+
+</section>
+        </div><!-- /.navbar-collapse -->
+      </nav><!-- /.navbar -->
+    </div><!-- /.container -->
+  </div> <!-- /.navigation -->
+</header>
+
+<div id="main-wrapper">
+  <div id="main" class="main container">
+
+    <ul class="breadcrumb"><li class="home-link"><a href="/"><i class="fa fa fa-home" aria-hidden="true"></i><span> Home</span></a></li><li><a href="/">Home</a></li><li><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749">COVID-19 Reported Patient Impact and Hospital Capacity by State</a></li><li><a href="/node/3281086/revisions">Revisions</a></li><li><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state">COVID-19 Reported Patient Impact and Hospital Capacity by State</a></li><li class="active-trail">COVID-19 Reported Patient Impact and Hospital Capacity by State - COVID-19 Reported Patient Impact and Hospital Capacity by State</li></ul>                <div class="region region-help">
+    <section id="block-system-help" class="block block-system block-- clearfix">
+
+        <div class="content">
+    <p>Revisions allow you to track differences between multiple versions of your content, and revert back to older versions.</p>
+  </div>
+
+</section>
+  </div>
+    
+
+    <div id="main-content" class="main-row">
+
+      <section>
+                                                  <div class="region region-content">
+    
+<div class="panel-display sutro clearfix radix-sutro" >
+
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12 radix-layouts-header panel-panel">
+        <div class="panel-panel-inner">
+          <div class="panel-pane pane-node-content"  >
+  
+        <h2 class="pane-title">
+      COVID-19 Reported Patient Impact and Hospital Capacity by State    </h2>
+    
+  
+  <div class="pane-content">
+    <article class="node node-resource clearfix">
+
+  
+      
+  
+  <div class="content">
+    <div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even"><p><strong>Updated: January 31, 2021 12:00 AM</strong></p>
+</div></div></div><div class="field field-name-field-upload field-type-recline-field field-label-hidden"><div class="field-items"><div class="field-item even"><div class="download"><a href="https://healthdata.gov/sites/default/files/reported_hospital_utilization_20210129_1606.csv" type="text/csv; length=18775" data-format="csv" class="format-label" title="reported_hospital_utilization_20210129_1606.csv">reported_hospital_utilization_20210129_1606.csv</a></div><div class="data-explorer-help"><i class="fa fa-info-circle" aria-hidden="true"></i> <strong>Data Preview:</strong> Note that by default the preview only displays up to 100 records. Use the pager to flip through more records or adjust the start and end fields to display the number of records you wish to see.</div><span class="data-explorer"></span></div></div></div>  </div>
+
+  
+  <div id="comments" class="comment-wrapper">
+  
+  
+  
+            <h2 class="title comment-form">Post new comment</h2>
+      <form class="comment-form" action="/comment/reply/3281086" method="post" id="comment-form" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-name form-group">
+  <label for="edit-name">Your name </label>
+ <input class="form-control form-text" type="text" id="edit-name" name="name" value="" size="30" maxlength="60" />
+</div>
+<div class="form-item form-type-textfield form-item-subject form-group">
+  <label for="edit-subject">Subject </label>
+ <input class="form-control form-text" type="text" id="edit-subject" name="subject" value="" size="60" maxlength="64" />
+</div>
+<div class="field-type-text-long field-name-comment-body field-widget-text-textarea form-wrapper" id="edit-comment-body"><div id="comment-body-add-more-wrapper"><div class="text-format-wrapper"><div class="form-item form-type-textarea form-item-comment-body-und-0-value form-group">
+  <label for="edit-comment-body-und-0-value">Comment <span class="form-required" title="This field is required.">*</span></label>
+ <div class="form-textarea-wrapper resizable"><textarea class="text-full form-textarea required" id="edit-comment-body-und-0-value" name="comment_body[und][0][value]" cols="60" rows="5"></textarea></div>
+</div>
+<fieldset class="filter-wrapper form-wrapper panel panel-default" id="edit-comment-body-und-0-format"><div class="panel-body fieldset-wrapper"><div class="filter-help form-wrapper" id="edit-comment-body-und-0-format-help"><p><a href="/filter/tips" target="_blank">More information about text formats</a></p></div><div class="filter-guidelines form-wrapper" id="edit-comment-body-und-0-format-guidelines"><div class="filter-guidelines-item filter-guidelines-plain_text"><h3>Plain text</h3><ul class="tips"><li>Web page addresses and e-mail addresses turn into links automatically.</li><li>Lines and paragraphs break automatically.</li></ul></div></div></div></fieldset>
+</div>
+</div></div><input type="hidden" name="form_build_id" value="form-2vc-GXpi45bZGsG3MltL3XiMt3OJApwz6fUVBAAr0F8" />
+<input type="hidden" name="form_id" value="comment_node_resource_form" />
+<fieldset class="captcha form-wrapper panel panel-default"><legend class="panel-heading"><div class="panel-title fieldset-legend">CAPTCHA</div></legend><div class="panel-body fieldset-wrapper"><p class="help-block">This question is for testing whether or not you are a human visitor and to prevent automated spam submissions.</p><input type="hidden" name="captcha_sid" value="64312601" />
+<input type="hidden" name="captcha_token" value="b65d5a40e01d2f1ccb3302859ae91187" />
+<img src="/image_captcha?sid=64312601&amp;ts=1612364398" width="180" height="60" alt="Image CAPTCHA" title="Image CAPTCHA" /><div class="form-item form-type-textfield form-item-captcha-response form-group">
+  <label for="edit-captcha-response">What code is in the image? <span class="form-required" title="This field is required.">*</span></label>
+ <input class="form-control form-text required" type="text" id="edit-captcha-response" name="captcha_response" value="" size="15" maxlength="128" />
+<span class="help-block">Enter the characters shown in the image.</span>
+</div>
+</div></fieldset>
+<div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit" name="op" value="Save" class="form-submit btn btn-default btn-primary" /><input type="submit" id="edit-preview" name="op" value="Preview" class="form-submit btn btn-default" /></div></div></form>      </div>
+
+</article>
+  </div>
+
+  
+  </div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="row">
+      <div class="col-md-6 radix-layouts-column1 panel-panel">
+        <div class="panel-panel-inner">
+          <div class="panel-pane pane-block pane-dkan-dataset-dkan-dataset-resource-nodes"  >
+  
+        <h2 class="pane-title">
+      Resources    </h2>
+    
+  
+  <div class="pane-content">
+    <div class="item-list"><ul class="list-group"><li class="first last"><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749" class="list-group-item"><span>COVID-19 Reported Patient Impact and Hospital Capacity by State</span></a></li>
+</ul></div>  </div>
+
+  
+  </div>
+        </div>
+      </div>
+      <div class="col-md-6 radix-layouts-column2 panel-panel">
+        <div class="panel-panel-inner">
+          <div class="panel-pane pane-block pane-dkan-sitewide-dkan-sitewide-resource-add"  >
+  
+        <h2 class="pane-title">
+      Additional Information    </h2>
+    
+  
+  <div class="pane-content">
+    <div class="table-responsive"><table class="table table-striped table-bordered sticky-enabled">
+ <thead><tr><th>Field</th><th>Value</th> </tr></thead>
+<tbody>
+ <tr class="odd"><td>mimetype</td><td>text/csv</td> </tr>
+ <tr class="even"><td>filesize</td><td>18.33 KB</td> </tr>
+ <tr class="odd"><td>resource type</td><td>file upload</td> </tr>
+ <tr class="even"><td>timestamp</td><td>Jan 31, 2021</td> </tr>
+</tbody>
+</table>
+</div>  </div>
+
+  
+  </div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="row">
+      <div class="col-md-12 radix-layouts-footer panel-panel">
+        <div class="panel-panel-inner">
+                  </div>
+      </div>
+    </div>
+  </div>
+ 
+</div><!-- /.sutro -->
+  </div>
+      </section>
+
+    </div>
+
+  </div> <!-- /#main -->
+</div> <!-- /#main-wrapper -->
+
+<footer id="footer" class="footer">
+  <div class="container">
+          <small class="copyright pull-left"><p>A federal government website managed by the  <a href="https://www.hhs.gov/">U.S. Department of Health &amp; Human Services</a><br />200 Independence Avenue, S.W. - Washington, D.C. 20201</p>
+<ul class="links">
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://healthdata.gov/content/about">About Us</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/accessibility.html">Accessibilty</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/privacy.html">Privacy Policy</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/open/plain-writing/index.html">Plain Writing</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/disclaimer.html">Disclaimers</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/asa/eeo/resources/index.html">No FEAR</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/open">HHS.gov/Open</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/foia/">FOIA</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/">HHS.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="https://www.whitehouse.gov/">WhiteHouse.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.usa.gov/">USA.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.usa.gov/gobiernousa/">GobiernoUSA.gov</a></li>
+</ul>
+</small>
+        <small class="pull-right"></small>
+  </div>
+</footer>
+  <script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_29qYXJz8NLGg8Aomg-RZPjJcj9yEdEst1BMZ9gZbs-4.js"></script>
+<script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"b7126202e5","applicationID":"65779789","transactionName":"NlQDNRNTXkJTBxBcVg8eIAIVW19fHRQFUlw+XAAPAFVVQ20KC1FcPkcIBBZtQFBVAQ==","queueTime":0,"applicationTime":390,"atts":"GhMAQ1tJTUw=","errorBeacon":"bam.nr-data.net","agent":""}</script></body>
+</html>

--- a/testdata/acquisition/covid_hosp/state_daily/revision_0130.html
+++ b/testdata/acquisition/covid_hosp/state_daily/revision_0130.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
+  "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">
+<html lang="en" dir="ltr">
+<head profile="http://www.w3.org/1999/xhtml/vocab">
+
+  <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
+
+    {'gtm.start': new Date().getTime(),event:'gtm.js'}
+    );var f=d.getElementsByTagName(s)[0],
+
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+
+    })(window,document,'script','dataLayer','GTM-K8VG67T');</script>
+  <!-- End Google Tag Manager -->
+
+  <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
+  <meta charset="utf-8"><script type="text/javascript">(window.NREUM||(NREUM={})).loader_config={licenseKey:"b7126202e5",applicationID:"65779789"};window.NREUM||(NREUM={}),__nr_require=function(e,t,n){function r(n){if(!t[n]){var i=t[n]={exports:{}};e[n][0].call(i.exports,function(t){var i=e[n][1][t];return r(i||t)},i,i.exports)}return t[n].exports}if("function"==typeof __nr_require)return __nr_require;for(var i=0;i<n.length;i++)r(n[i]);return r}({1:[function(e,t,n){function r(){}function i(e,t,n){return function(){return o(e,[u.now()].concat(c(arguments)),t?null:this,n),t?void 0:this}}var o=e("handle"),a=e(6),c=e(7),f=e("ee").get("tracer"),u=e("loader"),s=NREUM;"undefined"==typeof window.newrelic&&(newrelic=s);var d=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],p="api-",l=p+"ixn-";a(d,function(e,t){s[t]=i(p+t,!0,"api")}),s.addPageAction=i(p+"addPageAction",!0),s.setCurrentRouteName=i(p+"routeName",!0),t.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,t){var n={},r=this,i="function"==typeof t;return o(l+"tracer",[u.now(),e,n],r),function(){if(f.emit((i?"":"no-")+"fn-start",[u.now(),r,i],n),i)try{return t.apply(this,arguments)}catch(e){throw f.emit("fn-err",[arguments,this,e],n),e}finally{f.emit("fn-end",[u.now()],n)}}}};a("actionText,setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(e,t){m[t]=i(l+t)}),newrelic.noticeError=function(e,t){"string"==typeof e&&(e=new Error(e)),o("err",[e,u.now(),!1,t])}},{}],2:[function(e,t,n){function r(){return c.exists&&performance.now?Math.round(performance.now()):(o=Math.max((new Date).getTime(),o))-a}function i(){return o}var o=(new Date).getTime(),a=o,c=e(8);t.exports=r,t.exports.offset=a,t.exports.getLastTimestamp=i},{}],3:[function(e,t,n){function r(e,t){var n=e.getEntries();n.forEach(function(e){"first-paint"===e.name?d("timing",["fp",Math.floor(e.startTime)]):"first-contentful-paint"===e.name&&d("timing",["fcp",Math.floor(e.startTime)])})}function i(e,t){var n=e.getEntries();n.length>0&&d("lcp",[n[n.length-1]])}function o(e){e.getEntries().forEach(function(e){e.hadRecentInput||d("cls",[e])})}function a(e){if(e instanceof m&&!g){var t=Math.round(e.timeStamp),n={type:e.type};t<=p.now()?n.fid=p.now()-t:t>p.offset&&t<=Date.now()?(t-=p.offset,n.fid=p.now()-t):t=p.now(),g=!0,d("timing",["fi",t,n])}}function c(e){d("pageHide",[p.now(),e])}if(!("init"in NREUM&&"page_view_timing"in NREUM.init&&"enabled"in NREUM.init.page_view_timing&&NREUM.init.page_view_timing.enabled===!1)){var f,u,s,d=e("handle"),p=e("loader"),l=e(5),m=NREUM.o.EV;if("PerformanceObserver"in window&&"function"==typeof window.PerformanceObserver){f=new PerformanceObserver(r);try{f.observe({entryTypes:["paint"]})}catch(v){}u=new PerformanceObserver(i);try{u.observe({entryTypes:["largest-contentful-paint"]})}catch(v){}s=new PerformanceObserver(o);try{s.observe({type:"layout-shift",buffered:!0})}catch(v){}}if("addEventListener"in document){var g=!1,w=["click","keydown","mousedown","pointerdown","touchstart"];w.forEach(function(e){document.addEventListener(e,a,!1)})}l(c)}},{}],4:[function(e,t,n){function r(e,t){if(!i)return!1;if(e!==i)return!1;if(!t)return!0;if(!o)return!1;for(var n=o.split("."),r=t.split("."),a=0;a<r.length;a++)if(r[a]!==n[a])return!1;return!0}var i=null,o=null,a=/Version\/(\S+)\s+Safari/;if(navigator.userAgent){var c=navigator.userAgent,f=c.match(a);f&&c.indexOf("Chrome")===-1&&c.indexOf("Chromium")===-1&&(i="Safari",o=f[1])}t.exports={agent:i,version:o,match:r}},{}],5:[function(e,t,n){function r(e){function t(){e(a&&document[a]?document[a]:document[i]?"hidden":"visible")}"addEventListener"in document&&o&&document.addEventListener(o,t,!1)}t.exports=r;var i,o,a;"undefined"!=typeof document.hidden?(i="hidden",o="visibilitychange",a="visibilityState"):"undefined"!=typeof document.msHidden?(i="msHidden",o="msvisibilitychange"):"undefined"!=typeof document.webkitHidden&&(i="webkitHidden",o="webkitvisibilitychange",a="webkitVisibilityState")},{}],6:[function(e,t,n){function r(e,t){var n=[],r="",o=0;for(r in e)i.call(e,r)&&(n[o]=t(r,e[r]),o+=1);return n}var i=Object.prototype.hasOwnProperty;t.exports=r},{}],7:[function(e,t,n){function r(e,t,n){t||(t=0),"undefined"==typeof n&&(n=e?e.length:0);for(var r=-1,i=n-t||0,o=Array(i<0?0:i);++r<i;)o[r]=e[t+r];return o}t.exports=r},{}],8:[function(e,t,n){t.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,t,n){function r(){}function i(e){function t(e){return e&&e instanceof r?e:e?u(e,f,a):a()}function n(n,r,i,o,a){if(a!==!1&&(a=!0),!l.aborted||o){e&&a&&e(n,r,i);for(var c=t(i),f=v(n),u=f.length,s=0;s<u;s++)f[s].apply(c,r);var p=d[h[n]];return p&&p.push([b,n,r,c]),c}}function o(e,t){y[e]=v(e).concat(t)}function m(e,t){var n=y[e];if(n)for(var r=0;r<n.length;r++)n[r]===t&&n.splice(r,1)}function v(e){return y[e]||[]}function g(e){return p[e]=p[e]||i(n)}function w(e,t){s(e,function(e,n){t=t||"feature",h[n]=t,t in d||(d[t]=[])})}var y={},h={},b={on:o,addEventListener:o,removeEventListener:m,emit:n,get:g,listeners:v,context:t,buffer:w,abort:c,aborted:!1};return b}function o(e){return u(e,f,a)}function a(){return new r}function c(){(d.api||d.feature)&&(l.aborted=!0,d=l.backlog={})}var f="nr@context",u=e("gos"),s=e(6),d={},p={},l=t.exports=i();t.exports.getOrSetContext=o,l.backlog=d},{}],gos:[function(e,t,n){function r(e,t,n){if(i.call(e,t))return e[t];var r=n();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,t,{value:r,writable:!0,enumerable:!1}),r}catch(o){}return e[t]=r,r}var i=Object.prototype.hasOwnProperty;t.exports=r},{}],handle:[function(e,t,n){function r(e,t,n,r){i.buffer([e],r),i.emit(e,t,n)}var i=e("ee").get("handle");t.exports=r,r.ee=i},{}],id:[function(e,t,n){function r(e){var t=typeof e;return!e||"object"!==t&&"function"!==t?-1:e===window?0:a(e,o,function(){return i++})}var i=1,o="nr@id",a=e("gos");t.exports=r},{}],loader:[function(e,t,n){function r(){if(!x++){var e=b.info=NREUM.info,t=p.getElementsByTagName("script")[0];if(setTimeout(u.abort,3e4),!(e&&e.licenseKey&&e.applicationID&&t))return u.abort();f(y,function(t,n){e[t]||(e[t]=n)});var n=a();c("mark",["onload",n+b.offset],null,"api"),c("timing",["load",n]);var r=p.createElement("script");r.src="https://"+e.agent,t.parentNode.insertBefore(r,t)}}function i(){"complete"===p.readyState&&o()}function o(){c("mark",["domContent",a()+b.offset],null,"api")}var a=e(2),c=e("handle"),f=e(6),u=e("ee"),s=e(4),d=window,p=d.document,l="addEventListener",m="attachEvent",v=d.XMLHttpRequest,g=v&&v.prototype;NREUM.o={ST:setTimeout,SI:d.setImmediate,CT:clearTimeout,XHR:v,REQ:d.Request,EV:d.Event,PR:d.Promise,MO:d.MutationObserver};var w=""+location,y={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-1194.min.js"},h=v&&g&&g[l]&&!/CriOS/.test(navigator.userAgent),b=t.exports={offset:a.getLastTimestamp(),now:a,origin:w,features:{},xhrWrappable:h,userAgent:s};e(1),e(3),p[l]?(p[l]("DOMContentLoaded",o,!1),d[l]("load",r,!1)):(p[m]("onreadystatechange",i),d[m]("onload",r)),c("mark",["firstbyte",a.getLastTimestamp()],null,"api");var x=0},{}],"wrap-function":[function(e,t,n){function r(e,t){function n(t,n,r,f,u){function nrWrapper(){var o,a,s,p;try{a=this,o=d(arguments),s="function"==typeof r?r(o,a):r||{}}catch(l){i([l,"",[o,a,f],s],e)}c(n+"start",[o,a,f],s,u);try{return p=t.apply(a,o)}catch(m){throw c(n+"err",[o,a,m],s,u),m}finally{c(n+"end",[o,a,p],s,u)}}return a(t)?t:(n||(n=""),nrWrapper[p]=t,o(t,nrWrapper,e),nrWrapper)}function r(e,t,r,i,o){r||(r="");var c,f,u,s="-"===r.charAt(0);for(u=0;u<t.length;u++)f=t[u],c=e[f],a(c)||(e[f]=n(c,s?f+r:r,i,f,o))}function c(n,r,o,a){if(!m||t){var c=m;m=!0;try{e.emit(n,r,o,t,a)}catch(f){i([f,n,r,o],e)}m=c}}return e||(e=s),n.inPlace=r,n.flag=p,n}function i(e,t){t||(t=s);try{t.emit("internal-error",e)}catch(n){}}function o(e,t,n){if(Object.defineProperty&&Object.keys)try{var r=Object.keys(e);return r.forEach(function(n){Object.defineProperty(t,n,{get:function(){return e[n]},set:function(t){return e[n]=t,t}})}),t}catch(o){i([o],n)}for(var a in e)l.call(e,a)&&(t[a]=e[a]);return t}function a(e){return!(e&&e instanceof Function&&e.apply&&!e[p])}function c(e,t){var n=t(e);return n[p]=e,o(e,n,s),n}function f(e,t,n){var r=e[t];e[t]=c(r,n)}function u(){for(var e=arguments.length,t=new Array(e),n=0;n<e;++n)t[n]=arguments[n];return t}var s=e("ee"),d=e(7),p="nr@original",l=Object.prototype.hasOwnProperty,m=!1;t.exports=r,t.exports.wrapFunction=c,t.exports.wrapInPlace=f,t.exports.argsToArray=u},{}]},{},["loader"]);</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="Generator" content="Drupal 7 (http://drupal.org)" />
+<link rel="canonical" href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749" />
+<link rel="shortlink" href="/node/3281086" />
+<link rel="shortcut icon" href="https://healthdata.gov/sites/all/themes/custom/nuhealthdata/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>COVID-19 Reported Patient Impact and Hospital Capacity by State - COVID-19 Reported Patient Impact and Hospital Capacity by State | HealthData.gov</title>
+  <link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_kShW4RPmRstZ3SpIC-ZvVGNFVAi0WEMuCnI0ZkYIaFw.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_zWS33JphQ8354vADCrYEXghZq-7dBSX_GVE0h2a882o.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_PclrG84jul3FzOPY6aecmDD2k_CB0QT-xKgHJqBcCek.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_aQiRaGwrQLA1xsKXFyh_7NruQm-7hS0jN00qLp0n4To.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans::400,300,700" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_M3GDWqGTIjDW5ochjX8aHUFPH81l8L3gWPBBCgGLTKk.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css__n9YKsq7xsXwEwMrfJhLwruizLxg3Cb0WQoeIyW7aQ0.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_E5LxTHvotstXfBsPxcRlLKjEwjXPfi49JcaYB4zerlY.css" media="print" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/colorizer/nuhealthdata-bd90ffba.css" media="all" />
+
+<!--[if lte IE 9]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_afrXmziPY13Y9oUhiVMbLllpNaAnF9oeeqCoWSAcphU.css" media="all" />
+<![endif]-->
+
+<!--[if IE 9]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_qpzT6Nla_9qnBw9yFCNlaMSx-mR1C2PUztgmhLWV6Xc.css" media="all" />
+<![endif]-->
+
+<!--[if IE 8]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_niVepbI1pyCvJmhl54aXP4kQl1P0eSi3jLWf68uRmCU.css" media="all" />
+<![endif]-->
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_PxsPpITToy8ZnO0bJDA1TEC6bbFpGTfSWr2ZP8LuFYo.css" media="all" />
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <link href="/css/ie.css" media="screen" rel="stylesheet" type="text/css" />
+  <![endif]-->
+  <script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_mOx0WHl6cNZI0fqrVldT0Ay6Zv7VRFDm9LexZoNN_NI.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.migrateMute=true;jQuery.migrateTrace=false;
+//--><!]]>
+</script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_KfaBLR-BltoahyKqWl-Gti4gX3P_ywCrBhJzxOpwENQ.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/profiles/dkan/themes/contrib/nuboot_radix/assets/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js__Bnv-OxH3VuVfkYMQRgUHa3xCAKCmG7XimGQPEMs8CY.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_MhcB1FN2UMLPCnR-GfDjthX1HNPWMcDaupqqkDbY3yI.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_gnAxee1bR7uyP3sjkMimmwHC8nKs6Zp8c_Ru3SHrTLA.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+L.Icon.Default.imagePath = "/profiles/dkan/libraries/recline/vendor/leaflet/1.0.2/images/"
+//--><!]]>
+</script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_REbMwQ6tX2snu6GJRSFgsJqXzTwQiAF0Hu4pjCqc0cE.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_yZom1RMJVpo8-qmlGUMfpdJmnX169UZ2gK75qjeIJLs.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"nuhealthdata","theme_token":"Ncgnb0fcDojALkzsM3_2E_K-L5BM78wiW5dBtmRH3pg","js":{"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets.js":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets-spotlight.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/jquery\/1.12\/jquery.min.js":1,"0":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/jquery-migrate\/1\/jquery-migrate.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"https:\/\/healthdata.gov\/profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/js\/bootstrap.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.widget.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.mouse.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.sortable.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.tabs.min.js":1,"misc\/form.js":1,"misc\/states.js":1,"profiles\/dkan\/modules\/contrib\/panopoly_images\/panopoly-images.js":1,"profiles\/dkan\/modules\/dkan\/dkan_plugins\/js\/colorPicker.behavior.js":1,"profiles\/dkan\/modules\/contrib\/recline\/js\/jsondataview.js":1,"profiles\/dkan\/modules\/contrib\/recline\/js\/restdataview.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"profiles\/dkan\/libraries\/jquery.imagesloaded\/jquery.imagesloaded.min.js":1,"misc\/tableheader.js":1,"sites\/all\/modules\/contrib\/comment_goodness\/comment_goodness.js":1,"sites\/all\/modules\/contrib\/captcha\/captcha.js":1,"profiles\/dkan\/libraries\/lodash\/dist\/lodash.compat.min.js":1,"profiles\/dkan\/libraries\/backbone\/backbone-min.js":1,"profiles\/dkan\/libraries\/recline\/dist\/recline.js":1,"profiles\/dkan\/libraries\/csv\/csv.js":1,"profiles\/dkan\/libraries\/jsxlsx\/dist\/xlsx.core.min.js":1,"profiles\/dkan\/libraries\/xls\/dist\/recline.backend.xlsx.min.js":1,"profiles\/dkan\/libraries\/mustache\/mustache.min.js":1,"profiles\/dkan\/libraries\/moment\/min\/moment.min.js":1,"profiles\/dkan\/libraries\/slickgrid\/lib\/jquery.event.drag-2.2.js":1,"profiles\/dkan\/libraries\/slickgrid\/lib\/jquery.event.drop-2.2.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.core.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.formatters.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.editors.js":1,"profiles\/dkan\/libraries\/slickgrid\/slick.grid.js":1,"profiles\/dkan\/libraries\/slickgrid\/lib\/jquery-ui-1.8.16.custom.min.js":1,"profiles\/dkan\/libraries\/slickgrid\/plugins\/slick.rowselectionmodel.js":1,"profiles\/dkan\/libraries\/slickgrid\/plugins\/slick.rowmovemanager.js":1,"profiles\/dkan\/libraries\/leaflet\/dist\/leaflet.js":1,"profiles\/dkan\/libraries\/flot\/jquery.flot.js":1,"profiles\/dkan\/libraries\/deep_diff\/releases\/deep-diff-0.3.0.min.js":1,"profiles\/dkan\/libraries\/recline_deeplink\/dist\/recline.deeplink.min.js":1,"profiles\/dkan\/libraries\/leaflet_markercluster\/dist\/leaflet.markercluster.js":1,"profiles\/dkan\/modules\/contrib\/recline\/backend.ckan_get.js":1,"profiles\/dkan\/modules\/contrib\/recline\/recline.js":1,"1":1,"misc\/textarea.js":1,"modules\/filter\/filter.js":1,"profiles\/dkan\/modules\/dkan\/dkan_dataset\/js\/dkan_tooltip.js":1,"profiles\/dkan\/themes\/contrib\/radix\/assets\/js\/radix.script.js":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/js\/nuboot_radix.script.js":1,"sites\/all\/themes\/custom\/nuhealthdata\/assets\/js\/nuhealthdata.script.js":1},"css":{"modules\/system\/system.base.css":1,"modules\/system\/system.messages.css":1,"modules\/system\/system.theme.css":1,"misc\/ui\/jquery.ui.core.css":1,"misc\/ui\/jquery.ui.theme.css":1,"misc\/ui\/jquery.ui.tabs.css":1,"modules\/comment\/comment.css":1,"profiles\/dkan\/modules\/contrib\/date\/date_api\/date.css":1,"profiles\/dkan\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css":1,"profiles\/dkan\/modules\/dkan\/dkan_data_story\/css\/dkan_data_story.css":1,"profiles\/dkan\/modules\/dkan\/dkan_harvest\/modules\/dkan_harvest_dashboard\/css\/dkan_harvest_dashboard.css":1,"modules\/field\/theme\/field.css":1,"profiles\/dkan\/modules\/contrib\/field_hidden\/field_hidden.css":1,"modules\/node\/node.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets-spotlight.css":1,"profiles\/dkan\/modules\/contrib\/radix_layouts\/radix_layouts.css":1,"modules\/user\/user.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"profiles\/dkan\/modules\/contrib\/views\/css\/views.css":1,"profiles\/dkan\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/debut_blog\/debut_blog.css":1,"profiles\/dkan\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/modules\/contrib\/rate\/rate.css":1,"sites\/all\/modules\/contrib\/comment_goodness\/css\/disabled_actions.css":1,"profiles\/dkan\/libraries\/recline\/css\/grid.css":1,"profiles\/dkan\/libraries\/recline\/css\/slickgrid.css":1,"profiles\/dkan\/libraries\/recline\/css\/flot.css":1,"profiles\/dkan\/libraries\/recline\/css\/map.css":1,"profiles\/dkan\/libraries\/recline\/css\/multiview.css":1,"profiles\/dkan\/libraries\/recline\/css-site\/pygments.css":1,"profiles\/dkan\/libraries\/slickgrid\/slick.grid.css":1,"profiles\/dkan\/libraries\/leaflet\/dist\/leaflet.css":1,"profiles\/dkan\/libraries\/leaflet_markercluster\/dist\/MarkerCluster.css":1,"profiles\/dkan\/libraries\/leaflet_markercluster\/dist\/MarkerCluster.Default.css":1,"profiles\/dkan\/modules\/contrib\/recline\/recline.css":1,"modules\/filter\/filter.css":1,"sites\/all\/modules\/contrib\/dkan_feedback\/templates\/feedback\/feedback.css":1,"profiles\/dkan\/modules\/dkan\/dkan_topics\/theme\/dkan_topics.css":1,"\/\/fonts.googleapis.com\/css?family=Open+Sans::400,300,700":1,"public:\/\/font-icon-select-general-generated-1.css":1,"profiles\/dkan\/modules\/dkan\/dkan_dataset\/css\/dkan_dataset.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/nuboot_radix.style.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/dkan-flaticon.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/dkan-topics.css":1,"sites\/all\/themes\/custom\/nuhealthdata\/assets\/css\/nuhealthdata.style.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/print.css":1,"https:\/\/healthdata.gov\/sites\/default\/files\/colorizer\/nuhealthdata-bd90ffba.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie9.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie8.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_images\/panopoly-images.css":1}},"recline":{"file":"https:\/\/healthdata.gov\/sites\/default\/files\/reported_hospital_utilization_20210130_2344.csv","fileType":"text\/csv","fileSize":18825,"delimiter":",","grid":1,"graph":0,"map":0,"embed":0,"uuid":"38e07d07-40a2-4749-bfd3-68fefa42a61f","datastoreStatus":"dkan_datastore_3281086","maxSizePreview":3000000},"states":{"#edit-submit":{"disabled":{"textarea[name=\u0022comment_body[und][0][value]\u0022]":{"empty":true}}},"#edit-preview":{"disabled":{"textarea[name=\u0022comment_body[und][0][value]\u0022]":{"empty":true}}}},"urlIsAjaxTrusted":{"\/comment\/reply\/3281086":true,"\/node\/3281086\/revisions\/7498736\/view":true},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":0,"extSubdomains":1,"extExclude":"(healthdata\\.gov)|(localtest\\.me)","extInclude":"(twitter\\.com)|(facebook\\.com)|(linkedin\\.com)|(plus\\.google\\.com)|(www\\.reddit\\.com)","extCssExclude":"","extCssExplicit":"","extAlert":"_blank","extAlertText":"Endorsement Disclaimer - Links to Other Sites\n\nOur web site has links to many other federal agencies, and in a few cases we link to private organizations. You are subject to that site\u0027s privacy policy when you leave our site. We are not responsible for Section 508 compliance (accessibility) on other federal or private Web sites.\n\nReference in this web site to any specific commercial products, process, service, manufacturer, or company does not constitute its endorsement or recommendation by the U.S. Government or HHS. HHS is not responsible for the contents of any \u0022off-site\u0022 web page referenced from this server.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"}});
+//--><!]]>
+</script>
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-3281086 page-node-revisions page-node-revisions- page-node-revisions-7498736 page-node-revisions-view node-type-resource panel-layout-radix_sutro panel-region-column1 panel-region-column2 panel-region-header" >
+  <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K8VG67T"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+
+<!-- start USWDS BANNER -->
+  <section class="usa-banner" aria-label="Official government website">
+  <div class="container">
+    <header data-toggle="collapse" href="#gov-banner-default" role="button" aria-expanded="false" aria-controls="gov-banner-default">
+      <div class="usa-banner-inner">
+        <div class="usa-banner__header-flag"><img class="usa-banner__header-flag" src="/sites/all/themes/custom/nuhealthdata/assets/images/us_flag_small.png" alt="U.S. flag"></div>
+        <div class="usa-banner__header-text">An official website of the United States government</div>
+        <a class="usa-banner-link" aria-expanded="true" aria-controls="gov-banner-default">
+          Here’s how you know
+        </a>
+      </div>
+    </header>
+    <div class="collapse" id="gov-banner-default">
+      <div class="row clearfix">
+        <div class="guidance col-md-6">
+          <img class="usa-banner__icon" src="/sites/all/themes/custom/nuhealthdata/assets/images/icon-dot-gov.svg" role="img" alt="Dot gov">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Official websites use .gov</strong>
+              <br>
+              A <strong>.gov</strong> website belongs to an official government organization in the United States.
+            </p>
+          </div>
+        </div>
+        <div class="guidance col-md-6">
+          <img class="usa-banner__icon usa-media-block__img" src="/sites/all/themes/custom/nuhealthdata/assets/images/icon-https.svg" role="img" alt="Https">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Secure .gov websites use HTTPS</strong>
+              <br>
+              A <strong>lock</strong> (
+<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="18" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title-default banner-lock-description-default"><title id="banner-lock-title-default">Lock</title><desc id="banner-lock-description-default">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path></svg></span>
+) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+</section>
+<!-- end USWDS BANNER -->
+    <header id="header" class="header">
+  <div class="branding container">
+          <a class="logo navbar-btn pull-left" href="/" title="Home">
+        <img src="https://healthdata.gov/sites/default/files/logo.png" alt="Home" />
+      </a>
+            <!-- views exposed search -->
+    <section id="block-dkan-sitewide-dkan-sitewide-search-bar" class="block block-dkan-sitewide block-- clearfix">
+
+        <div class="content">
+    <form action="/node/3281086/revisions/7498736/view" method="post" id="dkan-sitewide-dataset-search-form" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-search form-group">
+  <label for="edit-search">Search </label>
+ <input placeholder="search" class="form-control form-text" type="text" id="edit-search" name="search" value="" size="30" maxlength="128" />
+</div>
+<input type="submit" id="edit-submit--2" name="op" value="" class="form-submit btn btn-default btn-primary" /><input type="hidden" name="form_build_id" value="form-iuyOapIzdvKNW696BjG4qzR0lDBXPxGaFaka2o5UVfk" />
+<input type="hidden" name="form_id" value="dkan_sitewide_dataset_search_form" />
+</div></form>  </div>
+
+</section>
+  </div>
+  <div class="navigation-wrapper">
+    <div class="container">
+      <nav class="navbar navbar-default" role="navigation">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+        </div> <!-- /.navbar-header -->
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="navbar-collapse">
+                      <ul id="main-menu" class="menu nav navbar-nav">
+              <li class="first leaf menu-link-about"><a href="/content/about">About</a></li>
+<li class="leaf menu-link-datasets"><a href="/search/type/dataset" title="">Datasets</a></li>
+<li class="expanded dropdown menu-link-developers-"><a href="/node/86" class="dropdown-toggle" data-toggle="dropdown" data-target="#">Developers <span class="fa fa-caret-down"></span></a><ul class="dropdown-menu"><li class="first last leaf menu-link-healthdatagov-api"><a href="/api">HealthData.gov API</a></li>
+</ul></li>
+<li class="leaf menu-link-feedback"><a href="/feedback">Feedback</a></li>
+<li class="last leaf menu-link-covid-19-datasets"><a href="/search/type/dataset?query=covid-19&amp;sort_by=changed&amp;sort_order=DESC" title="Search for HHS COVID-19 data">COVID-19 Datasets</a></li>
+            </ul>
+          
+          <!-- user menu -->
+          <section id="block-dkan-sitewide-dkan-sitewide-user-menu" class="block block-dkan-sitewide block-- clearfix">
+
+        <div class="content">
+    <span class="links"><a href="/user/login">Log in</a></span>  </div>
+
+</section>
+        </div><!-- /.navbar-collapse -->
+      </nav><!-- /.navbar -->
+    </div><!-- /.container -->
+  </div> <!-- /.navigation -->
+</header>
+
+<div id="main-wrapper">
+  <div id="main" class="main container">
+
+    <ul class="breadcrumb"><li class="home-link"><a href="/"><i class="fa fa fa-home" aria-hidden="true"></i><span> Home</span></a></li><li><a href="/">Home</a></li><li><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749">COVID-19 Reported Patient Impact and Hospital Capacity by State</a></li><li><a href="/node/3281086/revisions">Revisions</a></li><li><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state">COVID-19 Reported Patient Impact and Hospital Capacity by State</a></li><li class="active-trail">COVID-19 Reported Patient Impact and Hospital Capacity by State - COVID-19 Reported Patient Impact and Hospital Capacity by State</li></ul>                <div class="region region-help">
+    <section id="block-system-help" class="block block-system block-- clearfix">
+
+        <div class="content">
+    <p>Revisions allow you to track differences between multiple versions of your content, and revert back to older versions.</p>
+  </div>
+
+</section>
+  </div>
+    
+
+    <div id="main-content" class="main-row">
+
+      <section>
+                                                  <div class="region region-content">
+    
+<div class="panel-display sutro clearfix radix-sutro" >
+
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12 radix-layouts-header panel-panel">
+        <div class="panel-panel-inner">
+          <div class="panel-pane pane-node-content"  >
+  
+        <h2 class="pane-title">
+      COVID-19 Reported Patient Impact and Hospital Capacity by State    </h2>
+    
+  
+  <div class="pane-content">
+    <article class="node node-resource clearfix">
+
+  
+      
+  
+  <div class="content">
+    <div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even"><p><strong>Updated: January 31, 2021 12:02 AM</strong></p>
+</div></div></div><div class="field field-name-field-upload field-type-recline-field field-label-hidden"><div class="field-items"><div class="field-item even"><div class="download"><a href="https://healthdata.gov/sites/default/files/reported_hospital_utilization_20210130_2344.csv" type="text/csv; length=18825" data-format="csv" class="format-label" title="reported_hospital_utilization_20210130_2344.csv">reported_hospital_utilization_20210130_2344.csv</a></div><div class="data-explorer-help"><i class="fa fa-info-circle" aria-hidden="true"></i> <strong>Data Preview:</strong> Note that by default the preview only displays up to 100 records. Use the pager to flip through more records or adjust the start and end fields to display the number of records you wish to see.</div><span class="data-explorer"></span></div></div></div>  </div>
+
+  
+  <div id="comments" class="comment-wrapper">
+  
+  
+  
+            <h2 class="title comment-form">Post new comment</h2>
+      <form class="comment-form" action="/comment/reply/3281086" method="post" id="comment-form" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-name form-group">
+  <label for="edit-name">Your name </label>
+ <input class="form-control form-text" type="text" id="edit-name" name="name" value="" size="30" maxlength="60" />
+</div>
+<div class="form-item form-type-textfield form-item-subject form-group">
+  <label for="edit-subject">Subject </label>
+ <input class="form-control form-text" type="text" id="edit-subject" name="subject" value="" size="60" maxlength="64" />
+</div>
+<div class="field-type-text-long field-name-comment-body field-widget-text-textarea form-wrapper" id="edit-comment-body"><div id="comment-body-add-more-wrapper"><div class="text-format-wrapper"><div class="form-item form-type-textarea form-item-comment-body-und-0-value form-group">
+  <label for="edit-comment-body-und-0-value">Comment <span class="form-required" title="This field is required.">*</span></label>
+ <div class="form-textarea-wrapper resizable"><textarea class="text-full form-textarea required" id="edit-comment-body-und-0-value" name="comment_body[und][0][value]" cols="60" rows="5"></textarea></div>
+</div>
+<fieldset class="filter-wrapper form-wrapper panel panel-default" id="edit-comment-body-und-0-format"><div class="panel-body fieldset-wrapper"><div class="filter-help form-wrapper" id="edit-comment-body-und-0-format-help"><p><a href="/filter/tips" target="_blank">More information about text formats</a></p></div><div class="filter-guidelines form-wrapper" id="edit-comment-body-und-0-format-guidelines"><div class="filter-guidelines-item filter-guidelines-plain_text"><h3>Plain text</h3><ul class="tips"><li>Web page addresses and e-mail addresses turn into links automatically.</li><li>Lines and paragraphs break automatically.</li></ul></div></div></div></fieldset>
+</div>
+</div></div><input type="hidden" name="form_build_id" value="form-8tXmrXMprP5gkK6YkiNhEg20fzBdFxSO0ew3uIv8emA" />
+<input type="hidden" name="form_id" value="comment_node_resource_form" />
+<fieldset class="captcha form-wrapper panel panel-default"><legend class="panel-heading"><div class="panel-title fieldset-legend">CAPTCHA</div></legend><div class="panel-body fieldset-wrapper"><p class="help-block">This question is for testing whether or not you are a human visitor and to prevent automated spam submissions.</p><input type="hidden" name="captcha_sid" value="64312591" />
+<input type="hidden" name="captcha_token" value="7134b4b231aa877cccf05512e35ece03" />
+<img src="/image_captcha?sid=64312591&amp;ts=1612364383" width="180" height="60" alt="Image CAPTCHA" title="Image CAPTCHA" /><div class="form-item form-type-textfield form-item-captcha-response form-group">
+  <label for="edit-captcha-response">What code is in the image? <span class="form-required" title="This field is required.">*</span></label>
+ <input class="form-control form-text required" type="text" id="edit-captcha-response" name="captcha_response" value="" size="15" maxlength="128" />
+<span class="help-block">Enter the characters shown in the image.</span>
+</div>
+</div></fieldset>
+<div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit" name="op" value="Save" class="form-submit btn btn-default btn-primary" /><input type="submit" id="edit-preview" name="op" value="Preview" class="form-submit btn btn-default" /></div></div></form>      </div>
+
+</article>
+  </div>
+
+  
+  </div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="row">
+      <div class="col-md-6 radix-layouts-column1 panel-panel">
+        <div class="panel-panel-inner">
+          <div class="panel-pane pane-block pane-dkan-dataset-dkan-dataset-resource-nodes"  >
+  
+        <h2 class="pane-title">
+      Resources    </h2>
+    
+  
+  <div class="pane-content">
+    <div class="item-list"><ul class="list-group"><li class="first last"><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749" class="list-group-item"><span>COVID-19 Reported Patient Impact and Hospital Capacity by State</span></a></li>
+</ul></div>  </div>
+
+  
+  </div>
+        </div>
+      </div>
+      <div class="col-md-6 radix-layouts-column2 panel-panel">
+        <div class="panel-panel-inner">
+          <div class="panel-pane pane-block pane-dkan-sitewide-dkan-sitewide-resource-add"  >
+  
+        <h2 class="pane-title">
+      Additional Information    </h2>
+    
+  
+  <div class="pane-content">
+    <div class="table-responsive"><table class="table table-striped table-bordered sticky-enabled">
+ <thead><tr><th>Field</th><th>Value</th> </tr></thead>
+<tbody>
+ <tr class="odd"><td>mimetype</td><td>text/csv</td> </tr>
+ <tr class="even"><td>filesize</td><td>18.38 KB</td> </tr>
+ <tr class="odd"><td>resource type</td><td>file upload</td> </tr>
+ <tr class="even"><td>timestamp</td><td>Jan 31, 2021</td> </tr>
+</tbody>
+</table>
+</div>  </div>
+
+  
+  </div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="row">
+      <div class="col-md-12 radix-layouts-footer panel-panel">
+        <div class="panel-panel-inner">
+                  </div>
+      </div>
+    </div>
+  </div>
+ 
+</div><!-- /.sutro -->
+  </div>
+      </section>
+
+    </div>
+
+  </div> <!-- /#main -->
+</div> <!-- /#main-wrapper -->
+
+<footer id="footer" class="footer">
+  <div class="container">
+          <small class="copyright pull-left"><p>A federal government website managed by the  <a href="https://www.hhs.gov/">U.S. Department of Health &amp; Human Services</a><br />200 Independence Avenue, S.W. - Washington, D.C. 20201</p>
+<ul class="links">
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://healthdata.gov/content/about">About Us</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/accessibility.html">Accessibilty</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/privacy.html">Privacy Policy</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/open/plain-writing/index.html">Plain Writing</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/disclaimer.html">Disclaimers</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/asa/eeo/resources/index.html">No FEAR</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/open">HHS.gov/Open</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/foia/">FOIA</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/">HHS.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="https://www.whitehouse.gov/">WhiteHouse.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.usa.gov/">USA.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.usa.gov/gobiernousa/">GobiernoUSA.gov</a></li>
+</ul>
+</small>
+        <small class="pull-right"></small>
+  </div>
+</footer>
+  <script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_29qYXJz8NLGg8Aomg-RZPjJcj9yEdEst1BMZ9gZbs-4.js"></script>
+<script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"b7126202e5","applicationID":"65779789","transactionName":"NlQDNRNTXkJTBxBcVg8eIAIVW19fHRQFUlw+XAAPAFVVQ20KC1FcPkcIBBZtQFBVAQ==","queueTime":0,"applicationTime":931,"atts":"GhMAQ1tJTUw=","errorBeacon":"bam.nr-data.net","agent":""}</script></body>
+</html>

--- a/testdata/acquisition/covid_hosp/state_daily/revisions.html
+++ b/testdata/acquisition/covid_hosp/state_daily/revisions.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
+  "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">
+<html lang="en" dir="ltr">
+<head profile="http://www.w3.org/1999/xhtml/vocab">
+
+  <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
+
+    {'gtm.start': new Date().getTime(),event:'gtm.js'}
+    );var f=d.getElementsByTagName(s)[0],
+
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+
+    })(window,document,'script','dataLayer','GTM-K8VG67T');</script>
+  <!-- End Google Tag Manager -->
+
+  <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
+  <meta charset="utf-8"><script type="text/javascript">(window.NREUM||(NREUM={})).loader_config={licenseKey:"b7126202e5",applicationID:"65779789"};window.NREUM||(NREUM={}),__nr_require=function(e,t,n){function r(n){if(!t[n]){var i=t[n]={exports:{}};e[n][0].call(i.exports,function(t){var i=e[n][1][t];return r(i||t)},i,i.exports)}return t[n].exports}if("function"==typeof __nr_require)return __nr_require;for(var i=0;i<n.length;i++)r(n[i]);return r}({1:[function(e,t,n){function r(){}function i(e,t,n){return function(){return o(e,[u.now()].concat(c(arguments)),t?null:this,n),t?void 0:this}}var o=e("handle"),a=e(6),c=e(7),f=e("ee").get("tracer"),u=e("loader"),s=NREUM;"undefined"==typeof window.newrelic&&(newrelic=s);var d=["setPageViewName","setCustomAttribute","setErrorHandler","finished","addToTrace","inlineHit","addRelease"],p="api-",l=p+"ixn-";a(d,function(e,t){s[t]=i(p+t,!0,"api")}),s.addPageAction=i(p+"addPageAction",!0),s.setCurrentRouteName=i(p+"routeName",!0),t.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,t){var n={},r=this,i="function"==typeof t;return o(l+"tracer",[u.now(),e,n],r),function(){if(f.emit((i?"":"no-")+"fn-start",[u.now(),r,i],n),i)try{return t.apply(this,arguments)}catch(e){throw f.emit("fn-err",[arguments,this,e],n),e}finally{f.emit("fn-end",[u.now()],n)}}}};a("actionText,setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","),function(e,t){m[t]=i(l+t)}),newrelic.noticeError=function(e,t){"string"==typeof e&&(e=new Error(e)),o("err",[e,u.now(),!1,t])}},{}],2:[function(e,t,n){function r(){return c.exists&&performance.now?Math.round(performance.now()):(o=Math.max((new Date).getTime(),o))-a}function i(){return o}var o=(new Date).getTime(),a=o,c=e(8);t.exports=r,t.exports.offset=a,t.exports.getLastTimestamp=i},{}],3:[function(e,t,n){function r(e,t){var n=e.getEntries();n.forEach(function(e){"first-paint"===e.name?d("timing",["fp",Math.floor(e.startTime)]):"first-contentful-paint"===e.name&&d("timing",["fcp",Math.floor(e.startTime)])})}function i(e,t){var n=e.getEntries();n.length>0&&d("lcp",[n[n.length-1]])}function o(e){e.getEntries().forEach(function(e){e.hadRecentInput||d("cls",[e])})}function a(e){if(e instanceof m&&!g){var t=Math.round(e.timeStamp),n={type:e.type};t<=p.now()?n.fid=p.now()-t:t>p.offset&&t<=Date.now()?(t-=p.offset,n.fid=p.now()-t):t=p.now(),g=!0,d("timing",["fi",t,n])}}function c(e){d("pageHide",[p.now(),e])}if(!("init"in NREUM&&"page_view_timing"in NREUM.init&&"enabled"in NREUM.init.page_view_timing&&NREUM.init.page_view_timing.enabled===!1)){var f,u,s,d=e("handle"),p=e("loader"),l=e(5),m=NREUM.o.EV;if("PerformanceObserver"in window&&"function"==typeof window.PerformanceObserver){f=new PerformanceObserver(r);try{f.observe({entryTypes:["paint"]})}catch(v){}u=new PerformanceObserver(i);try{u.observe({entryTypes:["largest-contentful-paint"]})}catch(v){}s=new PerformanceObserver(o);try{s.observe({type:"layout-shift",buffered:!0})}catch(v){}}if("addEventListener"in document){var g=!1,w=["click","keydown","mousedown","pointerdown","touchstart"];w.forEach(function(e){document.addEventListener(e,a,!1)})}l(c)}},{}],4:[function(e,t,n){function r(e,t){if(!i)return!1;if(e!==i)return!1;if(!t)return!0;if(!o)return!1;for(var n=o.split("."),r=t.split("."),a=0;a<r.length;a++)if(r[a]!==n[a])return!1;return!0}var i=null,o=null,a=/Version\/(\S+)\s+Safari/;if(navigator.userAgent){var c=navigator.userAgent,f=c.match(a);f&&c.indexOf("Chrome")===-1&&c.indexOf("Chromium")===-1&&(i="Safari",o=f[1])}t.exports={agent:i,version:o,match:r}},{}],5:[function(e,t,n){function r(e){function t(){e(a&&document[a]?document[a]:document[i]?"hidden":"visible")}"addEventListener"in document&&o&&document.addEventListener(o,t,!1)}t.exports=r;var i,o,a;"undefined"!=typeof document.hidden?(i="hidden",o="visibilitychange",a="visibilityState"):"undefined"!=typeof document.msHidden?(i="msHidden",o="msvisibilitychange"):"undefined"!=typeof document.webkitHidden&&(i="webkitHidden",o="webkitvisibilitychange",a="webkitVisibilityState")},{}],6:[function(e,t,n){function r(e,t){var n=[],r="",o=0;for(r in e)i.call(e,r)&&(n[o]=t(r,e[r]),o+=1);return n}var i=Object.prototype.hasOwnProperty;t.exports=r},{}],7:[function(e,t,n){function r(e,t,n){t||(t=0),"undefined"==typeof n&&(n=e?e.length:0);for(var r=-1,i=n-t||0,o=Array(i<0?0:i);++r<i;)o[r]=e[t+r];return o}t.exports=r},{}],8:[function(e,t,n){t.exports={exists:"undefined"!=typeof window.performance&&window.performance.timing&&"undefined"!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,t,n){function r(){}function i(e){function t(e){return e&&e instanceof r?e:e?u(e,f,a):a()}function n(n,r,i,o,a){if(a!==!1&&(a=!0),!l.aborted||o){e&&a&&e(n,r,i);for(var c=t(i),f=v(n),u=f.length,s=0;s<u;s++)f[s].apply(c,r);var p=d[h[n]];return p&&p.push([b,n,r,c]),c}}function o(e,t){y[e]=v(e).concat(t)}function m(e,t){var n=y[e];if(n)for(var r=0;r<n.length;r++)n[r]===t&&n.splice(r,1)}function v(e){return y[e]||[]}function g(e){return p[e]=p[e]||i(n)}function w(e,t){s(e,function(e,n){t=t||"feature",h[n]=t,t in d||(d[t]=[])})}var y={},h={},b={on:o,addEventListener:o,removeEventListener:m,emit:n,get:g,listeners:v,context:t,buffer:w,abort:c,aborted:!1};return b}function o(e){return u(e,f,a)}function a(){return new r}function c(){(d.api||d.feature)&&(l.aborted=!0,d=l.backlog={})}var f="nr@context",u=e("gos"),s=e(6),d={},p={},l=t.exports=i();t.exports.getOrSetContext=o,l.backlog=d},{}],gos:[function(e,t,n){function r(e,t,n){if(i.call(e,t))return e[t];var r=n();if(Object.defineProperty&&Object.keys)try{return Object.defineProperty(e,t,{value:r,writable:!0,enumerable:!1}),r}catch(o){}return e[t]=r,r}var i=Object.prototype.hasOwnProperty;t.exports=r},{}],handle:[function(e,t,n){function r(e,t,n,r){i.buffer([e],r),i.emit(e,t,n)}var i=e("ee").get("handle");t.exports=r,r.ee=i},{}],id:[function(e,t,n){function r(e){var t=typeof e;return!e||"object"!==t&&"function"!==t?-1:e===window?0:a(e,o,function(){return i++})}var i=1,o="nr@id",a=e("gos");t.exports=r},{}],loader:[function(e,t,n){function r(){if(!x++){var e=b.info=NREUM.info,t=p.getElementsByTagName("script")[0];if(setTimeout(u.abort,3e4),!(e&&e.licenseKey&&e.applicationID&&t))return u.abort();f(y,function(t,n){e[t]||(e[t]=n)});var n=a();c("mark",["onload",n+b.offset],null,"api"),c("timing",["load",n]);var r=p.createElement("script");r.src="https://"+e.agent,t.parentNode.insertBefore(r,t)}}function i(){"complete"===p.readyState&&o()}function o(){c("mark",["domContent",a()+b.offset],null,"api")}var a=e(2),c=e("handle"),f=e(6),u=e("ee"),s=e(4),d=window,p=d.document,l="addEventListener",m="attachEvent",v=d.XMLHttpRequest,g=v&&v.prototype;NREUM.o={ST:setTimeout,SI:d.setImmediate,CT:clearTimeout,XHR:v,REQ:d.Request,EV:d.Event,PR:d.Promise,MO:d.MutationObserver};var w=""+location,y={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",agent:"js-agent.newrelic.com/nr-1194.min.js"},h=v&&g&&g[l]&&!/CriOS/.test(navigator.userAgent),b=t.exports={offset:a.getLastTimestamp(),now:a,origin:w,features:{},xhrWrappable:h,userAgent:s};e(1),e(3),p[l]?(p[l]("DOMContentLoaded",o,!1),d[l]("load",r,!1)):(p[m]("onreadystatechange",i),d[m]("onload",r)),c("mark",["firstbyte",a.getLastTimestamp()],null,"api");var x=0},{}],"wrap-function":[function(e,t,n){function r(e,t){function n(t,n,r,f,u){function nrWrapper(){var o,a,s,p;try{a=this,o=d(arguments),s="function"==typeof r?r(o,a):r||{}}catch(l){i([l,"",[o,a,f],s],e)}c(n+"start",[o,a,f],s,u);try{return p=t.apply(a,o)}catch(m){throw c(n+"err",[o,a,m],s,u),m}finally{c(n+"end",[o,a,p],s,u)}}return a(t)?t:(n||(n=""),nrWrapper[p]=t,o(t,nrWrapper,e),nrWrapper)}function r(e,t,r,i,o){r||(r="");var c,f,u,s="-"===r.charAt(0);for(u=0;u<t.length;u++)f=t[u],c=e[f],a(c)||(e[f]=n(c,s?f+r:r,i,f,o))}function c(n,r,o,a){if(!m||t){var c=m;m=!0;try{e.emit(n,r,o,t,a)}catch(f){i([f,n,r,o],e)}m=c}}return e||(e=s),n.inPlace=r,n.flag=p,n}function i(e,t){t||(t=s);try{t.emit("internal-error",e)}catch(n){}}function o(e,t,n){if(Object.defineProperty&&Object.keys)try{var r=Object.keys(e);return r.forEach(function(n){Object.defineProperty(t,n,{get:function(){return e[n]},set:function(t){return e[n]=t,t}})}),t}catch(o){i([o],n)}for(var a in e)l.call(e,a)&&(t[a]=e[a]);return t}function a(e){return!(e&&e instanceof Function&&e.apply&&!e[p])}function c(e,t){var n=t(e);return n[p]=e,o(e,n,s),n}function f(e,t,n){var r=e[t];e[t]=c(r,n)}function u(){for(var e=arguments.length,t=new Array(e),n=0;n<e;++n)t[n]=arguments[n];return t}var s=e("ee"),d=e(7),p="nr@original",l=Object.prototype.hasOwnProperty,m=!1;t.exports=r,t.exports.wrapFunction=c,t.exports.wrapInPlace=f,t.exports.argsToArray=u},{}]},{},["loader"]);</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="Generator" content="Drupal 7 (http://drupal.org)" />
+<link rel="shortcut icon" href="https://healthdata.gov/sites/all/themes/custom/nuhealthdata/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Revisions for COVID-19 Reported Patient Impact and Hospital Capacity by State | HealthData.gov</title>
+  <link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_kShW4RPmRstZ3SpIC-ZvVGNFVAi0WEMuCnI0ZkYIaFw.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_zWS33JphQ8354vADCrYEXghZq-7dBSX_GVE0h2a882o.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_PclrG84jul3FzOPY6aecmDD2k_CB0QT-xKgHJqBcCek.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_-eHWOsLUBkyHcIoDKnRPBfgfVL0RWJ1KESgufioRZWw.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans::400,300,700" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_cFSdLVma_5jr9gjNuGHUnVjswdXuP_QFkVhTIJ4G6jk.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css__n9YKsq7xsXwEwMrfJhLwruizLxg3Cb0WQoeIyW7aQ0.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_E5LxTHvotstXfBsPxcRlLKjEwjXPfi49JcaYB4zerlY.css" media="print" />
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/colorizer/nuhealthdata-bd90ffba.css" media="all" />
+
+<!--[if lte IE 9]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_afrXmziPY13Y9oUhiVMbLllpNaAnF9oeeqCoWSAcphU.css" media="all" />
+<![endif]-->
+
+<!--[if IE 9]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_qpzT6Nla_9qnBw9yFCNlaMSx-mR1C2PUztgmhLWV6Xc.css" media="all" />
+<![endif]-->
+
+<!--[if IE 8]>
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_niVepbI1pyCvJmhl54aXP4kQl1P0eSi3jLWf68uRmCU.css" media="all" />
+<![endif]-->
+<link type="text/css" rel="stylesheet" href="https://healthdata.gov/sites/default/files/css/css_PxsPpITToy8ZnO0bJDA1TEC6bbFpGTfSWr2ZP8LuFYo.css" media="all" />
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <link href="/css/ie.css" media="screen" rel="stylesheet" type="text/css" />
+  <![endif]-->
+  <script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_mOx0WHl6cNZI0fqrVldT0Ay6Zv7VRFDm9LexZoNN_NI.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.migrateMute=true;jQuery.migrateTrace=false;
+//--><!]]>
+</script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_KfaBLR-BltoahyKqWl-Gti4gX3P_ywCrBhJzxOpwENQ.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/profiles/dkan/themes/contrib/nuboot_radix/assets/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_h5xToSCJa7d2lsBERTKEx-eDVl8gKdbnZHHN5TA86X8.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_MhcB1FN2UMLPCnR-GfDjthX1HNPWMcDaupqqkDbY3yI.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_gYb0gpOTDLKJq-OgTmPEP2C71cqF8_w4Hb-Q2dudOck.js"></script>
+<script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_yZom1RMJVpo8-qmlGUMfpdJmnX169UZ2gK75qjeIJLs.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"nuhealthdata","theme_token":"n0JvsczRxsfVGvl5T3bT15U507JqWQIlL_pWfAYwwjM","js":{"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets.js":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets-spotlight.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/jquery\/1.12\/jquery.min.js":1,"0":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/jquery-migrate\/1\/jquery-migrate.min.js":1,"misc\/jquery-extend-3.4.0.js":1,"misc\/jquery-html-prefilter-3.5.0-backport.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"https:\/\/healthdata.gov\/profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/js\/bootstrap.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.widget.min.js":1,"profiles\/dkan\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.tabs.min.js":1,"profiles\/dkan\/modules\/contrib\/panopoly_images\/panopoly-images.js":1,"profiles\/dkan\/modules\/dkan\/dkan_plugins\/js\/colorPicker.behavior.js":1,"profiles\/dkan\/modules\/contrib\/recline\/js\/jsondataview.js":1,"profiles\/dkan\/modules\/contrib\/recline\/js\/restdataview.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"profiles\/dkan\/libraries\/jquery.imagesloaded\/jquery.imagesloaded.min.js":1,"profiles\/dkan\/modules\/contrib\/diff\/js\/diff.js":1,"profiles\/dkan\/themes\/contrib\/radix\/assets\/js\/radix.script.js":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/js\/nuboot_radix.script.js":1,"sites\/all\/themes\/custom\/nuhealthdata\/assets\/js\/nuhealthdata.script.js":1},"css":{"modules\/system\/system.base.css":1,"modules\/system\/system.messages.css":1,"modules\/system\/system.theme.css":1,"misc\/ui\/jquery.ui.core.css":1,"misc\/ui\/jquery.ui.theme.css":1,"misc\/ui\/jquery.ui.tabs.css":1,"modules\/comment\/comment.css":1,"profiles\/dkan\/modules\/contrib\/date\/date_api\/date.css":1,"profiles\/dkan\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css":1,"profiles\/dkan\/modules\/dkan\/dkan_data_story\/css\/dkan_data_story.css":1,"profiles\/dkan\/modules\/dkan\/dkan_harvest\/modules\/dkan_harvest_dashboard\/css\/dkan_harvest_dashboard.css":1,"modules\/field\/theme\/field.css":1,"profiles\/dkan\/modules\/contrib\/field_hidden\/field_hidden.css":1,"modules\/node\/node.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_widgets\/panopoly-widgets-spotlight.css":1,"profiles\/dkan\/modules\/contrib\/radix_layouts\/radix_layouts.css":1,"modules\/user\/user.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"profiles\/dkan\/modules\/contrib\/views\/css\/views.css":1,"profiles\/dkan\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/debut_blog\/debut_blog.css":1,"profiles\/dkan\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/modules\/contrib\/rate\/rate.css":1,"sites\/all\/modules\/contrib\/dkan_feedback\/templates\/feedback\/feedback.css":1,"profiles\/dkan\/modules\/dkan\/dkan_topics\/theme\/dkan_topics.css":1,"\/\/fonts.googleapis.com\/css?family=Open+Sans::400,300,700":1,"profiles\/dkan\/modules\/contrib\/diff\/css\/diff.default.css":1,"public:\/\/font-icon-select-general-generated-1.css":1,"profiles\/dkan\/modules\/dkan\/dkan_dataset\/css\/dkan_dataset.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/nuboot_radix.style.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/dkan-flaticon.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/dkan-topics.css":1,"sites\/all\/themes\/custom\/nuhealthdata\/assets\/css\/nuhealthdata.style.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/print.css":1,"https:\/\/healthdata.gov\/sites\/default\/files\/colorizer\/nuhealthdata-bd90ffba.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie9.css":1,"profiles\/dkan\/themes\/contrib\/nuboot_radix\/assets\/css\/ie8.css":1,"profiles\/dkan\/modules\/contrib\/panopoly_images\/panopoly-images.css":1}},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":0,"extSubdomains":1,"extExclude":"(healthdata\\.gov)|(localtest\\.me)","extInclude":"(twitter\\.com)|(facebook\\.com)|(linkedin\\.com)|(plus\\.google\\.com)|(www\\.reddit\\.com)","extCssExclude":"","extCssExplicit":"","extAlert":"_blank","extAlertText":"Endorsement Disclaimer - Links to Other Sites\n\nOur web site has links to many other federal agencies, and in a few cases we link to private organizations. You are subject to that site\u0027s privacy policy when you leave our site. We are not responsible for Section 508 compliance (accessibility) on other federal or private Web sites.\n\nReference in this web site to any specific commercial products, process, service, manufacturer, or company does not constitute its endorsement or recommendation by the U.S. Government or HHS. HHS is not responsible for the contents of any \u0022off-site\u0022 web page referenced from this server.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"urlIsAjaxTrusted":{"\/node\/3281086\/revisions":true},"diffRevisionRadios":"simple"});
+//--><!]]>
+</script>
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-3281086 page-node-revisions node-type-resource" >
+  <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K8VG67T"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+
+<!-- start USWDS BANNER -->
+  <section class="usa-banner" aria-label="Official government website">
+  <div class="container">
+    <header data-toggle="collapse" href="#gov-banner-default" role="button" aria-expanded="false" aria-controls="gov-banner-default">
+      <div class="usa-banner-inner">
+        <div class="usa-banner__header-flag"><img class="usa-banner__header-flag" src="/sites/all/themes/custom/nuhealthdata/assets/images/us_flag_small.png" alt="U.S. flag"></div>
+        <div class="usa-banner__header-text">An official website of the United States government</div>
+        <a class="usa-banner-link" aria-expanded="true" aria-controls="gov-banner-default">
+          Here’s how you know
+        </a>
+      </div>
+    </header>
+    <div class="collapse" id="gov-banner-default">
+      <div class="row clearfix">
+        <div class="guidance col-md-6">
+          <img class="usa-banner__icon" src="/sites/all/themes/custom/nuhealthdata/assets/images/icon-dot-gov.svg" role="img" alt="Dot gov">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Official websites use .gov</strong>
+              <br>
+              A <strong>.gov</strong> website belongs to an official government organization in the United States.
+            </p>
+          </div>
+        </div>
+        <div class="guidance col-md-6">
+          <img class="usa-banner__icon usa-media-block__img" src="/sites/all/themes/custom/nuhealthdata/assets/images/icon-https.svg" role="img" alt="Https">
+          <div class="usa-media-block__body">
+            <p>
+              <strong>Secure .gov websites use HTTPS</strong>
+              <br>
+              A <strong>lock</strong> (
+<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="18" viewBox="0 0 52 64" class="usa-banner__lock-image" role="img" aria-labelledby="banner-lock-title-default banner-lock-description-default"><title id="banner-lock-title-default">Lock</title><desc id="banner-lock-description-default">A locked padlock</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path></svg></span>
+) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+</section>
+<!-- end USWDS BANNER -->
+    <header id="header" class="header">
+  <div class="branding container">
+          <a class="logo navbar-btn pull-left" href="/" title="Home">
+        <img src="https://healthdata.gov/sites/default/files/logo.png" alt="Home" />
+      </a>
+            <!-- views exposed search -->
+    <section id="block-dkan-sitewide-dkan-sitewide-search-bar" class="block block-dkan-sitewide block-- clearfix">
+
+        <div class="content">
+    <form action="/node/3281086/revisions" method="post" id="dkan-sitewide-dataset-search-form" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-search form-group">
+  <label for="edit-search">Search </label>
+ <input placeholder="search" class="form-control form-text" type="text" id="edit-search" name="search" value="" size="30" maxlength="128" />
+</div>
+<input type="submit" id="edit-submit--2" name="op" value="" class="form-submit btn btn-default btn-primary" /><input type="hidden" name="form_build_id" value="form-kKtCp3rnWxmHc3e1pRWB835kNv3J1WJTV0UhLsfWud0" />
+<input type="hidden" name="form_id" value="dkan_sitewide_dataset_search_form" />
+</div></form>  </div>
+
+</section>
+  </div>
+  <div class="navigation-wrapper">
+    <div class="container">
+      <nav class="navbar navbar-default" role="navigation">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+        </div> <!-- /.navbar-header -->
+
+        <!-- Collect the nav links, forms, and other content for toggling -->
+        <div class="collapse navbar-collapse" id="navbar-collapse">
+                      <ul id="main-menu" class="menu nav navbar-nav">
+              <li class="first leaf menu-link-about"><a href="/content/about">About</a></li>
+<li class="leaf menu-link-datasets"><a href="/search/type/dataset" title="">Datasets</a></li>
+<li class="expanded dropdown menu-link-developers-"><a href="/node/86" class="dropdown-toggle" data-toggle="dropdown" data-target="#">Developers <span class="fa fa-caret-down"></span></a><ul class="dropdown-menu"><li class="first last leaf menu-link-healthdatagov-api"><a href="/api">HealthData.gov API</a></li>
+</ul></li>
+<li class="leaf menu-link-feedback"><a href="/feedback">Feedback</a></li>
+<li class="last leaf menu-link-covid-19-datasets"><a href="/search/type/dataset?query=covid-19&amp;sort_by=changed&amp;sort_order=DESC" title="Search for HHS COVID-19 data">COVID-19 Datasets</a></li>
+            </ul>
+          
+          <!-- user menu -->
+          <section id="block-dkan-sitewide-dkan-sitewide-user-menu" class="block block-dkan-sitewide block-- clearfix">
+
+        <div class="content">
+    <span class="links"><a href="/user/login">Log in</a></span>  </div>
+
+</section>
+        </div><!-- /.navbar-collapse -->
+      </nav><!-- /.navbar -->
+    </div><!-- /.container -->
+  </div> <!-- /.navigation -->
+</header>
+
+<div id="main-wrapper">
+  <div id="main" class="main container">
+
+    <ul class="breadcrumb"><li class="home-link"><a href="/"><i class="fa fa fa-home" aria-hidden="true"></i><span> Home</span></a></li><li><a href="/">Home</a></li><li><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749">COVID-19 Reported Patient Impact and Hospital Capacity by State</a></li><li><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state">COVID-19 Reported Patient Impact and Hospital Capacity by State</a></li><li class="active-trail">Revisions for <em class="placeholder">COVID-19 Reported Patient Impact and Hospital Capacity by State</em></li></ul>                <div class="region region-help">
+    <section id="block-system-help" class="block block-system block-- clearfix">
+
+        <div class="content">
+    <p>Revisions allow you to track differences between multiple versions of your content, and revert back to older versions.</p>
+  </div>
+
+</section>
+  </div>
+    
+
+    <div id="main-content" class="main-row">
+
+      <section>
+                          <h1 class="page-header">Revisions for <em class="placeholder">COVID-19 Reported Patient Impact and Hospital Capacity by State</em></h1>
+                                  <h2 class="element-invisible">Primary tabs</h2><ul class="tabs--primary nav nav-pills"><li><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749"><i class="fa fa-lg fa-eye"></i> View</a></li>
+<li class="active"><a href="/node/3281086/revisions" class="active"><i class="fa fa-lg fa-folder-open-o"></i> Revisions<span class="element-invisible">(active tab)</span></a></li>
+<li><a href="/node/3281086/dataset"><i class="fa fa-lg fa-caret-left"></i> Back to dataset</a></li>
+<li><a href="/node/3281086/download"><i class="fa fa-lg fa-download"></i> Download</a></li>
+</ul>                          <div class="region region-content">
+    <form action="/node/3281086/revisions" method="post" id="diff-node-revisions" accept-charset="UTF-8"><div><div class="table-responsive"><table class="diff-revisions table table-striped table-bordered">
+ <thead><tr><th>Revision</th><th colspan="2"><input type="submit" id="edit-submit" name="op" value="Compare" class="form-submit btn btn-default btn-primary" /></th><th colspan="2">Operations</th> </tr></thead>
+<tbody>
+ <tr class="revision-published diff-revision odd"><td class="revision-current"><a href="/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state/resource/38e07d07-40a2-4749">Mon, 02/01/2021 - 00:13</a> by <a href="/users/kevin-duvall" title="View user profile." class="username">Kevin Duvall</a><p class="revision-log">01/31/2021 2205 Revision File</p></td><td class="revision-current"><div class="form-item form-type-radio form-item-old radio">
+  <label for="edit-old-7501206"><input type="radio" id="edit-old-7501206" name="old" value="7501206" class="form-radio" /> </label>
+
+</div>
+</td><td class="revision-current"><div class="form-item form-type-radio form-item-new radio">
+  <label for="edit-new-7501206"><input type="radio" id="edit-new-7501206" name="new" value="7501206" checked="checked" class="form-radio" /> </label>
+
+</div>
+</td><td class="revision-current" colspan="2"><strong>This is the published revision.</strong></td> </tr>
+ <tr class="diff-revision even"><td><a href="/node/3281086/revisions/7498736/view">Sun, 12/13/2020 - 00:02</a> by <a href="/users/kevin-duvall" title="View user profile." class="username">Kevin Duvall</a><p class="revision-log">01/30/2021 2344 Revision File</p></td><td><div class="form-item form-type-radio form-item-old radio">
+  <label for="edit-old-7498736"><input type="radio" id="edit-old-7498736" name="old" value="7498736" checked="checked" class="form-radio" /> </label>
+
+</div>
+</td><td><div class="form-item form-type-radio form-item-new radio">
+  <label for="edit-new-7498736"><input type="radio" id="edit-new-7498736" name="new" value="7498736" class="form-radio" /> </label>
+
+</div>
+</td><td></td><td></td> </tr>
+ <tr class="diff-revision odd"><td><a href="/node/3281086/revisions/7498721/view">Sun, 12/13/2020 - 00:00</a> by <a href="/users/kevin-duvall" title="View user profile." class="username">Kevin Duvall</a><p class="revision-log">01/29/2021 1606 Revision File</p></td><td><div class="form-item form-type-radio form-item-old radio">
+  <label for="edit-old-7498721"><input type="radio" id="edit-old-7498721" name="old" value="7498721" class="form-radio" /> </label>
+
+</div>
+</td><td><div class="form-item form-type-radio form-item-new radio">
+  <label for="edit-new-7498721"><input type="radio" id="edit-new-7498721" name="new" value="7498721" class="form-radio" /> </label>
+
+</div>
+</td><td></td><td></td> </tr>
+ <tr class="diff-revision even"><td><a href="/node/3281086/revisions/7498686/view">Sat, 12/12/2020 - 23:59</a> by <a href="/users/kevin-duvall" title="View user profile." class="username">Kevin Duvall</a><p class="revision-log">01/28/2021 2205 Revision File</p></td><td><div class="form-item form-type-radio form-item-old radio">
+  <label for="edit-old-7498686"><input type="radio" id="edit-old-7498686" name="old" value="7498686" class="form-radio" /> </label>
+
+</div>
+</td><td><div class="form-item form-type-radio form-item-new radio">
+  <label for="edit-new-7498686"><input type="radio" id="edit-new-7498686" name="new" value="7498686" class="form-radio" /> </label>
+
+</div>
+</td><td></td><td></td> </tr>
+ <tr class="diff-revision odd"><td><a href="/node/3281086/revisions/7491031/view">Thu, 12/10/2020 - 23:38</a> by <a href="/users/kevin-duvall" title="View user profile." class="username">Kevin Duvall</a><p class="revision-log">01/27/2021 2205 Revision File</p></td><td><div class="form-item form-type-radio form-item-old radio">
+  <label for="edit-old-7491031"><input type="radio" id="edit-old-7491031" name="old" value="7491031" class="form-radio" /> </label>
+
+</div>
+</td><td><div class="form-item form-type-radio form-item-new radio">
+  <label for="edit-new-7491031"><input type="radio" id="edit-new-7491031" name="new" value="7491031" class="form-radio" /> </label>
+
+</div>
+</td><td></td><td></td> </tr>
+</tbody>
+</table>
+</div><input type="hidden" name="nid" value="3281086" />
+<div id="edit-old" class="form-radios"></div><div id="edit-new" class="form-radios"></div><input type="hidden" name="form_build_id" value="form-VdTGtceclcOKQp-ooPE8FYBo328IBEUcs8yONFG2OQY" />
+<input type="hidden" name="form_id" value="diff_node_revisions" />
+</div></form><div class="text-center"><div class="item-list"><ul class="pagination pager"><li class="pager-current active first"><span>1</span></li>
+<li class="pager-item"><a title="Go to page 2" href="/node/3281086/revisions?page=1">2</a></li>
+<li class="pager-item"><a title="Go to page 3" href="/node/3281086/revisions?page=2">3</a></li>
+<li class="pager-item"><a title="Go to page 4" href="/node/3281086/revisions?page=3">4</a></li>
+<li class="pager-next"><a title="Go to next page" href="/node/3281086/revisions?page=1">next ›</a></li>
+<li class="pager-last last"><a title="Go to last page" href="/node/3281086/revisions?page=3">last »</a></li>
+</ul></div></div>  </div>
+      </section>
+
+    </div>
+
+  </div> <!-- /#main -->
+</div> <!-- /#main-wrapper -->
+
+<footer id="footer" class="footer">
+  <div class="container">
+          <small class="copyright pull-left"><p>A federal government website managed by the  <a href="https://www.hhs.gov/">U.S. Department of Health &amp; Human Services</a><br />200 Independence Avenue, S.W. - Washington, D.C. 20201</p>
+<ul class="links">
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://healthdata.gov/content/about">About Us</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/accessibility.html">Accessibilty</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/privacy.html">Privacy Policy</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/open/plain-writing/index.html">Plain Writing</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/disclaimer.html">Disclaimers</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/asa/eeo/resources/index.html">No FEAR</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/open">HHS.gov/Open</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/foia/">FOIA</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.hhs.gov/">HHS.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="https://www.whitehouse.gov/">WhiteHouse.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.usa.gov/">USA.gov</a></li>
+<li class="col-xs-12 col-sm-4 col-md-3"><a href="http://www.usa.gov/gobiernousa/">GobiernoUSA.gov</a></li>
+</ul>
+</small>
+        <small class="pull-right"></small>
+  </div>
+</footer>
+  <script type="text/javascript" src="https://healthdata.gov/sites/default/files/js/js_29qYXJz8NLGg8Aomg-RZPjJcj9yEdEst1BMZ9gZbs-4.js"></script>
+<script type="text/javascript">window.NREUM||(NREUM={});NREUM.info={"beacon":"bam.nr-data.net","licenseKey":"b7126202e5","applicationID":"65779789","transactionName":"NlQDNRNTXkJTBxBcVg8eIAIVW19fHQANU18+VQgHB0FvXkQBFkNQBEY=","queueTime":0,"applicationTime":264,"atts":"GhMAQ1tJTUw=","errorBeacon":"bam.nr-data.net","agent":""}</script></body>
+</html>

--- a/tests/acquisition/covid_hosp/state_daily/test_database.py
+++ b/tests/acquisition/covid_hosp/state_daily/test_database.py
@@ -53,3 +53,18 @@ class DatabaseTests(unittest.TestCase):
         self.assertAlmostEqual(actual, expected)
       else:
         self.assertEqual(actual, expected)
+
+  def test_max_issue(self):
+    """Get the most recent issue added to the database"""
+
+    # Note that query logic is tested separately by integration tests. This
+    # test just checks that the function maps inputs to outputs as expected.
+
+    mock_connection = MagicMock()
+    mock_cursor = mock_connection.cursor()
+    database = Database(mock_connection)
+
+    result = database.get_max_issue()
+
+    self.assertEqual(mock_cursor.execute.call_count, 1)
+    self.assertEqual(result, 0, "max issue when db is empty")

--- a/tests/acquisition/covid_hosp/state_daily/test_network.py
+++ b/tests/acquisition/covid_hosp/state_daily/test_network.py
@@ -1,10 +1,13 @@
 """Unit tests for network.py."""
 
 # standard library
+import requests
 import unittest
 from unittest.mock import patch
 from unittest.mock import sentinel
 
+# first party
+from delphi.epidata.acquisition.covid_hosp.common.test_utils import TestUtils
 from delphi.epidata.acquisition.covid_hosp.state_daily.network import Network
 
 # py3tester coverage target
@@ -13,6 +16,11 @@ __test_target__ = \
 
 
 class NetworkTests(unittest.TestCase):
+  def setUp(self):
+    """Perform per-test setup."""
+
+    # configure test data
+    self.test_utils = TestUtils(__file__)
 
   def test_fetch_metadata(self):
     """Fetch metadata as JSON."""
@@ -24,3 +32,17 @@ class NetworkTests(unittest.TestCase):
 
       self.assertEqual(result, sentinel.json)
       func.assert_called_once_with(dataset_id=Network.DATASET_ID)
+
+  def test_fetch_revisions(self):
+    """Scrape CSV files from revision pages"""
+
+    with patch.object(requests, 'get',
+                      side_effect=list(self.test_utils.load_sample_revisions())) as requests_get:
+      result = Network.fetch_revisions(20201210)
+
+      self.assertEqual(requests_get.call_count, 4)
+      self.assertEqual(result, [
+        "https://healthdata.gov/sites/default/files/reported_hospital_utilization_20210130_2344.csv",
+        "https://healthdata.gov/sites/default/files/reported_hospital_utilization_20210129_1606.csv",
+        "https://healthdata.gov/sites/default/files/reported_hospital_utilization_20210128_2205.csv"
+      ])

--- a/tests/acquisition/covid_hosp/state_daily/test_network.py
+++ b/tests/acquisition/covid_hosp/state_daily/test_network.py
@@ -40,7 +40,12 @@ class NetworkTests(unittest.TestCase):
                       side_effect=list(self.test_utils.load_sample_revisions())) as requests_get:
       result = Network.fetch_revisions(20201210)
 
+      # 4: one for the revisions page, and one for each of three qualifying
+      # revisions details pages
       self.assertEqual(requests_get.call_count, 4)
+
+      # The revisions page lists 5 revisions, but the first should be skipped
+      # and the fifth should be excluded as outside the date range
       self.assertEqual(result, [
         "https://healthdata.gov/sites/default/files/reported_hospital_utilization_20210130_2344.csv",
         "https://healthdata.gov/sites/default/files/reported_hospital_utilization_20210129_1606.csv",

--- a/tests/acquisition/covid_hosp/state_daily/test_update.py
+++ b/tests/acquisition/covid_hosp/state_daily/test_update.py
@@ -6,6 +6,9 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 from unittest.mock import sentinel
 
+# third party
+import pandas as pd
+
 # first party
 from delphi.epidata.acquisition.covid_hosp.common.test_utils import TestUtils
 from delphi.epidata.acquisition.covid_hosp.common.utils import Utils
@@ -45,6 +48,9 @@ class UpdateTests(unittest.TestCase):
       # extra level of indirection due to context manager
       mock_connect.return_value.__enter__.return_value = mock_db
 
+      key_cols = ['state', 'reporting_cutoff_start']
+      self.assertTrue('state' in sample_dataset.columns)
+      self.assertTrue('reporting_cutoff_start' in sample_dataset.columns)
       result = Update.run()
 
       mock_metadata.assert_called_once()
@@ -53,7 +59,65 @@ class UpdateTests(unittest.TestCase):
       mock_connect.assert_called_once()
       mock_revisions.assert_called_with(sentinel.last_issue)
       mock_fetch.assert_called_with(sentinel.url)
+
+      # don't care what the third argument is, so only test the first two:
       self.assertEqual(mock_db.insert_metadata.call_args.args[0], sentinel.issue)
       self.assertEqual(mock_db.insert_metadata.call_args.args[1], sentinel.revision)
-      mock_db.insert_dataset.assert_called_with(sentinel.issue, sample_dataset)
-      self.assertEqual(result, True)
+
+      # can't use assert_called_with to test data frame equality, so check args individually:
+      self.assertEqual(mock_db.insert_dataset.call_args.args[0], sentinel.issue)
+      self.assertEqual(set(mock_db.insert_dataset.call_args.args[1].columns),
+                       set(sample_dataset.columns))
+      pd.testing.assert_frame_equal(
+        mock_db.insert_dataset.call_args.args[1],
+        sample_dataset[mock_db.insert_dataset.call_args.args[1].columns]
+      )
+      self.assertTrue(result)
+
+  def test_merge(self):
+    """Merging the set of updates in each batch is pretty tricky"""
+    # Generate a set of synthetic updates with overlapping keys
+    N = 10
+    dfs = []
+    for i in range(5):
+        # knock out every 2nd key, then every 3rd, then every 4th, etc
+        dfs.append(pd.DataFrame(dict(
+            state=range(1, N, i+1),
+            reporting_cutoff_start=range(N+1, 2*N, i+1),
+            **{spec[0]: i+1 for spec in Database.ORDERED_CSV_COLUMNS[2:]}
+        )))
+    # add a data frame with unseen keys
+    dfs.append(pd.DataFrame(dict(
+      state=[-1],
+      reporting_cutoff_start=[-1],
+      **{spec[0]: -1 for spec in Database.ORDERED_CSV_COLUMNS[2:]}
+    )))
+
+    # now we need to know which data frame was used as the final value. the
+    # above procedure is a prime number generator, so we can derive the result
+    # mathematically:
+
+    # for x in 1..N get the greatest number 5 or less that evenly divides x
+    value_from = [[i for i in range(5, 0, -1) if x/i == x//i][0] for x in range(N-1)] + [-1]
+    states = list(range(1, N)) + [-1]
+    dates = list(range(N+1, 2*N)) + [-1]
+    self.assertEqual(len(value_from), len(states))
+    self.assertEqual(len(states), len(dates))
+
+    expected = pd.DataFrame(dict(
+        state=states,
+        reporting_cutoff_start=dates,
+        **{spec[0]: value_from for spec in Database.ORDERED_CSV_COLUMNS[2:]}
+    )).astype({spec[0]: 'float64' for spec in Database.ORDERED_CSV_COLUMNS[2:]}
+    )
+    result = Update.merge_by_state_date(dfs)
+    try:
+      pd.testing.assert_frame_equal(result, expected)
+    except:
+      assert False, f"""
+result:
+{result}
+
+expected:
+{expected}
+"""

--- a/tests/acquisition/covid_hosp/state_daily/test_update.py
+++ b/tests/acquisition/covid_hosp/state_daily/test_update.py
@@ -2,12 +2,16 @@
 
 # standard library
 import unittest
+from unittest.mock import MagicMock
 from unittest.mock import patch
 from unittest.mock import sentinel
 
 # first party
+from delphi.epidata.acquisition.covid_hosp.common.test_utils import TestUtils
 from delphi.epidata.acquisition.covid_hosp.common.utils import Utils
 from delphi.epidata.acquisition.covid_hosp.state_daily.update import Update
+from delphi.epidata.acquisition.covid_hosp.state_daily.network import Network
+from delphi.epidata.acquisition.covid_hosp.state_daily.database import Database
 
 # py3tester coverage target
 __test_target__ = \
@@ -15,14 +19,41 @@ __test_target__ = \
 
 
 class UpdateTests(unittest.TestCase):
+  def setUp(self):
+    """Perform per-test setup."""
+
+    # configure test data
+    self.test_utils = TestUtils(__file__)
 
   def test_run(self):
-    """Acquire a new dataset."""
+    """Acquire a new dataset.
 
-    with patch.object(Utils, 'update_dataset') as mock_update_dataset:
-      mock_update_dataset.return_value = sentinel.result
+    This test is more involved than the other covid_hosp update tests because we
+    need to make sure batches are being fetched properly.
+    """
+
+    mock_db = MagicMock(spec=Database)
+    mock_db.contains_revision.return_value = False
+    mock_db.get_max_issue.return_value = sentinel.last_issue
+    sample_dataset = self.test_utils.load_sample_dataset()
+    with patch.object(Network, 'fetch_metadata', return_value=self.test_utils.load_sample_metadata()) as mock_metadata, \
+         patch.object(Utils, 'extract_resource_details', return_value=(sentinel.url, sentinel.revision)) as mock_details, \
+         patch.object(Utils, 'get_issue_from_revision', return_value=sentinel.issue) as mock_issue, \
+         patch.object(Database, 'connect', return_value=MagicMock()) as mock_connect, \
+         patch.object(Network, 'fetch_revisions', return_value=[sentinel.batch]) as mock_revisions, \
+         patch.object(Network, 'fetch_dataset', return_value=sample_dataset) as mock_fetch:
+      # extra level of indirection due to context manager
+      mock_connect.return_value.__enter__.return_value = mock_db
 
       result = Update.run()
 
-      self.assertEqual(result, sentinel.result)
-      mock_update_dataset.assert_called_once()
+      mock_metadata.assert_called_once()
+      mock_details.assert_called_once()
+      mock_issue.assert_called_with(sentinel.revision)
+      mock_connect.assert_called_once()
+      mock_revisions.assert_called_with(sentinel.last_issue)
+      mock_fetch.assert_called_with(sentinel.url)
+      self.assertEqual(mock_db.insert_metadata.call_args.args[0], sentinel.issue)
+      self.assertEqual(mock_db.insert_metadata.call_args.args[1], sentinel.revision)
+      mock_db.insert_dataset.assert_called_with(sentinel.issue, sample_dataset)
+      self.assertEqual(result, True)


### PR DESCRIPTION
Context: Daily update files are posted in batches of several days at a
time. Only the most recent file is surfaced through metadata, but all updates
are posted on the revisions page.

This PR adapts the state_daily pipeline to:

1. Fetch all files in the batch
2. Merge them (I checked with the Reich folks that this is the desired behavior)
3. Upload as a single issue based on the upload date (=date recorded in metadata)

This requires some substantial changes to Update and tests to account for and
mock out the pipeline differences to common, and minor changes to Network and
Database.

BeautifulSoup (`bs4`) was already listed in `operations.requirements.txt`, so it shouldn't need to be added to prod before merging.

Fixes #402 