### PR TITLE
Fix import for state daily integration test

### DIFF
--- a/integrations/acquisition/covid_hosp/state_daily/test_scenarios.py
+++ b/integrations/acquisition/covid_hosp/state_daily/test_scenarios.py
@@ -13,6 +13,7 @@ from delphi.epidata.acquisition.covid_hosp.common.database import Database
 from delphi.epidata.acquisition.covid_hosp.common.test_utils import TestUtils
 from delphi.epidata.client.delphi_epidata import Epidata
 from delphi.epidata.acquisition.covid_hosp.state_daily.update import Update
+from delphi.epidata.acquisition.covid_hosp.state_daily.network import Network
 import delphi.operations.secrets as secrets
 
 # py3tester coverage target (equivalent to `import *`)


### PR DESCRIPTION
Some of the state_daily update PRs were opened before #371  and merged after, so this pytest-required import got missed