### PR TITLE
Port to using legacy.healthdata.gov API url, need to move to use curr…

### DIFF
--- a/src/acquisition/covid_hosp/common/network.py
+++ b/src/acquisition/covid_hosp/common/network.py
@@ -4,9 +4,10 @@ import requests
 
 
 class Network:
-
+# This code is a temporary (two weeks or so) fix until the legacy API is fully retired. Code using this style of URL will be phased out entirely then
+# This needs to migrate to the new healthdata.gov API, which is different
   METADATA_URL_TEMPLATE = \
-      'https://healthdata.gov/api/3/action/package_show?id=%s&page=0'
+      'https://legacy.healthdata.gov/api/3/action/package_show?id=%s&page=0'
 
   def fetch_metadata_for_dataset(dataset_id, requests_impl=requests):
     """Download and return metadata.


### PR DESCRIPTION
…ent API