### PR TITLE
Extend SafeGraph limitations section

### DIFF
--- a/docs/api/covidcast-signals/safegraph.md
+++ b/docs/api/covidcast-signals/safegraph.md
@@ -121,9 +121,12 @@ meaning estimates for a specific day are only available 3-9 days later. It may
 take up to an additional day for SafeGraph's data to be ingested into the
 COVIDcast API.
 
-### Limitations
+## Limitations
 
-This data source is based on mobile devices that are members of SafeGraph panels, which is not necessarily the same thing as measuring the general public. This means that counts are subject to bias if some regions have a greater density of SafeGraph panel members as a percentage of the population. These counts do not represent absolute counts, and only count visits by members of the panel in that region.
+SafeGraph's Social Distancing Metrics and Weekly Patterns are based on mobile devices that are members of SafeGraph panels, which is not necessarily the same thing as measuring the general public. These counts do not represent absolute counts, and only count visits by members of the panel in that region. This can result in several biases:
+
+* **Geographic bias.** If some regions have a greater density of SafeGraph panel members as a percentage of the population than other regions, comparisons of metrics between regions may be biased. Regions with more SafeGraph panel members will appear to have more visits counted, even if the rate of visits in the general population is the same.
+* **Demographic bias.** SafeGraph panels may not be representative of the local population as a whole. For example, [some research suggests](https://arxiv.org/abs/2011.07194) that "older and non-white voters are less likely to be captured by mobility data", so this data will not accurately reflect behavior in those populations. Since population demographics vary across the United States, this can also contribute to geographic biases.
 
 The number of POIs coded as bars is much smaller than the number of POIs coded as restaurants. 
 SafeGraph's Weekly Patterns data consistently lacks data on bar visits for Alaska, Delaware, Maine, North Dakota, New Hampshire, South Dakota, Vermont, West Virginia, and Wyoming. 

--- a/docs/api/covidcast-signals/safegraph.md
+++ b/docs/api/covidcast-signals/safegraph.md
@@ -114,6 +114,10 @@ considered to be a full-service restaurant.  More information on NAICS codes is
 available from the [US Census Bureau: North American Industry Classification
 System](https://www.census.gov/eos/www/naics/index.html).
 
+The number of POIs coded as bars is much smaller than the number of POIs coded as restaurants.
+SafeGraph's Weekly Patterns data consistently lacks data on bar visits for Alaska, Delaware, Maine, North Dakota, New Hampshire, South Dakota, Vermont, West Virginia, and Wyoming.
+For certain dates, bar visits data is also missing for District of Columbia, Idaho and Washington. Restaurant visits data is available for all of the states, as well as the District of Columbia and Puerto Rico.
+
 ### Lag
 
 SafeGraph provides newly updated data for the previous week every Wednesday,
@@ -128,6 +132,3 @@ SafeGraph's Social Distancing Metrics and Weekly Patterns are based on mobile de
 * **Geographic bias.** If some regions have a greater density of SafeGraph panel members as a percentage of the population than other regions, comparisons of metrics between regions may be biased. Regions with more SafeGraph panel members will appear to have more visits counted, even if the rate of visits in the general population is the same.
 * **Demographic bias.** SafeGraph panels may not be representative of the local population as a whole. For example, [some research suggests](https://arxiv.org/abs/2011.07194) that "older and non-white voters are less likely to be captured by mobility data", so this data will not accurately reflect behavior in those populations. Since population demographics vary across the United States, this can also contribute to geographic biases.
 
-The number of POIs coded as bars is much smaller than the number of POIs coded as restaurants. 
-SafeGraph's Weekly Patterns data consistently lacks data on bar visits for Alaska, Delaware, Maine, North Dakota, New Hampshire, South Dakota, Vermont, West Virginia, and Wyoming. 
-For certain dates, bar visits data is also missing for District of Columbia, Idaho and Washington. Restaurant visits data is available for all of the states, as well as the District of Columbia and Puerto Rico.


### PR DESCRIPTION
This shouldn't be a subsection of Weekly Patterns (it applies to both), and we should mention research on its biases.