### PR TITLE
Include coverage time series in signal dash status

### DIFF
--- a/src/acquisition/covidcast/signal_dash_data_generator.py
+++ b/src/acquisition/covidcast/signal_dash_data_generator.py
@@ -166,14 +166,16 @@ def get_argument_parser():
 
 def get_latest_issue_from_metadata(dashboard_signal, metadata):
     """Get the most recent issue date for the signal."""
-    df_for_source = metadata[metadata.data_source == dashboard_signal.source]
+    df_for_source = metadata[(metadata.data_source == dashboard_signal.source) & (
+        metadata.signal == dashboard_signal.covidcast_signal)]
     max_issue = df_for_source["max_issue"].max()
     return pd.to_datetime(str(max_issue), format="%Y%m%d").date()
 
 
 def get_latest_time_value_from_metadata(dashboard_signal, metadata):
     """Get the most recent date with data for the signal."""
-    df_for_source = metadata[metadata.data_source == dashboard_signal.source]
+    df_for_source = metadata[(metadata.data_source == dashboard_signal.source) & (
+        metadata.signal == dashboard_signal.covidcast_signal)]
     return df_for_source["max_time"].max().date()
 
 

--- a/src/acquisition/covidcast/signal_dash_data_generator.py
+++ b/src/acquisition/covidcast/signal_dash_data_generator.py
@@ -24,6 +24,7 @@ class DashboardSignal:
     db_id: int
     name: str
     source: str
+    covidcast_signal: str
     latest_coverage_update: datetime.date
     latest_status_update: datetime.date
 
@@ -136,6 +137,7 @@ class Database:
         select_statement = f'''SELECT `id`, 
             `name`,
             `source`,
+            `covidcast_signal`,
             `latest_coverage_update`, 
             `latest_status_update`
             FROM `{Database.SIGNAL_TABLE_NAME}`
@@ -149,8 +151,9 @@ class Database:
                     db_id=result[0],
                     name=result[1],
                     source=result[2],
-                    latest_coverage_update=result[3],
-                    latest_status_update=result[4]))
+                    covidcast_signal=result[3],
+                    latest_coverage_update=result[4],
+                    latest_status_update=result[5]))
         return enabled_signals
 
 
@@ -179,14 +182,9 @@ def get_coverage(dashboard_signal: DashboardSignal,
     """Get the most recent coverage for the signal."""
     latest_time_value = get_latest_time_value_from_metadata(
         dashboard_signal, metadata)
-    df_for_source = metadata[metadata.data_source == dashboard_signal.source]
-    # we need to do something smarter here -- make this part of config
-    # (and allow multiple signals) and/or aggregate across all signals
-    # for a source
-    signal = df_for_source["signal"].iloc[0]
     latest_data = covidcast.signal(
         dashboard_signal.source,
-        signal,
+        dashboard_signal.covidcast_signal,
         end_day=latest_time_value,
         start_day=latest_time_value)
     count_by_geo_type_df = latest_data.groupby(

--- a/src/ddl/signal_dashboard.sql
+++ b/src/ddl/signal_dashboard.sql
@@ -8,6 +8,7 @@ This table stores the signals used in the public signal dashboard.
 | id                     | int(11)      | NO   | PRI | NULL       | auto_increment |
 | name                   | varchar(255) | NO   |     | NULL       |                |
 | source                 | varchar(32)  | NO   |     | NULL       |                |
+| covidcast_signal       | varchar(64)  | NO   |     | NULL       |                |
 | enabled                | tinyint(1)   | NO   |     | NULL       |                |
 | latest_coverage_update | date         | NO   |     | 2020-01-01 |                |
 | latest_status_update   | date         | NO   |     | 2020-01-01 |                |
@@ -19,6 +20,7 @@ CREATE TABLE `dashboard_signal` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `source` varchar(32) NOT NULL,
+  `covidcast_signal` varchar(64) NOT NULL,
   `enabled` boolean NOT NULL,
   `latest_coverage_update` date DEFAULT "2020-01-01" NOT NULL,
   `latest_status_update` date DEFAULT "2020-01-01" NOT NULL,

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -1009,7 +1009,8 @@ function get_signal_dash_status_data() {
               FROM `dashboard_signal`
               WHERE `enabled`) AS enabled_signal
             LEFT JOIN `dashboard_signal_status` AS status
-            ON enabled_signal.`latest_status_update` = status.`date`';
+            ON enabled_signal.`latest_status_update` = status.`date`
+            AND enabled_signal.`id` = status.`signal_id`';
   
   $epidata = array();
   $fields_string = array('name', 'latest_issue', 'latest_time_value');

--- a/src/server/api.php
+++ b/src/server/api.php
@@ -1003,9 +1003,11 @@ function get_covidcast($source, $signals, $time_type, $geo_type, $time_values, $
 
 function get_signal_dash_status_data() {
   $query = 'SELECT enabled_signal.`name`,
+              enabled_signal.`source`,
+              enabled_signal.`covidcast_signal`,
               status.`latest_issue`,
               status.`latest_time_value`
-            FROM (SELECT `id`, `name`, `latest_status_update`
+            FROM (SELECT `id`, `name`, `source`, `covidcast_signal`, `latest_status_update`
               FROM `dashboard_signal`
               WHERE `enabled`) AS enabled_signal
             LEFT JOIN `dashboard_signal_status` AS status
@@ -1013,10 +1015,22 @@ function get_signal_dash_status_data() {
             AND enabled_signal.`id` = status.`signal_id`';
   
   $epidata = array();
-  $fields_string = array('name', 'latest_issue', 'latest_time_value');
+  $fields_string = array('name', 'source', 'covidcast_signal', 'latest_issue', 'latest_time_value');
   execute_query($query, $epidata, $fields_string, null /* fields_int */, null /* fields_float */);
+
+  $coverage = get_signal_dash_coverage_data();
+
+  $out = array();
+  foreach ($epidata as $signal) {
+    if (isset($coverage[$signal['name']])) {
+      $signal_with_coverage = $signal;
+      $signal_with_coverage['coverage'] = $coverage[$signal['name']];
+      $out[] = $signal_with_coverage;
+    }
+  }
+
   // return the data
-  return count($epidata) === 0 ? null : $epidata; 
+  return count($out) === 0 ? null : $out; 
 }
 
 function get_signal_dash_coverage_data() {

--- a/tests/acquisition/covidcast/test_signal_dash_data_generator.py
+++ b/tests/acquisition/covidcast/test_signal_dash_data_generator.py
@@ -143,8 +143,10 @@ class UnitTests(unittest.TestCase):
             covidcast_signal="chng-sig",
             latest_coverage_update=date(2021, 1, 1),
             latest_status_update=date(2021, 1, 1))
-        data = [['chng', 20200101], ['chng', 20210101], ['quidel', 20220101]]
-        metadata = pd.DataFrame(data, columns=['data_source', 'max_issue'])
+        data = [['chng', 'chng-sig', 20200101],
+                ['chng', 'chng-sig', 20210101],
+                ['quidel', 'quidel-sig', 20220101]]
+        metadata = pd.DataFrame(data, columns=['data_source', 'signal', 'max_issue'])
 
         issue_date = get_latest_issue_from_metadata(signal, metadata)
         self.assertEqual(issue_date, date(2021, 1, 1))
@@ -156,10 +158,10 @@ class UnitTests(unittest.TestCase):
             latest_coverage_update=date(2021, 1, 1),
             latest_status_update=date(2021, 1, 1))
         data = [
-            ['chng', pd.Timestamp("2020-01-01")],
-            ['chng', pd.Timestamp("2021-01-01")],
-            ['quidel', pd.Timestamp("20220101")]]
-        metadata = pd.DataFrame(data, columns=['data_source', 'max_time'])
+            ['chng', 'chng-sig', pd.Timestamp("2020-01-01")],
+            ['chng', 'chng-sig', pd.Timestamp("2021-01-01")],
+            ['quidel', 'quidel-sig', pd.Timestamp("20220101")]]
+        metadata = pd.DataFrame(data, columns=['data_source', 'signal', 'max_time'])
 
         data_date = get_latest_time_value_from_metadata(signal, metadata)
         self.assertEqual(data_date, date(2021, 1, 1))
@@ -171,7 +173,7 @@ class UnitTests(unittest.TestCase):
             covidcast_signal="chng-sig",
             latest_coverage_update=date(2021, 1, 1),
             latest_status_update=date(2021, 1, 1))
-        data = [['chng', pd.Timestamp("2020-01-01"), "chng_signal"]]
+        data = [['chng', pd.Timestamp("2020-01-01"), "chng-sig"]]
         metadata = pd.DataFrame(
             data,
             columns=[
@@ -179,7 +181,7 @@ class UnitTests(unittest.TestCase):
                 'max_time',
                 'signal'])
 
-        epidata_data = [['chng', 'chng_signal',
+        epidata_data = [['chng', 'chng-sig',
                          pd.Timestamp("2020-01-01"), "state", "PA"]]
         epidata_df = pd.DataFrame(
             epidata_data,

--- a/tests/acquisition/covidcast/test_signal_dash_data_generator.py
+++ b/tests/acquisition/covidcast/test_signal_dash_data_generator.py
@@ -113,8 +113,8 @@ class UnitTests(unittest.TestCase):
         cursor = connection.cursor()
 
         db_rows = [
-            (1, "Change", "chng", datetime.date(2020, 1, 1), datetime.date(2020, 1, 2)),
-            (2, "Quidel", "quidel", datetime.date(2020, 2, 1), datetime.date(2020, 2, 2)),
+            (1, "Change", "chng", "chng-sig", datetime.date(2020, 1, 1), datetime.date(2020, 1, 2)),
+            (2, "Quidel", "quidel", "quidel-sig", datetime.date(2020, 2, 1), datetime.date(2020, 2, 2)),
         ]
         cursor.fetchall.return_value = db_rows
 
@@ -123,12 +123,14 @@ class UnitTests(unittest.TestCase):
         expected_signals = [
             DashboardSignal(db_id=1, 
                 name="Change", 
-                source="chng", 
+                source="chng",
+                covidcast_signal="chng-sig",
                 latest_coverage_update=date(2020, 1, 1),
                 latest_status_update=date(2020, 1, 2)),
             DashboardSignal(db_id=2, 
                 name="Quidel",
                 source="quidel",
+                covidcast_signal="quidel-sig",
                 latest_coverage_update=date(2020, 2, 1), 
                 latest_status_update=date(2020, 2, 2))
         ]
@@ -138,6 +140,7 @@ class UnitTests(unittest.TestCase):
     def test_get_latest_issue_from_metadata(self):
         signal = DashboardSignal(
             db_id=1, name="Change", source="chng",
+            covidcast_signal="chng-sig",
             latest_coverage_update=date(2021, 1, 1),
             latest_status_update=date(2021, 1, 1))
         data = [['chng', 20200101], ['chng', 20210101], ['quidel', 20220101]]
@@ -149,6 +152,7 @@ class UnitTests(unittest.TestCase):
     def test_get_latest_time_value_from_metadata(self):
         signal = DashboardSignal(
             db_id=1, name="Change", source="chng",
+            covidcast_signal="chng-sig",
             latest_coverage_update=date(2021, 1, 1),
             latest_status_update=date(2021, 1, 1))
         data = [
@@ -164,6 +168,7 @@ class UnitTests(unittest.TestCase):
     def test_get_coverage(self, mock_signal):
         signal = DashboardSignal(
             db_id=1, name="Change", source="chng",
+            covidcast_signal="chng-sig",
             latest_coverage_update=date(2021, 1, 1),
             latest_status_update=date(2021, 1, 1))
         data = [['chng', pd.Timestamp("2020-01-01"), "chng_signal"]]
@@ -205,6 +210,7 @@ class UnitTests(unittest.TestCase):
     def test_get_coverage_too_many_rows(self, mock_signal):
         signal = DashboardSignal(
             db_id=1, name="Change", source="chng",
+            covidcast_signal="chng-sig",
             latest_coverage_update=date(2021, 1, 1),
             latest_status_update=date(2021, 1, 1))
         data = [['chng', pd.Timestamp("2020-01-01"), "chng_signal"]]


### PR DESCRIPTION
Changes:
- Add covidcast_signal to the dashboard signal defs
- Embed the coverage time-series in the status response
- Add missing ID condition to status
- Update tests

Improves #438 