### PR TITLE
bump delphi-epidata version to 0.0.12

### DIFF
--- a/src/client/packaging/pypi/delphi_epidata/__init__.py
+++ b/src/client/packaging/pypi/delphi_epidata/__init__.py
@@ -1,4 +1,4 @@
 from .delphi_epidata import Epidata
 
 name = 'delphi_epidata'
-__version__ = '0.0.11'
+__version__ = '0.0.12'

--- a/src/client/packaging/pypi/setup.py
+++ b/src/client/packaging/pypi/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
   name='delphi_epidata',
-  version='0.0.11',
+  version='0.0.12',
   author='David Farrow',
   author_email='dfarrow0@gmail.com',
   description='A programmatic interface to Delphi\'s Epidata API.',


### PR DESCRIPTION
This will let us release correct handling for 5XX and 4XX response codes and more polite batching.