### PR TITLE
[POC] COVIDcast union

### DIFF
--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -193,6 +193,7 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
 
     with self.subTest(name='request as-of a date capturing a covidcast-covidcast2 collision'):
       # fetch data, specifying as_of
+      # 20200499 grabs everything before may 1 (doesn't need to be a real date)
       response_1a = Epidata.covidcast(
           'src', 'sig', 'day', 'county', 20200414, '01234',
           as_of=20200499)

--- a/src/ddl/covidcast.sql
+++ b/src/ddl/covidcast.sql
@@ -112,6 +112,38 @@ CREATE TABLE `covidcast` (
   KEY `by_lag` (`source`, `signal`, `time_type`, `geo_type`, `geo_value`, `time_value`, `lag`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+/* covidcast2 stores the data history for 2020 dates */
+CREATE TABLE `covidcast2` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `source` varchar(32) NOT NULL,
+  `signal` varchar(64) NOT NULL,
+  `time_type` varchar(12) NOT NULL,
+  `geo_type` varchar(12) NOT NULL,
+  `time_value` int(11) NOT NULL,
+  `geo_value` varchar(12) NOT NULL,
+  -- "primary" values are derived from the upstream data source
+  `value_updated_timestamp` int(11) NOT NULL,
+  `value` double NOT NULL,
+  `stderr` double,
+  `sample_size` double,
+  `direction_updated_timestamp` int(11) NOT NULL,
+  `direction` int(11),
+  `issue` int(11) NOT NULL,
+  `lag` int(11) NOT NULL,
+  `is_latest_issue` binary(1) NOT NULL,
+  `is_wip` binary(1) DEFAULT NULL,
+  -- TODO: `missing_value` int(11) DEFAULT NULL,
+  -- TODO: `missing_std` int(11) DEFAULT NULL,
+  -- TODO: `missing_sample_size` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  -- for uniqueness, and also fast lookup of all locations on a given date
+  UNIQUE KEY (`source`, `signal`, `time_type`, `geo_type`, `time_value`, `geo_value`, `issue`),
+  -- for fast lookup of a time-series for a given location
+  KEY `by_issue` (`source`, `signal`, `time_type`, `geo_type`, `geo_value`, `time_value`, `issue`),
+  KEY `by_lag` (`source`, `signal`, `time_type`, `geo_type`, `geo_value`, `time_value`, `lag`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
 /*
 `covidcast_meta_cache` stores a cache of the `covidcast_meta` endpoint
 response, e.g. for faster visualization load times.

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -1002,6 +1002,7 @@ function get_covidcast($source, $signals, $time_type, $geo_type, $time_values, $
   if ($union) {
     $from_2020 = str_replace("#TABLE#", "covidcast2", $query_template);
     $query = "({$from_2020}) UNION ({$from_2021})";
+    // add extra ORDER BY so we can drop the right duplicate later
     $order = "{$order}, `value_updated_timestamp` DESC";
   } else {
     $query = $from_2021;
@@ -1014,6 +1015,7 @@ function get_covidcast($source, $signals, $time_type, $geo_type, $time_values, $
 
   // drop duplicates where some source+signal+geo+date is in both tables with
   // different timestamps, preferring most recently updated copy
+  // NB this relies on the inclusion of the extra ORDER BY clause above
   if ($union) {
     $drop = array();
     $last = "";

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -2077,7 +2077,7 @@ if(database_connect()) {
     // get the metadata
     $epidata = get_covidcast_meta();
     store_result($data, $epidata);
-  } else if($endpoint === 'covid_hosp' || $source === 'covid_hosp_state_timeseries') {
+  } else if($endpoint === 'covid_hosp' || $endpoint === 'covid_hosp_state_timeseries') {
     if(require_all($data, array('states', 'dates'))) {
       // parse the request
       $states = extract_values($_REQUEST['states'], 'str');

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -2057,7 +2057,7 @@ if(database_connect()) {
           $as_of,
           $issues,
           $lag);
-      if(isset($_REQUEST['format']) && $_REQUEST['format']=="tree") {
+      if(isset($_REQUEST['format']) && $_REQUEST['format']=="tree" && !is_null($epidata)) {
         //organize results by signal
         $epi_tree = array();
         $key = -1;


### PR DESCRIPTION
With the limited dataset in place as the `covidcast` table, metadata updates take an hour instead of four, and CSV uploads take 20 minutes instead of 40-60. 

This PR is a POC for keeping the deep 2020 history in the `covidcast2` table, and leaving `covidcast` containing only the most recent issue for all dates plus the data history for dates from Jan 1 2021 onward. This solution would let us keep the fast meta and upload jobs without losing access to the full data history.

The tests include the following:
* Places where the row to be returned is only present in `covidcast`
* Places where the row to be returned is only present in `covidcast2`
* Places where the row to be returned is present in both tables with identical data
* Places where the row to be returned is present in both tables with different timestamps

The latter two in particular already exist in the production database, so it seemed prudent to check them. To handle the differing-timestamps case, rather than wrap everything in another terrible SQL query, I just did a pass through the results in PHP to toss out duplicates, preferring the most recently updated version. Definitely open to suggestions if folks think that won't scale.

UNION is only applied for lag, as-of, and issues queries, since the latest issue for each date is guaranteed to be in `covidcast`.