### PR TITLE
[fb-survey] Update contingency table links

### DIFF
--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -11,8 +11,8 @@ This documentation describes the fine-resolution contingency tables produced by
 grouping [COVID Symptom Survey](./index.md) individual responses by various
 demographic features:
 
-* [Weekly files](https://cmu.box.com/s/xwjulq0pteen52d4upni9ikagu7d8bl2)
-* [Monthly files](https://cmu.box.com/s/vh4gs3j541tt9pqn2pn72bktu0op8tpo)
+* [Weekly files](https://www.cmu.edu/delphi-web/surveys/weekly/)
+* [Monthly files](https://www.cmu.edu/delphi-web/surveys/monthly/)
 
 These contingency tables provide demographic breakdowns of COVID-related topics such as
 vaccine uptake and acceptance. They are more detailed than the


### PR DESCRIPTION
Nation and state tables, including old aggs and FB expansion aggs, are up on the Delphi AWPS site.