### PR TITLE
Add metadata IDs to hhs datasets

### DIFF
--- a/src/acquisition/covid_hosp/facility/network.py
+++ b/src/acquisition/covid_hosp/facility/network.py
@@ -5,6 +5,7 @@ from delphi.epidata.acquisition.covid_hosp.common.network import Network as Base
 class Network(BaseNetwork):
 
   DATASET_ID = 'anag-cw7u'
+  METADATA_ID = 'j4ip-wfsv'
 
   def fetch_metadata(*args, **kwags):
     """Download and return metadata.
@@ -13,4 +14,4 @@ class Network(BaseNetwork):
     """
 
     return Network.fetch_metadata_for_dataset(
-        *args, **kwags, dataset_id=Network.DATASET_ID)
+        *args, **kwags, dataset_id=Network.METADATA_ID)

--- a/src/acquisition/covid_hosp/state_daily/network.py
+++ b/src/acquisition/covid_hosp/state_daily/network.py
@@ -8,6 +8,7 @@ from delphi.epidata.acquisition.covid_hosp.common.network import Network as Base
 class Network(BaseNetwork):
 
   DATASET_ID = '6xf2-c3ie'
+  METADATA_ID = '4cnb-m4rz'
 
   @staticmethod
   def fetch_metadata(*args, **kwags):
@@ -17,7 +18,7 @@ class Network(BaseNetwork):
     """
 
     return Network.fetch_metadata_for_dataset(
-        *args, **kwags, dataset_id=Network.DATASET_ID)
+        *args, **kwags, dataset_id=Network.METADATA_ID)
 
   @staticmethod
   def fetch_revisions(metadata, newer_than):

--- a/src/acquisition/covid_hosp/state_timeseries/network.py
+++ b/src/acquisition/covid_hosp/state_timeseries/network.py
@@ -5,6 +5,7 @@ from delphi.epidata.acquisition.covid_hosp.common.network import Network as Base
 class Network(BaseNetwork):
 
   DATASET_ID = 'g62h-syeh'
+  METADATA_ID = 'qqte-vkut'
 
   def fetch_metadata(*args, **kwags):
     """Download and return metadata.
@@ -13,4 +14,4 @@ class Network(BaseNetwork):
     """
 
     return Network.fetch_metadata_for_dataset(
-        *args, **kwags, dataset_id=Network.DATASET_ID)
+        *args, **kwags, dataset_id=Network.METADATA_ID)

--- a/tests/acquisition/covid_hosp/facility/test_network.py
+++ b/tests/acquisition/covid_hosp/facility/test_network.py
@@ -22,4 +22,4 @@ class NetworkTests(unittest.TestCase):
       result = Network.fetch_metadata()
 
       self.assertEqual(result, sentinel.json)
-      func.assert_called_once_with(dataset_id=Network.DATASET_ID)
+      func.assert_called_once_with(dataset_id=Network.METADATA_ID)

--- a/tests/acquisition/covid_hosp/state_daily/test_network.py
+++ b/tests/acquisition/covid_hosp/state_daily/test_network.py
@@ -34,7 +34,7 @@ class NetworkTests(unittest.TestCase):
       result = Network.fetch_metadata()
 
       self.assertEqual(result, sentinel.json)
-      func.assert_called_once_with(dataset_id=Network.DATASET_ID)
+      func.assert_called_once_with(dataset_id=Network.METADATA_ID)
 
   def test_fetch_revisions(self):
     """Scrape CSV files from revision pages"""

--- a/tests/acquisition/covid_hosp/state_timeseries/test_network.py
+++ b/tests/acquisition/covid_hosp/state_timeseries/test_network.py
@@ -24,4 +24,4 @@ class NetworkTests(unittest.TestCase):
       result = Network.fetch_metadata()
 
       self.assertEqual(result, sentinel.json)
-      func.assert_called_once_with(dataset_id=Network.DATASET_ID)
+      func.assert_called_once_with(dataset_id=Network.METADATA_ID)


### PR DESCRIPTION
The new healthdata.gov API has different dataset IDs for the metadata and the raw data, so adding that as an attribute.

e.g.
data: https://healthdata.gov/dataset/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/6xf2-c3ie
metadata: https://healthdata.gov/dataset/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/4cnb-m4rz
