### PR TITLE
Add page to symptom surveys block to document contingency tables

### DIFF
--- a/docs/symptom-survey/coding.md
+++ b/docs/symptom-survey/coding.md
@@ -1,7 +1,7 @@
 ---
 title: Questions and Coding
 parent: COVID Symptom Survey
-nav_order: 5
+nav_order: 6
 ---
 
 # Questions and Coding

--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -14,9 +14,13 @@ demographic features:
 * [Weekly files](https://cmu.box.com/s/xwjulq0pteen52d4upni9ikagu7d8bl2)
 * [Monthly files](https://cmu.box.com/s/vh4gs3j541tt9pqn2pn72bktu0op8tpo)
 
-Please also take a look at the [individual response data](./survey-files.md),
-and the [coarse aggregates](../api/covidcast-signals/fb-survey.md) -- grouped
-only by region -- to find the data product that best suits your needs.
+These contingency tables demographic breakdowns of COVID-related topics such as
+vaccine uptake and acceptance. They are more detailed than the [coarse
+aggregates reported in the COVIDcast Epidata
+API](../api/covidcast-signals/fb-survey.md), which are grouped only by
+geographic region. [Individual response data](survey-files.md) for the survey is
+available, but only to academic or nonprofit researchers who sign a Data Use
+Agreement, whereas these contingency tables are available to the general public.
 
 Important updates for data users, including corrections to data or updates on
 data processing delays, are posted as `OUTAGES.txt` in the directory where the
@@ -36,17 +40,21 @@ monthly files. Because monthly aggregates include more responses, they have
 lower missingness when grouping by several features at a time.
 
 ## Dates
+
 The included files provide estimates for various metrics of interest over a
-period of either a full epiweek or a full month.
+period of either a full epiweek (or [MMWR
+week](https://wwwn.cdc.gov/nndss/document/MMWR_week_overview.pdf), a
+standardized numbering of weeks throughout the year) or a full month.
 
 ## Aggregation
+
 The aggregates are filtered to only include estimates for a particular group if
-that group includes 100 or more responses. Especially in the weekly aggregtes,
+that group includes 100 or more responses. Especially in the weekly aggregates,
 many of the state-level groups have been filtered out due to low sample size. In
 such cases, the state marginal files, which group by a single demographic of
 interest at a time, will likely provide more coverage.
 
-## File format
+## File Format
 
 ### Naming
 
@@ -67,25 +75,26 @@ Within a CSV, the first few columns are the grouping variables, ordered
 alphabetically. Each aggregate reports four columns (unrounded):
 
 * `val_<indicator name>`: the main value of interest, e.g., percent, average, or
-  count
+  count, estimated using the [survey weights](weights.md) to better match state
+  demographics
 * `se_<indicator name>`: the standard error of `val_<indicator name>`
 * `sample_size_<indicator name>`: the number of survey responses used to
   calculate `val_<indicator name>`
 * `represented_<indicator name>`: the number of people in the population that
   `val_<indicator name>` represents over all days in the given time period. This
-  is the sum of [participant weights](./weights.md) for all survey responses
+  is the sum of [survey weights](./weights.md) for all survey responses
   used.
 
 All aggregates using the same set of grouping variables appear in a single CSV.
 
 ## Indicators
 
-The files in this folder contain [weighted
+The files contain [weighted
 estimates](../api/covidcast-signals/fb-survey.md#survey-weighting) of percent of
 respondents who fulfill one or several criteria. Estimates are broken out by
 state, age, gender, race, and ethnicity.
 
-| Signal | Description | Survey Item |
+| Indicator | Description | Survey Item |
 | --- | --- | --- |
 | `pct_vaccinated` | Estimated percentage of respondents who have already received a COVID vaccine. <br/> **Earliest date available:** 2021-01-01 | V1 |
 | `pct_accepting` | Estimated percentage of respondents who would definitely or probably choose to get vaccinated, if a vaccine were offered to them today, among respondents who have not yet been vaccinated. <br/> **Earliest date available:** 2021-01-01 | V3 |

--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -1,0 +1,47 @@
+---
+title: Contingency Tables
+parent: COVID Symptom Survey
+nav_order: 4
+---
+
+# Contingency Tables
+{: .no_toc}
+
+This documentation describes the fine-resolution contingency tables produced by
+grouping [COVID Symptom Survey](./index.md) individual responses by various
+demographic features.
+
+Please also take a look at the [individual response data](./survey-files.md),
+and the geographic aggregate data available [through the COVIDcast
+API](../api/covidcast-signals/fb-survey.md) to find the data product that best
+suits your needs.
+
+Important updates for data users, including corrections to data or updates on
+data processing delays, are posted as `OUTAGES.txt` in the directory
+where the data is hosted.
+
+## Table of contents
+{: .no_toc .text-delta}
+
+1. TOC
+{:toc}
+
+## Available Data Files
+
+We provide two types of data files, weekly and monthly. Users who need the most
+up-to-date data or are interested in timeseries should use the weekly files,
+while those who want to study groups with smaller sample sizes should use the
+monthly files. Because monthly aggregates include more responses, they have
+lower missingness when grouping by several features at a time.
+
+### Weekly Files
+
+Once a week, we write CSV files with names following this pattern:
+
+  {date}_{region}_{vars}.csv
+
+Dates in of the form `YYYYmmdd`. `date` refers to the first day of the epiweek survey responses were aggregated over, in the Pacific time zone (UTC - 7). Unless noted otherwise, this is always a complete week. `region` is the geographic level responses were aggregated over. At the moment, only nation-wide and state groupings are available.
+
+### Monthly Files
+
+Once a month, we write CSV files that aggregate responses over the last complete month. Format and naming schemes are identical to the weekly case.

--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -15,9 +15,8 @@ demographic features:
 * [Monthly files](https://cmu.box.com/s/vh4gs3j541tt9pqn2pn72bktu0op8tpo)
 
 Please also take a look at the [individual response data](./survey-files.md),
-and the coarse aggregates -- grouped only by region -- available [through the
-COVIDcast API](../api/covidcast-signals/fb-survey.md) to find the data product
-that best suits your needs.
+and the [coarse aggregates](../api/covidcast-signals/fb-survey.md) -- grouped
+only by region -- to find the data product that best suits your needs.
 
 Important updates for data users, including corrections to data or updates on
 data processing delays, are posted as `OUTAGES.txt` in the directory where the
@@ -42,10 +41,10 @@ period of either a full epiweek or a full month.
 
 ## Aggregation
 The aggregates are filtered to only include estimates for a particular group if
-there were 100 or more responses. Especially in the weekly aggregtes, many of
-the state-level groups have been filtered out due to low sample size. In such
-cases, the state marginal files, which group by a single demographic of interest
-at a time, will likely provide more coverage.
+that group includes 100 or more responses. Especially in the weekly aggregtes,
+many of the state-level groups have been filtered out due to low sample size. In
+such cases, the state marginal files, which group by a single demographic of
+interest at a time, will likely provide more coverage.
 
 ## File format
 
@@ -55,12 +54,12 @@ Each CSV is named as follows:
 
     {date}_{region}_{vars}.csv
 
-Dates in of the form `YYYYmmdd`. `date` refers to the first day of the time
+Dates are of the form `YYYYmmdd`. `date` refers to the first day of the time
 period survey responses were aggregated over, in the Pacific time zone (UTC -
-7). Unless noted otherwise, this is always a complete month or epiweek. `region`
-is the geographic level responses were aggregated over. At the moment, only
-nation-wide and state groupings are available. `vars` is a list all other
-grouping variables used in the aggregation, ordered alphabetically.
+7). Unless noted otherwise, the time period is always a complete month or
+epiweek. `region` is the geographic level responses were aggregated over. At the
+moment, only nation-wide and state groupings are available. `vars` is a list all
+other grouping variables used in the aggregation, ordered alphabetically.
 
 ### Columns
 
@@ -81,8 +80,9 @@ All aggregates using the same set of grouping variables appear in a single CSV.
 
 ## Indicators
 
-The files in this folder contain [weighted](./weights.md) estimates of percent
-of respondents who fulfill one or several criteria. Estimates are broken out by
+The files in this folder contain [weighted
+estimates](../api/covidcast-signals/fb-survey.md#survey-weighting) of percent of
+respondents who fulfill one or several criteria. Estimates are broken out by
 state, age, gender, race, and ethnicity.
 
 | Signal | Description | Survey Item |
@@ -103,5 +103,6 @@ state, age, gender, race, and ethnicity.
 | `pct_trust_politicians` | Estimated percentage of respondents who would be more likely to get a COVID-19 vaccine if it were recommended to them by politicians, among respondents who have not yet been vaccinated *and* would "definitely not" or "probably not" get a COVID-19 vaccine if offered. <br/> **Earliest date available:** 2021-01-01 | V3 and V4 |
 
 Note: CSVs for the month of January 2021 only use data from January 6-31 due to
-a [definitional change](./coding.md#new-items-2) in a major vaccine item on
-January 6.
+a [definitional change in a major vaccine item on January
+6](./coding.md#new-items-2). Indicators based on [item V9 use data starting
+January 12](./coding.md#new-items-2).

--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -53,7 +53,7 @@ at a time, will likely provide more coverage.
 
 Each CSV is named as follows:
 
-  {date}_{region}_{vars}.csv
+    {date}_{region}_{vars}.csv
 
 Dates in of the form `YYYYmmdd`. `date` refers to the first day of the time
 period survey responses were aggregated over, in the Pacific time zone (UTC -

--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -1,7 +1,5 @@
 ---
-title: Contingency Tables
-parent: COVID Symptom Survey
-nav_order: 4
+title: Contingency Tables parent: COVID Symptom Survey nav_order: 4
 ---
 
 # Contingency Tables
@@ -12,19 +10,18 @@ grouping [COVID Symptom Survey](./index.md) individual responses by various
 demographic features.
 
 Please also take a look at the [individual response data](./survey-files.md),
-and the geographic aggregate data available [through the COVIDcast
-API](../api/covidcast-signals/fb-survey.md) to find the data product that best
-suits your needs.
+and the coarse aggregates -- grouped only by region -- available [through the
+COVIDcast API](../api/covidcast-signals/fb-survey.md) to find the data product
+that best suits your needs.
 
 Important updates for data users, including corrections to data or updates on
-data processing delays, are posted as `OUTAGES.txt` in the directory
-where the data is hosted.
+data processing delays, are posted as `OUTAGES.txt` in the directory where the
+data is hosted.
 
 ## Table of contents
 {: .no_toc .text-delta}
 
-1. TOC
-{:toc}
+1. TOC {:toc}
 
 ## Available Data Files
 
@@ -34,14 +31,72 @@ while those who want to study groups with smaller sample sizes should use the
 monthly files. Because monthly aggregates include more responses, they have
 lower missingness when grouping by several features at a time.
 
-### Weekly Files
+## Dates
+The included files provide estimates for various metrics of interest over a
+period of either a full epiweek or a full month.
 
-Once a week, we write CSV files with names following this pattern:
+## Aggregation
+The aggregates are filtered to only include estimates for a particular group if
+there were 100 or more responses. Especially in the weekly aggregtes, many of
+the state-level groups have been filtered out due to low sample size. In such
+cases, the state marginal files, which group by a single demographic of interest
+at a time, will likely provide more coverage.
+
+## File format
+
+### Naming
+
+Each CSV is named as follows:
 
   {date}_{region}_{vars}.csv
 
-Dates in of the form `YYYYmmdd`. `date` refers to the first day of the epiweek survey responses were aggregated over, in the Pacific time zone (UTC - 7). Unless noted otherwise, this is always a complete week. `region` is the geographic level responses were aggregated over. At the moment, only nation-wide and state groupings are available.
+Dates in of the form `YYYYmmdd`. `date` refers to the first day of the time
+period survey responses were aggregated over, in the Pacific time zone (UTC -
+7). Unless noted otherwise, this is always a complete month or epiweek. `region`
+is the geographic level responses were aggregated over. At the moment, only
+nation-wide and state groupings are available. `vars` is a list all other
+grouping variables used in the aggregation, ordered alphabetically.
 
-### Monthly Files
+### Columns
 
-Once a month, we write CSV files that aggregate responses over the last complete month. Format and naming schemes are identical to the weekly case.
+Within a CSV, the first few columns are the grouping variables, ordered
+alphabetically. Each aggregate reports four columns (unrounded):
+
+* `val_<indicator name>`: the main value of interest, e.g., percent, average, or
+  count
+* `se_<indicator name>`: the standard error of `val_<indicator name>`
+* `sample_size_<indicator name>`: the number of survey responses used to
+  calculate `val_<indicator name>`
+* `represented_<indicator name>`: the number of people in the population that
+  `val_<indicator name>` represents over all days in the given time period. This
+  is the sum of [participant weights](./weights.md) for all survey responses
+  used.
+
+All aggregates using the same set of grouping variables appear in a single CSV.
+
+## Indicators
+
+The files in this folder contain [weighted](./weights.md) estimates of percent
+of respondents who fulfill one or several criteria. Estimates are broken out by
+state, age, gender, race, and ethnicity.
+
+| Signal | Description | Survey Item |
+| --- | --- | --- |
+| `pct_vaccinated` | Estimated percentage of respondents who have already received a COVID vaccine. <br/> **Earliest date available:** 2021-01-01 | V1 |
+| `pct_accepting` | Estimated percentage of respondents who would definitely or probably choose to get vaccinated, if a vaccine were offered to them today, among respondents who have not yet been vaccinated. <br/> **Earliest date available:** 2021-01-01 | V3 |
+| `pct_concerned_sideeffects` | Estimated percentage of respondents who are very or moderately concerned that they would "experience a side effect from a COVID-19 vaccination." (Asked of all respondents, including those who have already received one or more doses of a COVID-19 vaccine.) <br/> **Earliest date available:** 2021-01-01 | V9 |
+| `pct_hesitant_sideeffects` | Estimated percentage of respondents who are very or moderately concerned that they would "experience a side effect from a COVID-19 vaccination" *and* would "definitely not" or "probably not" get a COVID-19 vaccine if offered. <br/> **Earliest date available:** 2021-01-01 | V9 and V3 |
+| `pct_trust_fam` | Estimated percentage of respondents who would be more likely to get a COVID-19 vaccine if it were recommended to them by friends and family, among respondents who have not yet been vaccinated. <br/> **Earliest date available:** 2021-01-01 | V4 |
+| `pct_trust_healthcare` | Estimated percentage of respondents who would be more likely to get a COVID-19 vaccine if it were recommended to them by local health workers, among respondents who have not yet been vaccinated. <br/> **Earliest date available:** 2021-01-01 | V4 |
+| `pct_trust_who` | Estimated percentage of respondents who would be more likely to get a COVID-19 vaccine if it were recommended to them by the World Health Organization, among respondents who have not yet been vaccinated. <br/> **Earliest date available:** 2021-01-01 | V4 |
+| `pct_trust_govt` | Estimated percentage of respondents who would be more likely to get a COVID-19 vaccine if it were recommended to them by government health officials, among respondents who have not yet been vaccinated. <br/> **Earliest date available:** 2021-01-01 | V4 |
+| `pct_trust_politicians` | Estimated percentage of respondents who would be more likely to get a COVID-19 vaccine if it were recommended to them by politicians, among respondents who have not yet been vaccinated. <br/> **Earliest date available:** 2021-01-01 | V4 |
+| `pct_hesitant_trust_fam` | Estimated percentage of respondents who would be more likely to get a COVID-19 vaccine if it were recommended to them by friends and family, among respondents who have not yet been vaccinated *and* would "definitely not" or "probably not" get a COVID-19 vaccine if offered. <br/> **Earliest date available:** 2021-01-01 | V3 and V4 |
+| `pct_hesitant_trust_healthcare` | Estimated percentage of respondents who would be more likely to get a COVID-19 vaccine if it were recommended to them by local health workers, among respondents who have not yet been vaccinated *and* would "definitely not" or "probably not" get a COVID-19 vaccine if offered. <br/> **Earliest date available:** 2021-01-01 | V3 and V4 |
+| `pct_hesitant_trust_who` | Estimated percentage of respondents who would be more likely to get a COVID-19 vaccine if it were recommended to them by the World Health Organization, among respondents who have not yet been vaccinated *and* would "definitely not" or "probably not" get a COVID-19 vaccine if offered. <br/> **Earliest date available:** 2021-01-01 | V3 and V4 |
+| `pct_hesitant_trust_govt` | Estimated percentage of respondents who would be more likely to get a COVID-19 vaccine if it were recommended to them by government health officials, among respondents who have not yet been vaccinated *and* would "definitely not" or "probably not" get a COVID-19 vaccine if offered. <br/> **Earliest date available:** 2021-01-01 | V3 and V4 |
+| `pct_trust_politicians` | Estimated percentage of respondents who would be more likely to get a COVID-19 vaccine if it were recommended to them by politicians, among respondents who have not yet been vaccinated *and* would "definitely not" or "probably not" get a COVID-19 vaccine if offered. <br/> **Earliest date available:** 2021-01-01 | V3 and V4 |
+
+Note: CSVs for the month of January 2021 only use data from January 6-31 due to
+a [definitional change](./coding.md#new-items-2) in a major vaccine item on
+January 6.

--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -1,5 +1,7 @@
 ---
-title: Contingency Tables parent: COVID Symptom Survey nav_order: 4
+title: Contingency Tables
+parent: COVID Symptom Survey
+nav_order: 4
 ---
 
 # Contingency Tables
@@ -7,7 +9,10 @@ title: Contingency Tables parent: COVID Symptom Survey nav_order: 4
 
 This documentation describes the fine-resolution contingency tables produced by
 grouping [COVID Symptom Survey](./index.md) individual responses by various
-demographic features.
+demographic features:
+
+* [Weekly files](https://cmu.box.com/s/xwjulq0pteen52d4upni9ikagu7d8bl2)
+* [Monthly files](https://cmu.box.com/s/vh4gs3j541tt9pqn2pn72bktu0op8tpo)
 
 Please also take a look at the [individual response data](./survey-files.md),
 and the coarse aggregates -- grouped only by region -- available [through the

--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -29,7 +29,8 @@ data is hosted.
 ## Table of contents
 {: .no_toc .text-delta}
 
-1. TOC {:toc}
+1. TOC
+{:toc}
 
 ## Available Data Files
 

--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -14,7 +14,7 @@ demographic features:
 * [Weekly files](https://cmu.box.com/s/xwjulq0pteen52d4upni9ikagu7d8bl2)
 * [Monthly files](https://cmu.box.com/s/vh4gs3j541tt9pqn2pn72bktu0op8tpo)
 
-These contingency tables demographic breakdowns of COVID-related topics such as
+These contingency tables provide demographic breakdowns of COVID-related topics such as
 vaccine uptake and acceptance. They are more detailed than the
 [coarse aggregates reported in the COVIDcast Epidata API](../api/covidcast-signals/fb-survey.md),
 which are grouped only by geographic region. [Individual response data](survey-files.md)

--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -15,12 +15,12 @@ demographic features:
 * [Monthly files](https://cmu.box.com/s/vh4gs3j541tt9pqn2pn72bktu0op8tpo)
 
 These contingency tables demographic breakdowns of COVID-related topics such as
-vaccine uptake and acceptance. They are more detailed than the [coarse
-aggregates reported in the COVIDcast Epidata
-API](../api/covidcast-signals/fb-survey.md), which are grouped only by
-geographic region. [Individual response data](survey-files.md) for the survey is
-available, but only to academic or nonprofit researchers who sign a Data Use
-Agreement, whereas these contingency tables are available to the general public.
+vaccine uptake and acceptance. They are more detailed than the
+[coarse aggregates reported in the COVIDcast Epidata API](../api/covidcast-signals/fb-survey.md),
+which are grouped only by geographic region. [Individual response data](survey-files.md)
+for the survey is available, but only to academic or nonprofit researchers who
+sign a Data Use Agreement, whereas these contingency tables are available to the
+general public.
 
 Important updates for data users, including corrections to data or updates on
 data processing delays, are posted as `OUTAGES.txt` in the directory where the
@@ -112,6 +112,5 @@ state, age, gender, race, and ethnicity.
 | `pct_trust_politicians` | Estimated percentage of respondents who would be more likely to get a COVID-19 vaccine if it were recommended to them by politicians, among respondents who have not yet been vaccinated *and* would "definitely not" or "probably not" get a COVID-19 vaccine if offered. <br/> **Earliest date available:** 2021-01-01 | V3 and V4 |
 
 Note: CSVs for the month of January 2021 only use data from January 6-31 due to
-a [definitional change in a major vaccine item on January
-6](./coding.md#new-items-2). Indicators based on [item V9 use data starting
-January 12](./coding.md#new-items-2).
+a [definitional change in a major vaccine item on January 6](./coding.md#new-items-2).
+Indicators based on [item V9 use data starting January 12](./coding.md#new-items-2).

--- a/docs/symptom-survey/data-access.md
+++ b/docs/symptom-survey/data-access.md
@@ -21,6 +21,7 @@ which sets out the basic conditions and provides a form to request access. An
 is conducted by the University of Maryland (UMD) and access can be requested
 through the same form.
 
-[High-level aggregates](../api/covidcast.md) of select survey items are available in the [COVIDcast
-API](../api/fb-survey.md). [Finer aggregates](./contingency-tables.md) grouped by
-various demographic characteristics are available for download.
+[High-level aggregates](../api/covidcast.md) of select survey items are
+available in the [COVIDcast API](../api/covidcast-signals/fb-survey.md).
+[Finer aggregates](./contingency-tables.md) grouped by various demographic
+characteristics are available for download.

--- a/docs/symptom-survey/data-access.md
+++ b/docs/symptom-survey/data-access.md
@@ -21,7 +21,6 @@ which sets out the basic conditions and provides a form to request access. An
 is conducted by the University of Maryland (UMD) and access can be requested
 through the same form.
 
-High-level aggregates of select survey items are available in the [COVIDcast
-API](../api/fb-survey.md), more information [here](../api/covidcast.md). Finer aggregates grouped by
-various demographic characteristics are available for download, more information
-[here](./contingency-tables.md).
+[High-level aggregates](../api/covidcast.md) of select survey items are available in the [COVIDcast
+API](../api/fb-survey.md). [Finer aggregates](./contingency-tables.md) grouped by
+various demographic characteristics are available for download.

--- a/docs/symptom-survey/data-access.md
+++ b/docs/symptom-survey/data-access.md
@@ -12,7 +12,7 @@ spread of COVID-19 and its effects on public health and well-being. This may
 help improve our local and national responses to the pandemic and our
 understanding of how it has affected society.
 
-De-identified data can be made available to researchers associated with
+De-identified individual survey responses can be made available to researchers associated with
 universities or non-profit organizations. To request access to the data please
 submit the information requested in [Facebook's page on obtaining data
 access](https://dataforgood.fb.com/docs/covid-19-symptom-survey-request-for-data-access/),
@@ -20,3 +20,8 @@ which sets out the basic conditions and provides a form to request access. An
 [international version of the COVID Symptom Survey](https://covidmap.umd.edu/)
 is conducted by the University of Maryland (UMD) and access can be requested
 through the same form.
+
+High-level aggregates of select survey items are available in the [COVIDcast
+API](../api/fb-survey.md), more information [here](../api/covidcast.md). Finer aggregates grouped by
+various demographic characteristics are available for download, more information
+[here](./contingency-tables.md).

--- a/docs/symptom-survey/data-access.md
+++ b/docs/symptom-survey/data-access.md
@@ -22,6 +22,6 @@ is conducted by the University of Maryland (UMD) and access can be requested
 through the same form.
 
 [High-level aggregates](../api/covidcast.md) of select survey items are
-available in the [COVIDcast API](../api/covidcast-signals/fb-survey.md).
+publicly available in the [COVIDcast API](../api/covidcast-signals/fb-survey.md).
 [Finer aggregates](./contingency-tables.md) grouped by various demographic
 characteristics are available for download.

--- a/docs/symptom-survey/index.md
+++ b/docs/symptom-survey/index.md
@@ -14,10 +14,9 @@ experienced as a result of the pandemic. A high-level overview of the survey is
 posted [on the COVIDcast website](https://delphi.cmu.edu/covidcast/surveys/).
 
 Geographically aggregated data from this survey is publicly available through
-the [COVIDcast API](../api/covidcast.md) as the [`fb-survey` data
-source](../api/covidcast-signals/fb-survey.md). Demographic breakdowns of survey
-data are publicly available as [downloadable contingency
-tables](contingency-tables.md).
+the [COVIDcast API](../api/covidcast.md) as the [`fb-survey` data source](../api/covidcast-signals/fb-survey.md).
+Demographic breakdowns of survey data are publicly available as
+[downloadable contingency tables](contingency-tables.md).
 
 This documentation describes the survey items, data coding, data distribution,
 and the survey weights computed by Facebook. It also documents the individual

--- a/docs/symptom-survey/index.md
+++ b/docs/symptom-survey/index.md
@@ -13,14 +13,17 @@ social distancing), mental health, and economic and health impacts they have
 experienced as a result of the pandemic. A high-level overview of the survey is
 posted [on the COVIDcast website](https://delphi.cmu.edu/covidcast/surveys/).
 
-Aggregate data from this survey is available through the [COVIDcast API](../api/covidcast.md)
-as the [`fb-survey` data source](../api/covidcast-signals/fb-survey.md).
+Geographically aggregated data from this survey is publicly available through
+the [COVIDcast API](../api/covidcast.md) as the [`fb-survey` data
+source](../api/covidcast-signals/fb-survey.md). Demographic breakdowns of survey
+data are publicly available as [downloadable contingency
+tables](contingency-tables.md).
 
-This documentation is for users who have a signed Data Use Agreement to receive
-individual response data from the survey. It describes the survey items, data
-coding, data distribution, and the survey weights computed by Facebook. If you
-are a researcher and would like to get access to the data, see our page on
-getting [data access](data-access.md).
+This documentation describes the survey items, data coding, data distribution,
+and the survey weights computed by Facebook. It also documents the individual
+response data, which is available to researchers with a signed Data Use
+Agreement. If you are a researcher and would like to get access to the data, see
+our page on getting [data access](data-access.md).
 
 If you have questions about the survey or getting access to data, contact us at
 <delphi-survey-info@lists.andrew.cmu.edu>.
@@ -49,9 +52,8 @@ and others. If you are interested in getting involved, see our
 
 ## Citing the Survey
 
-Researchers who use the survey microdata for research are asked to credit and
-cite the survey in publications based on the data. Specifically, we ask that
-you:
+Researchers who use the survey data for research are asked to credit and cite
+the survey in publications based on the data. Specifically, we ask that you:
 
 1. Include the acknowledgment "This research is based on survey results from
    Carnegie Mellon University’s Delphi Group."

--- a/docs/symptom-survey/server-access.md
+++ b/docs/symptom-survey/server-access.md
@@ -9,7 +9,7 @@ nav_order: 2
 Researchers with data use agreements to access the raw data from the COVID-19
 symptom survey can access the data over SFTP. (If you do not have a data use
 agreement, see the [main survey page](index.md) for information about getting
-access.)
+access and about aggregate data that is available for public download.)
 
 If you're not familiar with SFTP, it is a protocol for securely accessing and downloading
 large amounts of data from remote servers. The instructions below explain how to

--- a/docs/symptom-survey/survey-files.md
+++ b/docs/symptom-survey/survey-files.md
@@ -13,8 +13,8 @@ are stored. To connect to the server, see the [server access documentation](serv
 This documentation describes the survey data available on that server.
 
 You must sign a Data Use Agreement with Facebook and with CMU to gain
-access to the individual survey responses. If you have not done so, aggregate data is available
-[through the COVIDcast API](../api/covidcast-signals/fb-survey.md).
+access to the individual survey responses. If you have not done so, aggregate
+data is publicly available; see the [survey overview for details](index.md).
 
 Important updates for data users, including corrections to data or updates on
 data processing delays, are posted as `OUTAGES.txt` in the SFTP server directory

--- a/docs/symptom-survey/weights.md
+++ b/docs/symptom-survey/weights.md
@@ -8,8 +8,11 @@ nav_order: 5
 {: .no_toc}
 
 The symptom survey individual response files contain survey weights calculated
-by Facebook. Facebook has provided documentation to describe the calculation and
-usage of these weights, [available here](symptom-survey-weights.pdf). This
-documentation explains the weight methodology, gives examples of how to use the
-weights when calculating estimates, and states the known limitations of the
-weights.
+by Facebook. These weights are also used to produce our [public contingency
+tables](contingency-tables.md) and the geographic aggregates [in the COVIDcast
+Epidata API](../api/covidcast-signals/fb-survey.md).
+
+Facebook has provided documentation to describe the calculation and usage of
+these weights, [available here](symptom-survey-weights.pdf). This documentation
+explains the weight methodology, gives examples of how to use the weights when
+calculating estimates, and states the known limitations of the weights.

--- a/docs/symptom-survey/weights.md
+++ b/docs/symptom-survey/weights.md
@@ -8,9 +8,8 @@ nav_order: 5
 {: .no_toc}
 
 The symptom survey individual response files contain survey weights calculated
-by Facebook. These weights are also used to produce our [public contingency
-tables](contingency-tables.md) and the geographic aggregates [in the COVIDcast
-Epidata API](../api/covidcast-signals/fb-survey.md).
+by Facebook. These weights are also used to produce our [public contingency tables](contingency-tables.md)
+and the geographic aggregates [in the COVIDcast Epidata API](../api/covidcast-signals/fb-survey.md).
 
 Facebook has provided documentation to describe the calculation and usage of
 these weights, [available here](symptom-survey-weights.pdf). This documentation

--- a/docs/symptom-survey/weights.md
+++ b/docs/symptom-survey/weights.md
@@ -1,7 +1,7 @@
 ---
 title: Survey Weights
 parent: COVID Symptom Survey
-nav_order: 4
+nav_order: 5
 ---
 
 # Survey Weights


### PR DESCRIPTION
Adds documentation for contingency tables. This is largely taken from the existing README, plus some formatting and intro. This page is nested under `COVID Symptom Survey`, between `Response Files` and 'Survey Weights`.

Adds information about this data source and aggregates in the API to the `data-access` page.