### PR TITLE
Persist last update time for signal dashboard

### DIFF
--- a/src/acquisition/covidcast/signal_dash_data_generator.py
+++ b/src/acquisition/covidcast/signal_dash_data_generator.py
@@ -226,7 +226,7 @@ def main(args):
     logger.info("Starting generating dashboard data.", enabled_signals=[
                 signal.name for signal in signals_to_generate])
 
-    metadata =Epidata.covidcast.metadata()
+    metadata = Epidata.covidcast.metadata()
 
     signal_status_list: List[DashboardSignalStatus] = []
     coverage_list: List[DashboardSignalCoverage] = []

--- a/src/acquisition/covidcast/signal_dash_data_generator.py
+++ b/src/acquisition/covidcast/signal_dash_data_generator.py
@@ -132,7 +132,11 @@ class Database:
 
     def get_enabled_signals(self) -> List[DashboardSignal]:
         """Retrieve all enabled signals from the database"""
-        select_statement = f'''SELECT `id`, `name`, `source`, `latest_coverage_update`, `latest_status_update`
+        select_statement = f'''SELECT `id`, 
+            `name`,
+            `source`,
+            `latest_coverage_update`, 
+            `latest_status_update`
             FROM `{Database.SIGNAL_TABLE_NAME}`
             WHERE `enabled`
             '''

--- a/src/ddl/signal_dashboard.sql
+++ b/src/ddl/signal_dashboard.sql
@@ -2,14 +2,16 @@
 
 This table stores the signals used in the public signal dashboard.
 
-+---------+--------------+------+-----+---------+----------------+
-| Field   | Type         | Null | Key | Default | Extra          |
-+---------+--------------+------+-----+---------+----------------+
-| id      | int(11)      | NO   | PRI | NULL    | auto_increment |
-| name    | varchar(255) | NO   |     | NULL    |                |
-| source  | varchar(32)  | NO   |     | NULL    |                |
-| enabled | binary(1)    | NO   |     | NULL    |                |
-+---------+--------------+------+-----+---------+----------------+
++------------------------+--------------+------+-----+------------+----------------+
+| Field                  | Type         | Null | Key | Default    | Extra          |
++------------------------+--------------+------+-----+------------+----------------+
+| id                     | int(11)      | NO   | PRI | NULL       | auto_increment |
+| name                   | varchar(255) | NO   |     | NULL       |                |
+| source                 | varchar(32)  | NO   |     | NULL       |                |
+| enabled                | tinyint(1)   | NO   |     | NULL       |                |
+| latest_coverage_update | date         | NO   |     | 2020-01-01 |                |
+| latest_status_update   | date         | NO   |     | 2020-01-01 |                |
++------------------------+--------------+------+-----+------------+----------------+
 
 */
 
@@ -18,6 +20,8 @@ CREATE TABLE `dashboard_signal` (
   `name` varchar(255) NOT NULL,
   `source` varchar(32) NOT NULL,
   `enabled` boolean NOT NULL,
+  `latest_coverage_update` date DEFAULT "2020-01-01" NOT NULL,
+  `latest_status_update` date DEFAULT "2020-01-01" NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -1005,17 +1005,11 @@ function get_signal_dash_status_data() {
   $query = 'SELECT enabled_signal.`name`,
               status.`latest_issue`,
               status.`latest_time_value`
-            FROM (SELECT `id`, `name`
+            FROM (SELECT `id`, `name`, `latest_status_update`
               FROM `dashboard_signal`
               WHERE `enabled`) AS enabled_signal
-            LEFT JOIN (SELECT `signal_id`,
-                              Max(`date`) max_date
-                       FROM `dashboard_signal_status`
-                       GROUP BY `signal_id`) AS max_dates
-            ON enabled_signal.`id` = max_dates.`signal_id`
             LEFT JOIN `dashboard_signal_status` AS status
-            ON max_dates.`signal_id` = status.`signal_id`
-              AND status.`date` = max_dates.`max_date`';
+            ON enabled_signal.`latest_status_update` = status.`date`';
   
   $epidata = array();
   $fields_string = array('name', 'latest_issue', 'latest_time_value');
@@ -1029,17 +1023,11 @@ function get_signal_dash_coverage_data() {
               coverage.`date`,
               coverage.`geo_type`,
               coverage.`geo_value`
-            FROM (SELECT `id`, `name`
+            FROM (SELECT `id`, `name`, `latest_coverage_update`
               FROM `dashboard_signal`
               WHERE `enabled`) AS enabled_signal
-            LEFT JOIN (SELECT `signal_id`,
-                              Max(`date`) max_date
-                       FROM `dashboard_signal_coverage`
-                       GROUP BY `signal_id`) AS max_dates
-            ON enabled_signal.`id` = max_dates.`signal_id`
             LEFT JOIN `dashboard_signal_coverage` AS coverage
-            ON max_dates.`signal_id` = coverage.`signal_id`
-              AND coverage.`date` = max_dates.`max_date`';
+            ON enabled_signal.`latest_coverage_update` = coverage.`date`';
   
   $epidata = array();
   $fields_string = array('name', 'date', 'geo_type', 'geo_value');


### PR DESCRIPTION
- Save last update time when writing updates (if greater than what is currently stored)
- Adjust API SQL to remove the now unnecessary nested query to find max time.
- Update SQL table defs to add the new last update fields
- Update tests

Improves #438 