### PR TITLE
[flask]: add new parameter version: signal,time,geo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+
+[tool.black]
+line-length = 200
+target-version = ['py38']
+include = 'server,tests/server'

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -68,7 +68,7 @@ def _verify_range(start: int, end: int) -> Union[int, Tuple[int, int]]:
 
 def parse_week_value(time_value: str) -> Union[int, Tuple[int, int]]:
     count_dashes = time_value.count("-")
-    msg = f"{time_value} is not matching a known format YYYYWW or YYYYWW-YYYYWW"
+    msg = f"{time_value} does not match a known format YYYYWW or YYYYWW-YYYYWW"
 
     if count_dashes == 0:
         # plain delphi date YYYYWW

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -88,7 +88,7 @@ def parse_week_value(time_value: str) -> Union[int, Tuple[int, int]]:
 
 def parse_day_value(time_value: str) -> Union[int, Tuple[int, int]]:
     count_dashes = time_value.count("-")
-    msg = f"{time_value} is not matching a known format YYYYMMDD, YYYY-MM-DD, YYYYMMDD-YYYYMMDD, or YYYY-MM-DD--YYYY-MM-DD"
+    msg = f"{time_value} does not match a known format YYYYMMDD, YYYY-MM-DD, YYYYMMDD-YYYYMMDD, or YYYY-MM-DD--YYYY-MM-DD"
 
     if count_dashes == 0:
         # plain delphi date YYYYMMDD

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -8,6 +8,7 @@ from ._exceptions import ValidationFailedException
 
 
 def _parse_common_multi_arg(key: str) -> List[Tuple[str, Union[bool, Sequence[str]]]]:
+    # support multiple request parameter with the same name
     line = ";".join(request.values.getlist(key))
 
     parsed: List[Tuple[str, Union[bool, Sequence[str]]]] = []
@@ -15,13 +16,13 @@ def _parse_common_multi_arg(key: str) -> List[Tuple[str, Union[bool, Sequence[st
     if not line:
         return parsed
 
-    pattern = re.compile(r"^(\w+):(.*)$", re.MULTILINE)
+    pattern: re.Pattern[str] = re.compile(r"^(\w+):(.*)$", re.MULTILINE)
     for entry in line.split(";"):
-        m = pattern.match(entry)
+        m: Optional[re.Match[str]] = pattern.match(entry)
         if not m:
             raise ValidationFailedException(f"{key} param: {entry} is not matching <{key}_type>:<{key}_values> syntax")
-        group_type = m.group(1).strip()
-        group_value = m.group(2).strip()
+        group_type: str = m.group(1).strip().lower()
+        group_value: str = m.group(2).strip().lower()
         if group_value == "*":
             parsed.append((group_type, True))
         else:

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -1,0 +1,77 @@
+import re
+from dataclasses import dataclass
+from typing import Any, List, Optional, Sequence, Tuple, Union
+
+from flask import request
+
+from ._exceptions import ValidationFailedException
+
+
+def _parse_common_multi_arg(key: str) -> List[Tuple[str, Union[bool, Sequence[str]]]]:
+    line = ';'.join(request.values.getlist(key))
+
+    parsed: List[Tuple[str, Union[bool, Sequence[str]]]] = []
+
+    if not line:
+        return parsed
+
+    pattern = re.compile(r'^(\w+):(.*)$', re.MULTILINE)
+    for entry in line.split(';'):
+        m = pattern.match(entry)
+        if not m:
+            raise ValidationFailedException(f"{key} param: {entry} is not matching <{key}_type>:<{key}_values> syntax")
+        group_type = m.group(1).strip()
+        group_value = m.group(2).strip()
+        if group_value == '*':
+            parsed.append((group_type, True))
+        else:
+            parsed.append((group_type, [g.strip() for g in group_value.split(',')]))
+    return parsed
+
+
+@dataclass
+class GeoPair:
+    geo_type: str
+    geo_values: Union[bool, Sequence[str]]
+
+
+def parse_geo_arg() -> List[GeoPair]:
+    return [GeoPair(geo_type, geo_values) for [geo_type, geo_values] in _parse_common_multi_arg('geo')]
+
+
+@dataclass
+class SourceSignalPair:
+    source: str
+    signal: Union[bool, Sequence[str]]
+
+
+def parse_source_signal_arg() -> List[SourceSignalPair]:
+    return [SourceSignalPair(source, signals) for [source, signals] in _parse_common_multi_arg('signals')]
+
+
+@dataclass
+class TimePair:
+    time_type: str
+    time_values: Union[bool, Sequence[Union[int, Tuple[int, int]]]]
+
+
+def parse_week_values(time_values: Sequence[str]) -> Sequence[Union[int, Tuple[int, int]]]:
+    # TODO
+    return []
+
+
+def parse_day_values(time_values: Sequence[str]) -> Sequence[Union[int, Tuple[int, int]]]:
+    # TODO
+    return []
+
+
+def parse_time_arg() -> List[TimePair]:
+    def parse(time_type: str, time_values: Union[bool, Sequence[str]]) -> TimePair:
+        if isinstance(time_values, bool):
+            return TimePair(time_type, time_values)
+
+        if time_type == 'week':
+            return TimePair('week', parse_week_values(time_values))
+        return TimePair('day', parse_day_values(time_values))
+
+    return [parse(time_type, time_values) for [time_type, time_values] in _parse_common_multi_arg('time')]

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -19,9 +19,7 @@ def _parse_common_multi_arg(key: str) -> List[Tuple[str, Union[bool, Sequence[st
     for entry in line.split(";"):
         m = pattern.match(entry)
         if not m:
-            raise ValidationFailedException(
-                f"{key} param: {entry} is not matching <{key}_type>:<{key}_values> syntax"
-            )
+            raise ValidationFailedException(f"{key} param: {entry} is not matching <{key}_type>:<{key}_values> syntax")
         group_type = m.group(1).strip()
         group_value = m.group(2).strip()
         if group_value == "*":
@@ -38,10 +36,7 @@ class GeoPair:
 
 
 def parse_geo_arg() -> List[GeoPair]:
-    return [
-        GeoPair(geo_type, geo_values)
-        for [geo_type, geo_values] in _parse_common_multi_arg("geo")
-    ]
+    return [GeoPair(geo_type, geo_values) for [geo_type, geo_values] in _parse_common_multi_arg("geo")]
 
 
 @dataclass
@@ -51,10 +46,7 @@ class SourceSignalPair:
 
 
 def parse_source_signal_arg() -> List[SourceSignalPair]:
-    return [
-        SourceSignalPair(source, signals)
-        for [source, signals] in _parse_common_multi_arg("signal")
-    ]
+    return [SourceSignalPair(source, signals) for [source, signals] in _parse_common_multi_arg("signal")]
 
 
 @dataclass
@@ -119,9 +111,7 @@ def parse_day_value(time_value: str) -> Union[int, Tuple[int, int]]:
 
     if count_dashes == 6:
         # delphi iso date range YYYY-MM-DD--YYYY-MM-DD
-        if not re.match(
-            r"^(\d{4}-\d{2}-\d{2})--(\d{4}-\d{2}-\d{2})$", time_value, re.MULTILINE
-        ):
+        if not re.match(r"^(\d{4}-\d{2}-\d{2})--(\d{4}-\d{2}-\d{2})$", time_value, re.MULTILINE):
             raise ValidationFailedException(msg)
         [first, last] = time_value.split("--", 2)
         return _verify_range(int(first.replace("-", "")), int(last.replace("-", "")))
@@ -138,11 +128,6 @@ def parse_time_arg() -> List[TimePair]:
             return TimePair("week", [parse_week_value(t) for t in time_values])
         elif time_type == "day":
             return TimePair("day", [parse_day_value(t) for t in time_values])
-        raise ValidationFailedException(
-            f'time param: {time_type} is not one of "day" or "week"'
-        )
+        raise ValidationFailedException(f'time param: {time_type} is not one of "day" or "week"')
 
-    return [
-        parse(time_type, time_values)
-        for [time_type, time_values] in _parse_common_multi_arg("time")
-    ]
+    return [parse(time_type, time_values) for [time_type, time_values] in _parse_common_multi_arg("time")]

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -46,7 +46,7 @@ class SourceSignalPair:
 
 
 def parse_source_signal_arg() -> List[SourceSignalPair]:
-    return [SourceSignalPair(source, signals) for [source, signals] in _parse_common_multi_arg('signals')]
+    return [SourceSignalPair(source, signals) for [source, signals] in _parse_common_multi_arg('signal')]
 
 
 @dataclass

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -16,7 +16,7 @@ def _parse_common_multi_arg(key: str) -> List[Tuple[str, Union[bool, Sequence[st
     if not line:
         return parsed
 
-    pattern: re.Pattern[str] = re.compile(r"^(\w+):(.*)$", re.MULTILINE)
+    pattern: re.Pattern[str] = re.compile(r"^([\w\-_]+):(.*)$", re.MULTILINE)
     for entry in line.split(";"):
         m: Optional[re.Match[str]] = pattern.match(entry)
         if not m:

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -8,24 +8,26 @@ from ._exceptions import ValidationFailedException
 
 
 def _parse_common_multi_arg(key: str) -> List[Tuple[str, Union[bool, Sequence[str]]]]:
-    line = ';'.join(request.values.getlist(key))
+    line = ";".join(request.values.getlist(key))
 
     parsed: List[Tuple[str, Union[bool, Sequence[str]]]] = []
 
     if not line:
         return parsed
 
-    pattern = re.compile(r'^(\w+):(.*)$', re.MULTILINE)
-    for entry in line.split(';'):
+    pattern = re.compile(r"^(\w+):(.*)$", re.MULTILINE)
+    for entry in line.split(";"):
         m = pattern.match(entry)
         if not m:
-            raise ValidationFailedException(f"{key} param: {entry} is not matching <{key}_type>:<{key}_values> syntax")
+            raise ValidationFailedException(
+                f"{key} param: {entry} is not matching <{key}_type>:<{key}_values> syntax"
+            )
         group_type = m.group(1).strip()
         group_value = m.group(2).strip()
-        if group_value == '*':
+        if group_value == "*":
             parsed.append((group_type, True))
         else:
-            parsed.append((group_type, [g.strip() for g in group_value.split(',')]))
+            parsed.append((group_type, [g.strip() for g in group_value.split(",")]))
     return parsed
 
 
@@ -36,7 +38,10 @@ class GeoPair:
 
 
 def parse_geo_arg() -> List[GeoPair]:
-    return [GeoPair(geo_type, geo_values) for [geo_type, geo_values] in _parse_common_multi_arg('geo')]
+    return [
+        GeoPair(geo_type, geo_values)
+        for [geo_type, geo_values] in _parse_common_multi_arg("geo")
+    ]
 
 
 @dataclass
@@ -46,7 +51,10 @@ class SourceSignalPair:
 
 
 def parse_source_signal_arg() -> List[SourceSignalPair]:
-    return [SourceSignalPair(source, signals) for [source, signals] in _parse_common_multi_arg('signal')]
+    return [
+        SourceSignalPair(source, signals)
+        for [source, signals] in _parse_common_multi_arg("signal")
+    ]
 
 
 @dataclass
@@ -67,54 +75,56 @@ def _verify_range(start: int, end: int) -> Union[int, Tuple[int, int]]:
 
 
 def parse_week_value(time_value: str) -> Union[int, Tuple[int, int]]:
-    count_dashes = time_value.count('-')
+    count_dashes = time_value.count("-")
     msg = f"{time_value} is not matching a known format YYYYWW or YYYYWW-YYYYWW"
 
     if count_dashes == 0:
         # plain delphi date YYYYWW
-        if not re.match(r'^(\d{6})$', time_value, re.MULTILINE):
+        if not re.match(r"^(\d{6})$", time_value, re.MULTILINE):
             raise ValidationFailedException(msg)
         return int(time_value)
 
     if count_dashes == 1:
         # delphi date range YYYYWW-YYYYWW
-        if not re.match(r'^(\d{6})-(\d{6})$', time_value, re.MULTILINE):
+        if not re.match(r"^(\d{6})-(\d{6})$", time_value, re.MULTILINE):
             raise ValidationFailedException(msg)
-        [first, last] = time_value.split('-', 2)
+        [first, last] = time_value.split("-", 2)
         return _verify_range(int(first), int(last))
 
     raise ValidationFailedException(msg)
 
 
 def parse_day_value(time_value: str) -> Union[int, Tuple[int, int]]:
-    count_dashes = time_value.count('-')
+    count_dashes = time_value.count("-")
     msg = f"{time_value} is not matching a known format YYYYMMDD, YYYY-MM-DD, YYYYMMDD-YYYYMMDD, or YYYY-MM-DD--YYYY-MM-DD"
 
     if count_dashes == 0:
         # plain delphi date YYYYMMDD
-        if not re.match(r'^(\d{8})$', time_value, re.MULTILINE):
+        if not re.match(r"^(\d{8})$", time_value, re.MULTILINE):
             raise ValidationFailedException(msg)
         return int(time_value)
 
     if count_dashes == 2:
         # iso date YYYY-MM-DD
-        if not re.match(r'^(\d{4}-\d{2}-\d{2})$', time_value, re.MULTILINE):
+        if not re.match(r"^(\d{4}-\d{2}-\d{2})$", time_value, re.MULTILINE):
             raise ValidationFailedException(msg)
-        return int(time_value.replace('-', ''))
+        return int(time_value.replace("-", ""))
 
     if count_dashes == 1:
         # delphi date range YYYYMMDD-YYYYMMDD
-        if not re.match(r'^(\d{8})-(\d{8})$', time_value, re.MULTILINE):
+        if not re.match(r"^(\d{8})-(\d{8})$", time_value, re.MULTILINE):
             raise ValidationFailedException(msg)
-        [first, last] = time_value.split('-', 2)
+        [first, last] = time_value.split("-", 2)
         return _verify_range(int(first), int(last))
 
     if count_dashes == 6:
         # delphi iso date range YYYY-MM-DD--YYYY-MM-DD
-        if not re.match(r'^(\d{4}-\d{2}-\d{2})--(\d{4}-\d{2}-\d{2})$', time_value, re.MULTILINE):
+        if not re.match(
+            r"^(\d{4}-\d{2}-\d{2})--(\d{4}-\d{2}-\d{2})$", time_value, re.MULTILINE
+        ):
             raise ValidationFailedException(msg)
-        [first, last] = time_value.split('--', 2)
-        return _verify_range(int(first.replace('-', '')), int(last.replace('-', '')))
+        [first, last] = time_value.split("--", 2)
+        return _verify_range(int(first.replace("-", "")), int(last.replace("-", "")))
 
     raise ValidationFailedException(msg)
 
@@ -124,10 +134,15 @@ def parse_time_arg() -> List[TimePair]:
         if isinstance(time_values, bool):
             return TimePair(time_type, time_values)
 
-        if time_type == 'week':
-            return TimePair('week', [parse_week_value(t) for t in time_values])
-        elif time_type == 'day':
-            return TimePair('day', [parse_day_value(t) for t in time_values])
-        raise ValidationFailedException(f'time param: {time_type} is not one of "day" or "week"')
+        if time_type == "week":
+            return TimePair("week", [parse_week_value(t) for t in time_values])
+        elif time_type == "day":
+            return TimePair("day", [parse_day_value(t) for t in time_values])
+        raise ValidationFailedException(
+            f'time param: {time_type} is not one of "day" or "week"'
+        )
 
-    return [parse(time_type, time_values) for [time_type, time_values] in _parse_common_multi_arg('time')]
+    return [
+        parse(time_type, time_values)
+        for [time_type, time_values] in _parse_common_multi_arg("time")
+    ]

--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -177,7 +177,7 @@ def filter_time_pairs(
         params[type_param] = pair.time_type
         if isinstance(pair.time_values, bool) and pair.time_values:
             return f'{type_field} = :{type_param}'
-        return f'({type_field} = :{type_param} AND {filter_dates(time_field, cast(Sequence[Union[int, Tuple[int,int]]], pair.time_values), type_param, params)})'
+        return f'({type_field} = :{type_param} AND {filter_integers(time_field, cast(Sequence[Union[int, Tuple[int,int]]], pair.time_values), type_param, params)})'
 
     parts = [filter_pair(p, i) for i,p in enumerate(values)]
 

--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -112,24 +112,24 @@ def filter_geo_pairs(
     value_field: str,
     values: Sequence[GeoPair],
     param_key: str,
-    params: Dict[str, Any]
+    params: Dict[str, Any],
 ) -> str:
     """
     returns the SQL sub query to filter by the given geo pairs
     """
 
     def filter_pair(pair: GeoPair, i) -> str:
-        type_param = f'{param_key}_{i}t'
+        type_param = f"{param_key}_{i}t"
         params[type_param] = pair.geo_type
         if isinstance(pair.geo_values, bool) and pair.geo_values:
-            return f'{type_field} = :{type_param}'
-        return f'({type_field} = :{type_param} AND {filter_strings(value_field, cast(Sequence[str], pair.geo_values), type_param, params)})'
+            return f"{type_field} = :{type_param}"
+        return f"({type_field} = :{type_param} AND {filter_strings(value_field, cast(Sequence[str], pair.geo_values), type_param, params)})"
 
-    parts = [filter_pair(p, i) for i,p in enumerate(values)]
+    parts = [filter_pair(p, i) for i, p in enumerate(values)]
 
     if not parts:
         # something has to be selected
-        return 'FALSE'
+        return "FALSE"
 
     return f"({' OR '.join(parts)})"
 
@@ -139,24 +139,24 @@ def filter_source_signal_pairs(
     signal_field: str,
     values: Sequence[SourceSignalPair],
     param_key: str,
-    params: Dict[str, Any]
+    params: Dict[str, Any],
 ) -> str:
     """
     returns the SQL sub query to filter by the given source signal pairs
     """
 
     def filter_pair(pair: SourceSignalPair, i) -> str:
-        source_param = f'{param_key}_{i}t'
+        source_param = f"{param_key}_{i}t"
         params[source_param] = pair.source
         if isinstance(pair.signal, bool) and pair.signal:
-            return f'{source_field} = :{source_param}'
-        return f'({source_field} = :{source_param} AND {filter_strings(signal_field, cast(Sequence[str], pair.signal), source_param, params)})'
+            return f"{source_field} = :{source_param}"
+        return f"({source_field} = :{source_param} AND {filter_strings(signal_field, cast(Sequence[str], pair.signal), source_param, params)})"
 
-    parts = [filter_pair(p, i) for i,p in enumerate(values)]
+    parts = [filter_pair(p, i) for i, p in enumerate(values)]
 
     if not parts:
         # something has to be selected
-        return 'FALSE'
+        return "FALSE"
 
     return f"({' OR '.join(parts)})"
 
@@ -166,24 +166,24 @@ def filter_time_pairs(
     time_field: str,
     values: Sequence[TimePair],
     param_key: str,
-    params: Dict[str, Any]
+    params: Dict[str, Any],
 ) -> str:
     """
     returns the SQL sub query to filter by the given time pairs
     """
 
     def filter_pair(pair: TimePair, i) -> str:
-        type_param = f'{param_key}_{i}t'
+        type_param = f"{param_key}_{i}t"
         params[type_param] = pair.time_type
         if isinstance(pair.time_values, bool) and pair.time_values:
-            return f'{type_field} = :{type_param}'
-        return f'({type_field} = :{type_param} AND {filter_integers(time_field, cast(Sequence[Union[int, Tuple[int,int]]], pair.time_values), type_param, params)})'
+            return f"{type_field} = :{type_param}"
+        return f"({type_field} = :{type_param} AND {filter_integers(time_field, cast(Sequence[Union[int, Tuple[int,int]]], pair.time_values), type_param, params)})"
 
-    parts = [filter_pair(p, i) for i,p in enumerate(values)]
+    parts = [filter_pair(p, i) for i, p in enumerate(values)]
 
     if not parts:
         # something has to be selected
-        return 'FALSE'
+        return "FALSE"
 
     return f"({' OR '.join(parts)})"
 
@@ -390,7 +390,13 @@ class QueryBuilder:
         fq_type_field = self._fq_field(type_field)
         fq_value_field = self._fq_field(value_field)
         self.conditions.append(
-            filter_geo_pairs(fq_type_field, fq_value_field, values, param_key or type_field, self.params)
+            filter_geo_pairs(
+                fq_type_field,
+                fq_value_field,
+                values,
+                param_key or type_field,
+                self.params,
+            )
         )
         return self
 
@@ -404,7 +410,13 @@ class QueryBuilder:
         fq_type_field = self._fq_field(type_field)
         fq_value_field = self._fq_field(value_field)
         self.conditions.append(
-            filter_source_signal_pairs(fq_type_field, fq_value_field, values, param_key or type_field, self.params)
+            filter_source_signal_pairs(
+                fq_type_field,
+                fq_value_field,
+                values,
+                param_key or type_field,
+                self.params,
+            )
         )
         return self
 
@@ -418,7 +430,13 @@ class QueryBuilder:
         fq_type_field = self._fq_field(type_field)
         fq_value_field = self._fq_field(value_field)
         self.conditions.append(
-            filter_time_pairs(fq_type_field, fq_value_field, values, param_key or type_field, self.params)
+            filter_time_pairs(
+                fq_type_field,
+                fq_value_field,
+                values,
+                param_key or type_field,
+                self.params,
+            )
         )
         return self
 

--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -60,10 +60,7 @@ def filter_values(
     # builds a SQL expression to filter strings (ex: locations)
     #   $field: name of the field to filter
     #   $values: array of values
-    conditions = [
-        to_condition(field, v, f"{param_key}_{i}", params, formatter)
-        for i, v in enumerate(values)
-    ]
+    conditions = [to_condition(field, v, f"{param_key}_{i}", params, formatter) for i, v in enumerate(values)]
     return f"({' OR '.join(conditions)})"
 
 
@@ -221,10 +218,7 @@ def parse_result(
     """
     execute the given query and return the result as a list of dictionaries
     """
-    return [
-        parse_row(row, fields_string, fields_int, fields_float)
-        for row in db.execute(text(query), **params)
-    ]
+    return [parse_row(row, fields_string, fields_int, fields_float) for row in db.execute(text(query), **params)]
 
 
 def run_query(p: APrinter, query_tuple: Tuple[str, Dict[str, Any]]):
@@ -348,9 +342,7 @@ class QueryBuilder:
         param_key: Optional[str] = None,
     ) -> "QueryBuilder":
         fq_field = f"{self.alias}.{field}" if "." not in field else field
-        self.conditions.append(
-            filter_strings(fq_field, values, param_key or field, self.params)
-        )
+        self.conditions.append(filter_strings(fq_field, values, param_key or field, self.params))
         return self
 
     def _fq_field(self, field: str) -> str:
@@ -363,9 +355,7 @@ class QueryBuilder:
         param_key: Optional[str] = None,
     ) -> "QueryBuilder":
         fq_field = self._fq_field(field)
-        self.conditions.append(
-            filter_integers(fq_field, values, param_key or field, self.params)
-        )
+        self.conditions.append(filter_integers(fq_field, values, param_key or field, self.params))
         return self
 
     def where_dates(
@@ -375,9 +365,7 @@ class QueryBuilder:
         param_key: Optional[str] = None,
     ) -> "QueryBuilder":
         fq_field = self._fq_field(field)
-        self.conditions.append(
-            filter_dates(fq_field, values, param_key or field, self.params)
-        )
+        self.conditions.append(filter_dates(fq_field, values, param_key or field, self.params))
         return self
 
     def where_geo_pairs(
@@ -441,9 +429,7 @@ class QueryBuilder:
         return self
 
     def set_fields(self, *fields: Iterable[str]) -> "QueryBuilder":
-        self.fields = [
-            f"{self.alias}.{field}" for field_list in fields for field in field_list
-        ]
+        self.fields = [f"{self.alias}.{field}" for field_list in fields for field in field_list]
         return self
 
     def set_order(self, *args: str, **kwargs: Union[str, bool]) -> "QueryBuilder":
@@ -468,9 +454,7 @@ class QueryBuilder:
 
         subfields = f"max(issue) max_issue, {','.join(fields)}"
         group_by = ",".join(fields)
-        field_conditions = " AND ".join(
-            f"x.{field} = {self.alias}.{field}" for field in fields
-        )
+        field_conditions = " AND ".join(f"x.{field} = {self.alias}.{field}" for field in fields)
         condition = f"x.max_issue = {self.alias}.issue AND {field_conditions}"
         self.subquery = f"JOIN (SELECT {subfields} FROM {self.table} WHERE {self.conditions_clause} GROUP BY {group_by}) x ON {condition}"
         # reset conditions since for join

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -1,7 +1,17 @@
-from flask import Blueprint, request
 from typing import List
 
-from .._query import execute_query, filter_integers, filter_strings, QueryBuilder
+from flask import Blueprint, request
+
+from .._exceptions import ValidationFailedException
+from .._params import (
+    GeoPair,
+    SourceSignalPair,
+    TimePair,
+    parse_geo_arg,
+    parse_source_signal_arg,
+    parse_time_arg,
+)
+from .._query import QueryBuilder, execute_query, filter_integers, filter_strings
 from .._validate import (
     extract_date,
     extract_dates,
@@ -11,15 +21,6 @@ from .._validate import (
     require_all,
     require_any,
 )
-from .._params import (
-    parse_geo_arg,
-    parse_source_signal_arg,
-    parse_time_arg,
-    GeoPair,
-    TimePair,
-    SourceSignalPair,
-)
-from .._exceptions import ValidationFailedException
 
 # first argument is the endpoint name
 bp = Blueprint("covidcast", __name__)
@@ -27,45 +28,51 @@ alias = None
 
 
 def parse_source_signal_pairs() -> List[SourceSignalPair]:
-    ds = request.values.get('data_source')
+    ds = request.values.get("data_source")
     if ds:
         # old version
         require_any("signal", "signals")
         signals = extract_strings(("signals", "signal"))
         return [SourceSignalPair(ds, signals)]
 
-    if ':' not in request.values.get('signal', ''):
-        raise ValidationFailedException('missing parameter: signal or (data_source and signal[s])')
+    if ":" not in request.values.get("signal", ""):
+        raise ValidationFailedException(
+            "missing parameter: signal or (data_source and signal[s])"
+        )
 
     return parse_source_signal_arg()
 
 
 def parse_geo_pairs() -> List[GeoPair]:
-    geo_type = request.values.get('geo_type')
+    geo_type = request.values.get("geo_type")
     if geo_type:
         # old version
         require_any("geo_value", "geo_values", empty=True)
         geo_values = extract_strings(("geo_values", "geo_value"))
-        if len(geo_values) == 1 and geo_values[0] == '*':
+        if len(geo_values) == 1 and geo_values[0] == "*":
             return [GeoPair(geo_type, True)]
         return [GeoPair(geo_type, geo_values)]
 
-    if ':' not in request.values.get('geo', ''):
-        raise ValidationFailedException('missing parameter: geo or (geo_type and geo_value[s])')
+    if ":" not in request.values.get("geo", ""):
+        raise ValidationFailedException(
+            "missing parameter: geo or (geo_type and geo_value[s])"
+        )
 
     return parse_geo_arg()
 
 
 def parse_time_pairs() -> List[TimePair]:
-    time_type = request.values.get('time_type')
+    time_type = request.values.get("time_type")
     if time_type:
         # old version
         require_all("time_type", "time_values")
         time_values = extract_dates("time_values")
         return [TimePair(time_type, time_values)]
 
-    if ':' not in request.values.get('time', ''):
-        raise ValidationFailedException('missing parameter: time or (time_type and time_values)')
+    if ":" not in request.values.get("time", ""):
+        raise ValidationFailedException(
+            "missing parameter: time or (time_type and time_values)"
+        )
 
     return parse_time_arg()
 
@@ -87,15 +94,15 @@ def handle():
     fields_int = ["time_value", "direction", "issue", "lag"]
     fields_float = ["value", "stderr", "sample_size"]
     q.set_fields(fields_string, fields_int, fields_float)
-    q.set_order('signal', 'time_value', 'geo_value', 'issue')
+    q.set_order("signal", "time_value", "geo_value", "issue")
 
     # basic query info
     # data type of each field
     # build the source, signal, time, and location (type and id) filters
 
-    q.where_source_signal_pairs('source','signal',source_signal_pairs)
-    q.where_geo_pairs('geo_type','geo_value',geo_pairs)
-    q.where_time_pairs('time_type','time_value',time_pairs)
+    q.where_source_signal_pairs("source", "signal", source_signal_pairs)
+    q.where_geo_pairs("geo_type", "geo_value", geo_pairs)
+    q.where_time_pairs("time_type", "time_value", time_pairs)
 
     subquery = ""
     if issues:

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -93,7 +93,7 @@ def handle():
     else:
         # transfer also the new detail columns
         fields_string.extend(["source", "geo_type", "time_type"])
-        q.set_order("signal", "signal", "time_type", "time_value", "geo_type", "geo_value", "issue")
+        q.set_order("source", "signal", "time_type", "time_value", "geo_type", "geo_value", "issue")
     q.set_fields(fields_string, fields_int, fields_float)
 
     # basic query info

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -2,6 +2,7 @@ from typing import List
 
 from flask import Blueprint, request
 
+from .._common import is_compatibility_mode
 from .._exceptions import ValidationFailedException
 from .._params import (
     GeoPair,
@@ -87,8 +88,13 @@ def handle():
     fields_string = ["geo_value", "signal"]
     fields_int = ["time_value", "direction", "issue", "lag"]
     fields_float = ["value", "stderr", "sample_size"]
+    if is_compatibility_mode():
+        q.set_order("signal", "time_value", "geo_value", "issue")
+    else:
+        # transfer also the new detail columns
+        fields_string.extend(["source", "geo_type", "time_type"])
+        q.set_order("signal", "signal", "time_type", "time_value", "geo_type", "geo_value", "issue")
     q.set_fields(fields_string, fields_int, fields_float)
-    q.set_order("signal", "time_value", "geo_value", "issue")
 
     # basic query info
     # data type of each field

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -36,9 +36,7 @@ def parse_source_signal_pairs() -> List[SourceSignalPair]:
         return [SourceSignalPair(ds, signals)]
 
     if ":" not in request.values.get("signal", ""):
-        raise ValidationFailedException(
-            "missing parameter: signal or (data_source and signal[s])"
-        )
+        raise ValidationFailedException("missing parameter: signal or (data_source and signal[s])")
 
     return parse_source_signal_arg()
 
@@ -54,9 +52,7 @@ def parse_geo_pairs() -> List[GeoPair]:
         return [GeoPair(geo_type, geo_values)]
 
     if ":" not in request.values.get("geo", ""):
-        raise ValidationFailedException(
-            "missing parameter: geo or (geo_type and geo_value[s])"
-        )
+        raise ValidationFailedException("missing parameter: geo or (geo_type and geo_value[s])")
 
     return parse_geo_arg()
 
@@ -70,9 +66,7 @@ def parse_time_pairs() -> List[TimePair]:
         return [TimePair(time_type, time_values)]
 
     if ":" not in request.values.get("time", ""):
-        raise ValidationFailedException(
-            "missing parameter: time or (time_type and time_values)"
-        )
+        raise ValidationFailedException("missing parameter: time or (time_type and time_values)")
 
     return parse_time_arg()
 

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -11,37 +11,74 @@ from .._validate import (
     require_all,
     require_any,
 )
+from .._params import (
+    parse_geo_arg,
+    parse_source_signal_arg,
+    parse_time_arg,
+    GeoPair,
+    TimePair,
+    SourceSignalPair,
+)
+from .._exceptions import ValidationFailedException
 
 # first argument is the endpoint name
 bp = Blueprint("covidcast", __name__)
 alias = None
 
-def where_geo_values(q: QueryBuilder, geo_values: List[str]):
-    if not geo_values:
-        q.conditions.append("FALSE")
-    elif len(geo_values) == 1 and geo_values[0] == "*":
-        # the wildcard query should return data for all locations in geo_type
-        pass
-    else:
-        # return data for multiple location
-        q.where_strings("geo_value", geo_values)
+
+def parse_source_signal_pairs() -> List[SourceSignalPair]:
+    ds = request.values.get('data_source')
+    if ds:
+        # old version
+        require_any("signal", "signals")
+        signals = extract_strings(("signals", "signal"))
+        return [SourceSignalPair(ds, signals)]
+
+    if ':' not in request.values.get('signal', ''):
+        raise ValidationFailedException('missing parameter: signal or (data_source and signal[s])')
+
+    return parse_source_signal_arg()
+
+
+def parse_geo_pairs() -> List[GeoPair]:
+    geo_type = request.values.get('geo_type')
+    if geo_type:
+        # old version
+        require_any("geo_value", "geo_values", empty=True)
+        geo_values = extract_strings(("geo_values", "geo_value"))
+        if len(geo_values) == 1 and geo_values[0] == '*':
+            return [GeoPair(geo_type, True)]
+        return [GeoPair(geo_type, geo_values)]
+
+    if ':' not in request.values.get('geo', ''):
+        raise ValidationFailedException('missing parameter: geo or (geo_type and geo_value[s])')
+
+    return parse_geo_arg()
+
+
+def parse_time_pairs() -> List[TimePair]:
+    time_type = request.values.get('time_type')
+    if time_type:
+        # old version
+        require_all("time_type", "time_values")
+        time_values = extract_dates("time_values")
+        return [TimePair(time_type, time_values)]
+
+    if ':' not in request.values.get('time', ''):
+        raise ValidationFailedException('missing parameter: time or (time_type and time_values)')
+
+    return parse_time_arg()
 
 
 @bp.route("/", methods=("GET", "POST"))
 def handle():
-    require_all("data_source", "time_type", "geo_type", "time_values")
-    require_any("signal", "signals")
-    require_any("geo_value", "geo_values", empty=True)
+    source_signal_pairs = parse_source_signal_pairs()
+    time_pairs = parse_time_pairs()
+    geo_pairs = parse_geo_pairs()
 
-    time_values = extract_dates("time_values")
     as_of = extract_date("as_of")
     issues = extract_dates("issues")
     lag = extract_integer("lag")
-    signals = extract_strings(("signals", "signal"))
-    geo_values = extract_strings(("geo_values", "geo_value"))
-    data_source = request.values["data_source"]
-    time_type = request.values["time_type"]
-    geo_type = request.values["geo_type"]
 
     # build query
     q = QueryBuilder("covidcast", "t")
@@ -56,11 +93,9 @@ def handle():
     # data type of each field
     # build the source, signal, time, and location (type and id) filters
 
-    q.where(source=data_source, time_type=time_type, geo_type=geo_type)
-    q.where_strings("signal", signals)
-    q.where_integers("time_value", time_values)
-
-    where_geo_values(q, geo_values)
+    q.where_source_signal_pairs('source','signal',source_signal_pairs)
+    q.where_geo_pairs('geo_type','geo_value',geo_pairs)
+    q.where_time_pairs('time_type','time_value',time_pairs)
 
     subquery = ""
     if issues:

--- a/tests/server/endpoints/test_covidcast.py
+++ b/tests/server/endpoints/test_covidcast.py
@@ -23,15 +23,15 @@ class UnitTests(unittest.TestCase):
         self.client = app.test_client()
 
     def test_url(self):
-        rv: Response = self.client.get('/covidcast/', follow_redirects=True)
+        rv: Response = self.client.get("/covidcast/", follow_redirects=True)
         msg = rv.get_json()
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(msg['result'], -1)
-        self.assertRegex(msg['message'], r"missing parameter.*")
+        self.assertEqual(msg["result"], -1)
+        self.assertRegex(msg["message"], r"missing parameter.*")
 
     def test_time(self):
-        rv: Response = self.client.get('/covidcast/', query_string=dict(signal="src1:*", time="day:20200101", geo="state:*"))
+        rv: Response = self.client.get("/covidcast/", query_string=dict(signal="src1:*", time="day:20200101", geo="state:*"))
         msg = rv.get_json()
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(msg['result'], -2)  # no result
-        self.assertEqual(msg['message'], "no results")
+        self.assertEqual(msg["result"], -2)  # no result
+        self.assertEqual(msg["message"], "no results")

--- a/tests/server/endpoints/test_covidcast.py
+++ b/tests/server/endpoints/test_covidcast.py
@@ -1,0 +1,37 @@
+# standard library
+import unittest
+import base64
+
+from json import loads
+from flask.testing import FlaskClient
+from flask import Response
+from delphi.epidata.server.main import app
+
+# py3tester coverage target
+__test_target__ = "delphi.epidata.server.endpoints.covidcast"
+
+
+class UnitTests(unittest.TestCase):
+    """Basic unit tests."""
+
+    client: FlaskClient
+
+    def setUp(self):
+        app.config["TESTING"] = True
+        app.config["WTF_CSRF_ENABLED"] = False
+        app.config["DEBUG"] = False
+        self.client = app.test_client()
+
+    def test_url(self):
+        rv: Response = self.client.get('/covidcast/', follow_redirects=True)
+        msg = rv.get_json()
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(msg['result'], -1)
+        self.assertRegex(msg['message'], r"missing parameter.*")
+
+    def test_time(self):
+        rv: Response = self.client.get('/covidcast/', query_string=dict(signal="src1:*", time="day:20200101", geo="state:*"))
+        msg = rv.get_json()
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(msg['result'], -2)  # no result
+        self.assertEqual(msg['message'], "no results")

--- a/tests/server/test_params.py
+++ b/tests/server/test_params.py
@@ -48,9 +48,7 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(parse_geo_arg(), [GeoPair("state", ["AK", "TK"])])
         with self.subTest("multi"):
             with app.test_request_context("/?geo=state:*;nation:*"):
-                self.assertEqual(
-                    parse_geo_arg(), [GeoPair("state", True), GeoPair("nation", True)]
-                )
+                self.assertEqual(parse_geo_arg(), [GeoPair("state", True), GeoPair("nation", True)])
             with app.test_request_context("/?geo=state:AK;nation:US"):
                 self.assertEqual(
                     parse_geo_arg(),
@@ -93,13 +91,9 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(parse_source_signal_arg(), [])
         with self.subTest("single"):
             with app.test_request_context("/?signal=src1:*"):
-                self.assertEqual(
-                    parse_source_signal_arg(), [SourceSignalPair("src1", True)]
-                )
+                self.assertEqual(parse_source_signal_arg(), [SourceSignalPair("src1", True)])
             with app.test_request_context("/?signal=src1:sig1"):
-                self.assertEqual(
-                    parse_source_signal_arg(), [SourceSignalPair("src1", ["sig1"])]
-                )
+                self.assertEqual(parse_source_signal_arg(), [SourceSignalPair("src1", ["sig1"])])
         with self.subTest("single list"):
             with app.test_request_context("/?signal=src1:sig1,sig2"):
                 self.assertEqual(
@@ -161,25 +155,17 @@ class UnitTests(unittest.TestCase):
             with self.subTest("iso date"):
                 self.assertEqual(parse_day_value("2020-01-01"), 20200101)
             with self.subTest("delphi date range"):
-                self.assertEqual(
-                    parse_day_value("20200101-20210404"), (20200101, 20210404)
-                )
+                self.assertEqual(parse_day_value("20200101-20210404"), (20200101, 20210404))
             with self.subTest("iso date range"):
-                self.assertEqual(
-                    parse_day_value("2020-01-01--2021-04-04"), (20200101, 20210404)
-                )
+                self.assertEqual(parse_day_value("2020-01-01--2021-04-04"), (20200101, 20210404))
 
             with self.subTest("wrong"):
                 self.assertRaises(ValidationFailedException, parse_day_value, "")
                 self.assertRaises(ValidationFailedException, parse_day_value, "x")
                 self.assertRaises(ValidationFailedException, parse_day_value, "2020")
                 self.assertRaises(ValidationFailedException, parse_day_value, "202001")
-                self.assertRaises(
-                    ValidationFailedException, parse_day_value, "2020-03-111"
-                )
-                self.assertRaises(
-                    ValidationFailedException, parse_day_value, "2020-02-30---20200403"
-                )
+                self.assertRaises(ValidationFailedException, parse_day_value, "2020-03-111")
+                self.assertRaises(ValidationFailedException, parse_day_value, "2020-02-30---20200403")
 
     def test_parse_week_value(self):
         with app.test_request_context(""):
@@ -191,15 +177,9 @@ class UnitTests(unittest.TestCase):
                 self.assertRaises(ValidationFailedException, parse_week_value, "")
                 self.assertRaises(ValidationFailedException, parse_week_value, "x")
                 self.assertRaises(ValidationFailedException, parse_week_value, "2020")
-                self.assertRaises(
-                    ValidationFailedException, parse_week_value, "20200100"
-                )
-                self.assertRaises(
-                    ValidationFailedException, parse_week_value, "2020-03-11"
-                )
-                self.assertRaises(
-                    ValidationFailedException, parse_week_value, "2020-02-30---20200403"
-                )
+                self.assertRaises(ValidationFailedException, parse_week_value, "20200100")
+                self.assertRaises(ValidationFailedException, parse_week_value, "2020-03-11")
+                self.assertRaises(ValidationFailedException, parse_week_value, "2020-02-30---20200403")
 
     def test_parse_time_arg(self):
         with self.subTest("empty"):
@@ -212,28 +192,20 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(parse_time_arg(), [TimePair("day", [20201201])])
         with self.subTest("single list"):
             with app.test_request_context("/?time=day:20201201,20201202"):
-                self.assertEqual(
-                    parse_time_arg(), [TimePair("day", [20201201, 20201202])]
-                )
+                self.assertEqual(parse_time_arg(), [TimePair("day", [20201201, 20201202])])
         with self.subTest("single range"):
             with app.test_request_context("/?time=day:20201201-20201204"):
-                self.assertEqual(
-                    parse_time_arg(), [TimePair("day", [(20201201, 20201204)])]
-                )
+                self.assertEqual(parse_time_arg(), [TimePair("day", [(20201201, 20201204)])])
         with self.subTest("multi"):
             with app.test_request_context("/?time=day:*;week:*"):
-                self.assertEqual(
-                    parse_time_arg(), [TimePair("day", True), TimePair("week", True)]
-                )
+                self.assertEqual(parse_time_arg(), [TimePair("day", True), TimePair("week", True)])
             with app.test_request_context("/?time=day:20201201;week:202012"):
                 self.assertEqual(
                     parse_time_arg(),
                     [TimePair("day", [20201201]), TimePair("week", [202012])],
                 )
         with self.subTest("hybrid"):
-            with app.test_request_context(
-                "/?time=day:*;day:20202012;week:202101-202104"
-            ):
+            with app.test_request_context("/?time=day:*;day:20202012;week:202101-202104"):
                 self.assertEqual(
                     parse_time_arg(),
                     [

--- a/tests/server/test_params.py
+++ b/tests/server/test_params.py
@@ -71,31 +71,31 @@ class UnitTests(unittest.TestCase):
             with app.test_request_context("/"):
                 self.assertEqual(parse_source_signal_arg(), [])
         with self.subTest("single"):
-            with app.test_request_context("/?signals=src1:*"):
+            with app.test_request_context("/?signal=src1:*"):
                 self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', True)])
-            with app.test_request_context("/?signals=src1:sig1"):
+            with app.test_request_context("/?signal=src1:sig1"):
                 self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', ['sig1'])])
         with self.subTest("single list"):
-            with app.test_request_context("/?signals=src1:sig1,sig2"):
+            with app.test_request_context("/?signal=src1:sig1,sig2"):
                 self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', ['sig1', 'sig2'])])
         with self.subTest("multi"):
-            with app.test_request_context("/?signals=src1:*;src2:*"):
+            with app.test_request_context("/?signal=src1:*;src2:*"):
                 self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', True), SourceSignalPair('src2', True)])
-            with app.test_request_context("/?signals=src1:sig1;src2:sig3"):
+            with app.test_request_context("/?signal=src1:sig1;src2:sig3"):
                 self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', ['sig1']), SourceSignalPair('src2', ['sig3'])])
-            with app.test_request_context("/?signals=src1:sig1;src1:sig4"):
+            with app.test_request_context("/?signal=src1:sig1;src1:sig4"):
                 self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', ['sig1']), SourceSignalPair('src1', ['sig4'])])
         with self.subTest("multi list"):
-            with app.test_request_context("/?signals=src1:sig1,sig2;county:sig5,sig6"):
+            with app.test_request_context("/?signal=src1:sig1,sig2;county:sig5,sig6"):
                 self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', ['sig1', 'sig2']), SourceSignalPair('county', ['sig5', 'sig6'])])
         with self.subTest("hybrid"):
-            with app.test_request_context("/?signals=src2:*;src1:sig4;src3:sig5,sig6"):
+            with app.test_request_context("/?signal=src2:*;src1:sig4;src3:sig5,sig6"):
                 self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src2', True), SourceSignalPair('src1', ['sig4']), SourceSignalPair('src3', ['sig5', 'sig6'])])
 
         with self.subTest("wrong"):
-            with app.test_request_context("/?signals=abc"):
+            with app.test_request_context("/?signal=abc"):
                 self.assertRaises(ValidationFailedException, parse_source_signal_arg)
-            with app.test_request_context("/?signals=sig=4"):
+            with app.test_request_context("/?signal=sig=4"):
                 self.assertRaises(ValidationFailedException, parse_source_signal_arg)
 
     def test_parse_day_value(self):

--- a/tests/server/test_params.py
+++ b/tests/server/test_params.py
@@ -1,0 +1,61 @@
+"""Unit tests for granular sensor authentication in api.php."""
+
+# standard library
+import unittest
+import base64
+
+# from flask.testing import FlaskClient
+from delphi.epidata.server._common import app
+from delphi.epidata.server._params import (
+    parse_geo_arg,
+    GeoPair,
+)
+from delphi.epidata.server._exceptions import (
+    ValidationFailedException,
+)
+
+# py3tester coverage target
+__test_target__ = "delphi.epidata.server._params"
+
+
+class UnitTests(unittest.TestCase):
+    """Basic unit tests."""
+
+    # app: FlaskClient
+
+    def setUp(self):
+        app.config["TESTING"] = True
+        app.config["WTF_CSRF_ENABLED"] = False
+        app.config["DEBUG"] = False
+
+    def test_parse_geo_arg(self):
+        with self.subTest("empty"):
+            with app.test_request_context("/"):
+                self.assertEqual(parse_geo_arg(), [])
+        with self.subTest("single"):
+            with app.test_request_context("/?geo=state:*"):
+                self.assertEqual(parse_geo_arg(), [GeoPair('state', True)])
+            with app.test_request_context("/?geo=state:AK"):
+                self.assertEqual(parse_geo_arg(), [GeoPair('state', ['AK'])])
+        with self.subTest("single list"):
+            with app.test_request_context("/?geo=state:AK,TK"):
+                self.assertEqual(parse_geo_arg(), [GeoPair('state', ['AK', 'TK'])])
+        with self.subTest("multi"):
+            with app.test_request_context("/?geo=state:*;nation:*"):
+                self.assertEqual(parse_geo_arg(), [GeoPair('state', True), GeoPair('nation', True)])
+            with app.test_request_context("/?geo=state:AK;nation:US"):
+                self.assertEqual(parse_geo_arg(), [GeoPair('state', ['AK']), GeoPair('nation', ['US'])])
+            with app.test_request_context("/?geo=state:AK;state:KY"):
+                self.assertEqual(parse_geo_arg(), [GeoPair('state', ['AK']), GeoPair('state', ['KY'])])
+        with self.subTest("multi list"):
+            with app.test_request_context("/?geo=state:AK,TK;county:42003,40556"):
+                self.assertEqual(parse_geo_arg(), [GeoPair('state', ['AK', 'TK']), GeoPair('county', ['42003', '40556'])])
+        with self.subTest("hybrid"):
+            with app.test_request_context("/?geo=nation:*;state:PA;county:42003,42002"):
+                self.assertEqual(parse_geo_arg(), [GeoPair('nation', True), GeoPair('state', ['PA']), GeoPair('county', ['42003', '42002'])])
+
+        with self.subTest("wrong"):
+            with app.test_request_context("/?geo=abc"):
+                self.assertRaises(ValidationFailedException, parse_geo_arg)
+            with app.test_request_context("/?geo=state=4"):
+                self.assertRaises(ValidationFailedException, parse_geo_arg)

--- a/tests/server/test_params.py
+++ b/tests/server/test_params.py
@@ -42,29 +42,29 @@ class UnitTests(unittest.TestCase):
             with app.test_request_context("/?geo=state:*"):
                 self.assertEqual(parse_geo_arg(), [GeoPair("state", True)])
             with app.test_request_context("/?geo=state:AK"):
-                self.assertEqual(parse_geo_arg(), [GeoPair("state", ["AK"])])
+                self.assertEqual(parse_geo_arg(), [GeoPair("state", ["ak"])])
         with self.subTest("single list"):
             with app.test_request_context("/?geo=state:AK,TK"):
-                self.assertEqual(parse_geo_arg(), [GeoPair("state", ["AK", "TK"])])
+                self.assertEqual(parse_geo_arg(), [GeoPair("state", ["ak", "tk"])])
         with self.subTest("multi"):
             with app.test_request_context("/?geo=state:*;nation:*"):
                 self.assertEqual(parse_geo_arg(), [GeoPair("state", True), GeoPair("nation", True)])
             with app.test_request_context("/?geo=state:AK;nation:US"):
                 self.assertEqual(
                     parse_geo_arg(),
-                    [GeoPair("state", ["AK"]), GeoPair("nation", ["US"])],
+                    [GeoPair("state", ["ak"]), GeoPair("nation", ["us"])],
                 )
             with app.test_request_context("/?geo=state:AK;state:KY"):
                 self.assertEqual(
                     parse_geo_arg(),
-                    [GeoPair("state", ["AK"]), GeoPair("state", ["KY"])],
+                    [GeoPair("state", ["ak"]), GeoPair("state", ["ky"])],
                 )
         with self.subTest("multi list"):
             with app.test_request_context("/?geo=state:AK,TK;county:42003,40556"):
                 self.assertEqual(
                     parse_geo_arg(),
                     [
-                        GeoPair("state", ["AK", "TK"]),
+                        GeoPair("state", ["ak", "tk"]),
                         GeoPair("county", ["42003", "40556"]),
                     ],
                 )
@@ -74,7 +74,7 @@ class UnitTests(unittest.TestCase):
                     parse_geo_arg(),
                     [
                         GeoPair("nation", True),
-                        GeoPair("state", ["PA"]),
+                        GeoPair("state", ["pa"]),
                         GeoPair("county", ["42003", "42002"]),
                     ],
                 )

--- a/tests/server/test_params.py
+++ b/tests/server/test_params.py
@@ -40,25 +40,46 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(parse_geo_arg(), [])
         with self.subTest("single"):
             with app.test_request_context("/?geo=state:*"):
-                self.assertEqual(parse_geo_arg(), [GeoPair('state', True)])
+                self.assertEqual(parse_geo_arg(), [GeoPair("state", True)])
             with app.test_request_context("/?geo=state:AK"):
-                self.assertEqual(parse_geo_arg(), [GeoPair('state', ['AK'])])
+                self.assertEqual(parse_geo_arg(), [GeoPair("state", ["AK"])])
         with self.subTest("single list"):
             with app.test_request_context("/?geo=state:AK,TK"):
-                self.assertEqual(parse_geo_arg(), [GeoPair('state', ['AK', 'TK'])])
+                self.assertEqual(parse_geo_arg(), [GeoPair("state", ["AK", "TK"])])
         with self.subTest("multi"):
             with app.test_request_context("/?geo=state:*;nation:*"):
-                self.assertEqual(parse_geo_arg(), [GeoPair('state', True), GeoPair('nation', True)])
+                self.assertEqual(
+                    parse_geo_arg(), [GeoPair("state", True), GeoPair("nation", True)]
+                )
             with app.test_request_context("/?geo=state:AK;nation:US"):
-                self.assertEqual(parse_geo_arg(), [GeoPair('state', ['AK']), GeoPair('nation', ['US'])])
+                self.assertEqual(
+                    parse_geo_arg(),
+                    [GeoPair("state", ["AK"]), GeoPair("nation", ["US"])],
+                )
             with app.test_request_context("/?geo=state:AK;state:KY"):
-                self.assertEqual(parse_geo_arg(), [GeoPair('state', ['AK']), GeoPair('state', ['KY'])])
+                self.assertEqual(
+                    parse_geo_arg(),
+                    [GeoPair("state", ["AK"]), GeoPair("state", ["KY"])],
+                )
         with self.subTest("multi list"):
             with app.test_request_context("/?geo=state:AK,TK;county:42003,40556"):
-                self.assertEqual(parse_geo_arg(), [GeoPair('state', ['AK', 'TK']), GeoPair('county', ['42003', '40556'])])
+                self.assertEqual(
+                    parse_geo_arg(),
+                    [
+                        GeoPair("state", ["AK", "TK"]),
+                        GeoPair("county", ["42003", "40556"]),
+                    ],
+                )
         with self.subTest("hybrid"):
             with app.test_request_context("/?geo=nation:*;state:PA;county:42003,42002"):
-                self.assertEqual(parse_geo_arg(), [GeoPair('nation', True), GeoPair('state', ['PA']), GeoPair('county', ['42003', '42002'])])
+                self.assertEqual(
+                    parse_geo_arg(),
+                    [
+                        GeoPair("nation", True),
+                        GeoPair("state", ["PA"]),
+                        GeoPair("county", ["42003", "42002"]),
+                    ],
+                )
 
         with self.subTest("wrong"):
             with app.test_request_context("/?geo=abc"):
@@ -72,25 +93,60 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(parse_source_signal_arg(), [])
         with self.subTest("single"):
             with app.test_request_context("/?signal=src1:*"):
-                self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', True)])
+                self.assertEqual(
+                    parse_source_signal_arg(), [SourceSignalPair("src1", True)]
+                )
             with app.test_request_context("/?signal=src1:sig1"):
-                self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', ['sig1'])])
+                self.assertEqual(
+                    parse_source_signal_arg(), [SourceSignalPair("src1", ["sig1"])]
+                )
         with self.subTest("single list"):
             with app.test_request_context("/?signal=src1:sig1,sig2"):
-                self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', ['sig1', 'sig2'])])
+                self.assertEqual(
+                    parse_source_signal_arg(),
+                    [SourceSignalPair("src1", ["sig1", "sig2"])],
+                )
         with self.subTest("multi"):
             with app.test_request_context("/?signal=src1:*;src2:*"):
-                self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', True), SourceSignalPair('src2', True)])
+                self.assertEqual(
+                    parse_source_signal_arg(),
+                    [SourceSignalPair("src1", True), SourceSignalPair("src2", True)],
+                )
             with app.test_request_context("/?signal=src1:sig1;src2:sig3"):
-                self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', ['sig1']), SourceSignalPair('src2', ['sig3'])])
+                self.assertEqual(
+                    parse_source_signal_arg(),
+                    [
+                        SourceSignalPair("src1", ["sig1"]),
+                        SourceSignalPair("src2", ["sig3"]),
+                    ],
+                )
             with app.test_request_context("/?signal=src1:sig1;src1:sig4"):
-                self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', ['sig1']), SourceSignalPair('src1', ['sig4'])])
+                self.assertEqual(
+                    parse_source_signal_arg(),
+                    [
+                        SourceSignalPair("src1", ["sig1"]),
+                        SourceSignalPair("src1", ["sig4"]),
+                    ],
+                )
         with self.subTest("multi list"):
             with app.test_request_context("/?signal=src1:sig1,sig2;county:sig5,sig6"):
-                self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src1', ['sig1', 'sig2']), SourceSignalPair('county', ['sig5', 'sig6'])])
+                self.assertEqual(
+                    parse_source_signal_arg(),
+                    [
+                        SourceSignalPair("src1", ["sig1", "sig2"]),
+                        SourceSignalPair("county", ["sig5", "sig6"]),
+                    ],
+                )
         with self.subTest("hybrid"):
             with app.test_request_context("/?signal=src2:*;src1:sig4;src3:sig5,sig6"):
-                self.assertEqual(parse_source_signal_arg(), [SourceSignalPair('src2', True), SourceSignalPair('src1', ['sig4']), SourceSignalPair('src3', ['sig5', 'sig6'])])
+                self.assertEqual(
+                    parse_source_signal_arg(),
+                    [
+                        SourceSignalPair("src2", True),
+                        SourceSignalPair("src1", ["sig4"]),
+                        SourceSignalPair("src3", ["sig5", "sig6"]),
+                    ],
+                )
 
         with self.subTest("wrong"):
             with app.test_request_context("/?signal=abc"):
@@ -101,35 +157,49 @@ class UnitTests(unittest.TestCase):
     def test_parse_day_value(self):
         with app.test_request_context(""):
             with self.subTest("delphi date"):
-                self.assertEqual(parse_day_value('20200101'), 20200101)
+                self.assertEqual(parse_day_value("20200101"), 20200101)
             with self.subTest("iso date"):
-                self.assertEqual(parse_day_value('2020-01-01'), 20200101)
+                self.assertEqual(parse_day_value("2020-01-01"), 20200101)
             with self.subTest("delphi date range"):
-                self.assertEqual(parse_day_value('20200101-20210404'), (20200101, 20210404))
+                self.assertEqual(
+                    parse_day_value("20200101-20210404"), (20200101, 20210404)
+                )
             with self.subTest("iso date range"):
-                self.assertEqual(parse_day_value('2020-01-01--2021-04-04'), (20200101, 20210404))
+                self.assertEqual(
+                    parse_day_value("2020-01-01--2021-04-04"), (20200101, 20210404)
+                )
 
             with self.subTest("wrong"):
-                self.assertRaises(ValidationFailedException, parse_day_value, '')
-                self.assertRaises(ValidationFailedException, parse_day_value, 'x')
-                self.assertRaises(ValidationFailedException, parse_day_value, '2020')
-                self.assertRaises(ValidationFailedException, parse_day_value, '202001')
-                self.assertRaises(ValidationFailedException, parse_day_value, '2020-03-111')
-                self.assertRaises(ValidationFailedException, parse_day_value, '2020-02-30---20200403')
+                self.assertRaises(ValidationFailedException, parse_day_value, "")
+                self.assertRaises(ValidationFailedException, parse_day_value, "x")
+                self.assertRaises(ValidationFailedException, parse_day_value, "2020")
+                self.assertRaises(ValidationFailedException, parse_day_value, "202001")
+                self.assertRaises(
+                    ValidationFailedException, parse_day_value, "2020-03-111"
+                )
+                self.assertRaises(
+                    ValidationFailedException, parse_day_value, "2020-02-30---20200403"
+                )
 
     def test_parse_week_value(self):
         with app.test_request_context(""):
             with self.subTest("delphi week"):
-                self.assertEqual(parse_week_value('202001'), 202001)
+                self.assertEqual(parse_week_value("202001"), 202001)
             with self.subTest("delphi week range"):
-                self.assertEqual(parse_week_value('202001-202104'), (202001, 202104))
+                self.assertEqual(parse_week_value("202001-202104"), (202001, 202104))
             with self.subTest("wrong"):
-                self.assertRaises(ValidationFailedException, parse_week_value, '')
-                self.assertRaises(ValidationFailedException, parse_week_value, 'x')
-                self.assertRaises(ValidationFailedException, parse_week_value, '2020')
-                self.assertRaises(ValidationFailedException, parse_week_value, '20200100')
-                self.assertRaises(ValidationFailedException, parse_week_value, '2020-03-11')
-                self.assertRaises(ValidationFailedException, parse_week_value, '2020-02-30---20200403')
+                self.assertRaises(ValidationFailedException, parse_week_value, "")
+                self.assertRaises(ValidationFailedException, parse_week_value, "x")
+                self.assertRaises(ValidationFailedException, parse_week_value, "2020")
+                self.assertRaises(
+                    ValidationFailedException, parse_week_value, "20200100"
+                )
+                self.assertRaises(
+                    ValidationFailedException, parse_week_value, "2020-03-11"
+                )
+                self.assertRaises(
+                    ValidationFailedException, parse_week_value, "2020-02-30---20200403"
+                )
 
     def test_parse_time_arg(self):
         with self.subTest("empty"):
@@ -137,23 +207,41 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(parse_time_arg(), [])
         with self.subTest("single"):
             with app.test_request_context("/?time=day:*"):
-                self.assertEqual(parse_time_arg(), [TimePair('day', True)])
+                self.assertEqual(parse_time_arg(), [TimePair("day", True)])
             with app.test_request_context("/?time=day:20201201"):
-                self.assertEqual(parse_time_arg(), [TimePair('day', [20201201])])
+                self.assertEqual(parse_time_arg(), [TimePair("day", [20201201])])
         with self.subTest("single list"):
             with app.test_request_context("/?time=day:20201201,20201202"):
-                self.assertEqual(parse_time_arg(), [TimePair('day', [20201201, 20201202])])
+                self.assertEqual(
+                    parse_time_arg(), [TimePair("day", [20201201, 20201202])]
+                )
         with self.subTest("single range"):
             with app.test_request_context("/?time=day:20201201-20201204"):
-                self.assertEqual(parse_time_arg(), [TimePair('day', [(20201201, 20201204)])])
+                self.assertEqual(
+                    parse_time_arg(), [TimePair("day", [(20201201, 20201204)])]
+                )
         with self.subTest("multi"):
             with app.test_request_context("/?time=day:*;week:*"):
-                self.assertEqual(parse_time_arg(), [TimePair('day', True), TimePair('week', True)])
+                self.assertEqual(
+                    parse_time_arg(), [TimePair("day", True), TimePair("week", True)]
+                )
             with app.test_request_context("/?time=day:20201201;week:202012"):
-                self.assertEqual(parse_time_arg(), [TimePair('day', [20201201]), TimePair('week', [202012])])
+                self.assertEqual(
+                    parse_time_arg(),
+                    [TimePair("day", [20201201]), TimePair("week", [202012])],
+                )
         with self.subTest("hybrid"):
-            with app.test_request_context("/?time=day:*;day:20202012;week:202101-202104"):
-                self.assertEqual(parse_time_arg(), [TimePair('day', True), TimePair('day', [20202012]), TimePair('week', [(202101, 202104)])])
+            with app.test_request_context(
+                "/?time=day:*;day:20202012;week:202101-202104"
+            ):
+                self.assertEqual(
+                    parse_time_arg(),
+                    [
+                        TimePair("day", True),
+                        TimePair("day", [20202012]),
+                        TimePair("week", [(202101, 202104)]),
+                    ],
+                )
 
         with self.subTest("wrong"):
             with app.test_request_context("/?time=abc"):

--- a/tests/server/test_params.py
+++ b/tests/server/test_params.py
@@ -1,4 +1,4 @@
-"""Unit tests for granular sensor authentication in api.php."""
+"""Unit tests for parameter parsing."""
 
 # standard library
 import unittest

--- a/tests/server/test_query.py
+++ b/tests/server/test_query.py
@@ -48,9 +48,7 @@ class UnitTests(unittest.TestCase):
         self.assertEqual(to_condition("a", 0, "a", params), "a = :a")
         self.assertEqual(params, {"a": 0})
         params = {}
-        self.assertEqual(
-            to_condition("a", (1, 4), "a", params), "a BETWEEN :a AND :a_2"
-        )
+        self.assertEqual(to_condition("a", (1, 4), "a", params), "a BETWEEN :a AND :a_2")
         self.assertEqual(params, {"a": 1, "a_2": 4})
 
     def test_filter_strings(self):
@@ -61,9 +59,7 @@ class UnitTests(unittest.TestCase):
         self.assertEqual(filter_strings("a", ["1"], "a", params), "(a = :a_0)")
         self.assertEqual(params, {"a_0": "1"})
         params = {}
-        self.assertEqual(
-            filter_strings("a", ["1", "2"], "a", params), "(a = :a_0 OR a = :a_1)"
-        )
+        self.assertEqual(filter_strings("a", ["1", "2"], "a", params), "(a = :a_0 OR a = :a_1)")
         self.assertEqual(params, {"a_0": "1", "a_1": "2"})
         params = {}
         self.assertEqual(
@@ -80,9 +76,7 @@ class UnitTests(unittest.TestCase):
         self.assertEqual(filter_integers("a", [1], "a", params), "(a = :a_0)")
         self.assertEqual(params, {"a_0": 1})
         params = {}
-        self.assertEqual(
-            filter_integers("a", [1, 2], "a", params), "(a = :a_0 OR a = :a_1)"
-        )
+        self.assertEqual(filter_integers("a", [1, 2], "a", params), "(a = :a_0 OR a = :a_1)")
         self.assertEqual(params, {"a_0": 1, "a_1": 2})
         params = {}
         self.assertEqual(
@@ -141,9 +135,7 @@ class UnitTests(unittest.TestCase):
         with self.subTest("multi"):
             params = {}
             self.assertEqual(
-                filter_geo_pairs(
-                    "t", "v", [GeoPair("state", ["KY", "AK"])], "p", params
-                ),
+                filter_geo_pairs("t", "v", [GeoPair("state", ["KY", "AK"])], "p", params),
                 "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
             )
             self.assertEqual(params, {"p_0t": "state", "p_0t_0": "KY", "p_0t_1": "AK"})
@@ -180,39 +172,29 @@ class UnitTests(unittest.TestCase):
     def test_filter_source_signal_pairs(self):
         with self.subTest("empty"):
             params = {}
-            self.assertEqual(
-                filter_source_signal_pairs("t", "v", [], "p", params), "FALSE"
-            )
+            self.assertEqual(filter_source_signal_pairs("t", "v", [], "p", params), "FALSE")
             self.assertEqual(params, {})
         with self.subTest("*"):
             params = {}
             self.assertEqual(
-                filter_source_signal_pairs(
-                    "t", "v", [SourceSignalPair("src1", True)], "p", params
-                ),
+                filter_source_signal_pairs("t", "v", [SourceSignalPair("src1", True)], "p", params),
                 "(t = :p_0t)",
             )
             self.assertEqual(params, {"p_0t": "src1"})
         with self.subTest("single"):
             params = {}
             self.assertEqual(
-                filter_source_signal_pairs(
-                    "t", "v", [SourceSignalPair("src1", ["sig1"])], "p", params
-                ),
+                filter_source_signal_pairs("t", "v", [SourceSignalPair("src1", ["sig1"])], "p", params),
                 "((t = :p_0t AND (v = :p_0t_0)))",
             )
             self.assertEqual(params, {"p_0t": "src1", "p_0t_0": "sig1"})
         with self.subTest("multi"):
             params = {}
             self.assertEqual(
-                filter_source_signal_pairs(
-                    "t", "v", [SourceSignalPair("src1", ["sig1", "sig2"])], "p", params
-                ),
+                filter_source_signal_pairs("t", "v", [SourceSignalPair("src1", ["sig1", "sig2"])], "p", params),
                 "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
             )
-            self.assertEqual(
-                params, {"p_0t": "src1", "p_0t_0": "sig1", "p_0t_1": "sig2"}
-            )
+            self.assertEqual(params, {"p_0t": "src1", "p_0t_0": "sig1", "p_0t_1": "sig2"})
         with self.subTest("multiple pairs"):
             params = {}
             self.assertEqual(
@@ -268,22 +250,14 @@ class UnitTests(unittest.TestCase):
         with self.subTest("multi"):
             params = {}
             self.assertEqual(
-                filter_time_pairs(
-                    "t", "v", [TimePair("day", [20201201, 20201203])], "p", params
-                ),
+                filter_time_pairs("t", "v", [TimePair("day", [20201201, 20201203])], "p", params),
                 "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
             )
-            self.assertEqual(
-                params, {"p_0t": "day", "p_0t_0": 20201201, "p_0t_1": 20201203}
-            )
+            self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20201201, "p_0t_1": 20201203})
         with self.subTest("range"):
             params = {}
             self.assertEqual(
-                filter_time_pairs(
-                    "t", "v", [TimePair("day", [(20201201, 20201203)])], "p", params
-                ),
+                filter_time_pairs("t", "v", [TimePair("day", [(20201201, 20201203)])], "p", params),
                 "((t = :p_0t AND (v BETWEEN :p_0t_0 AND :p_0t_0_2)))",
             )
-            self.assertEqual(
-                params, {"p_0t": "day", "p_0t_0": 20201201, "p_0t_0_2": 20201203}
-            )
+            self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20201201, "p_0t_0_2": 20201203})

--- a/tests/server/test_query.py
+++ b/tests/server/test_query.py
@@ -165,5 +165,5 @@ class UnitTests(unittest.TestCase):
             self.assertEqual(params, {'p_0t': 'day', 'p_0t_0': 20201201, 'p_0t_1': 20201203})
         with self.subTest('range'):
             params = {}
-            self.assertEqual(filter_time_pairs('t', 'v', [TimePair('day', [(20201201, 20201203)])], 'p', params), '((t = :p_0t AND (v = BETWEEN :p_0t_0 AND v = :p_0t_0_2)))')
+            self.assertEqual(filter_time_pairs('t', 'v', [TimePair('day', [(20201201, 20201203)])], 'p', params), '((t = :p_0t AND (v BETWEEN :p_0t_0 AND :p_0t_0_2)))')
             self.assertEqual(params, {'p_0t': 'day', 'p_0t_0': 20201201, 'p_0t_0_2': 20201203})

--- a/tests/server/test_query.py
+++ b/tests/server/test_query.py
@@ -41,129 +41,249 @@ class UnitTests(unittest.TestCase):
         app.config["DEBUG"] = False
 
     def test_date_string(self):
-        self.assertEqual(date_string(20200101), '2020-01-01')
+        self.assertEqual(date_string(20200101), "2020-01-01")
 
     def test_to_condition(self):
         params = {}
-        self.assertEqual(to_condition('a', 0, 'a', params), 'a = :a')
-        self.assertEqual(params, {'a': 0})
+        self.assertEqual(to_condition("a", 0, "a", params), "a = :a")
+        self.assertEqual(params, {"a": 0})
         params = {}
-        self.assertEqual(to_condition('a', (1, 4), 'a', params), 'a BETWEEN :a AND :a_2')
-        self.assertEqual(params, {'a': 1, 'a_2': 4})
+        self.assertEqual(
+            to_condition("a", (1, 4), "a", params), "a BETWEEN :a AND :a_2"
+        )
+        self.assertEqual(params, {"a": 1, "a_2": 4})
 
     def test_filter_strings(self):
         params = {}
-        self.assertEqual(filter_strings('a', None, 'a', params), 'FALSE')
+        self.assertEqual(filter_strings("a", None, "a", params), "FALSE")
         self.assertEqual(params, {})
         params = {}
-        self.assertEqual(filter_strings('a', ['1'], 'a', params), '(a = :a_0)')
-        self.assertEqual(params, {'a_0': '1'})
+        self.assertEqual(filter_strings("a", ["1"], "a", params), "(a = :a_0)")
+        self.assertEqual(params, {"a_0": "1"})
         params = {}
-        self.assertEqual(filter_strings('a', ['1', '2'], 'a', params), '(a = :a_0 OR a = :a_1)')
-        self.assertEqual(params, {'a_0': '1', 'a_1': '2'})
+        self.assertEqual(
+            filter_strings("a", ["1", "2"], "a", params), "(a = :a_0 OR a = :a_1)"
+        )
+        self.assertEqual(params, {"a_0": "1", "a_1": "2"})
         params = {}
-        self.assertEqual(filter_strings('a', ['1', '2', ('1','4')], 'a', params), '(a = :a_0 OR a = :a_1 OR a BETWEEN :a_2 AND :a_2_2)')
-        self.assertEqual(params, {'a_0': '1', 'a_1': '2', 'a_2': '1', 'a_2_2': '4'})
+        self.assertEqual(
+            filter_strings("a", ["1", "2", ("1", "4")], "a", params),
+            "(a = :a_0 OR a = :a_1 OR a BETWEEN :a_2 AND :a_2_2)",
+        )
+        self.assertEqual(params, {"a_0": "1", "a_1": "2", "a_2": "1", "a_2_2": "4"})
 
     def test_filter_integers(self):
         params = {}
-        self.assertEqual(filter_integers('a', None, 'a', params), 'FALSE')
+        self.assertEqual(filter_integers("a", None, "a", params), "FALSE")
         self.assertEqual(params, {})
         params = {}
-        self.assertEqual(filter_integers('a', [1], 'a', params), '(a = :a_0)')
-        self.assertEqual(params, {'a_0': 1})
+        self.assertEqual(filter_integers("a", [1], "a", params), "(a = :a_0)")
+        self.assertEqual(params, {"a_0": 1})
         params = {}
-        self.assertEqual(filter_integers('a', [1, 2], 'a', params), '(a = :a_0 OR a = :a_1)')
-        self.assertEqual(params, {'a_0': 1, 'a_1': 2})
+        self.assertEqual(
+            filter_integers("a", [1, 2], "a", params), "(a = :a_0 OR a = :a_1)"
+        )
+        self.assertEqual(params, {"a_0": 1, "a_1": 2})
         params = {}
-        self.assertEqual(filter_integers('a', [1, 2, (1,4)], 'a', params), '(a = :a_0 OR a = :a_1 OR a BETWEEN :a_2 AND :a_2_2)')
-        self.assertEqual(params, {'a_0': 1, 'a_1': 2, 'a_2': 1, 'a_2_2': 4})
+        self.assertEqual(
+            filter_integers("a", [1, 2, (1, 4)], "a", params),
+            "(a = :a_0 OR a = :a_1 OR a BETWEEN :a_2 AND :a_2_2)",
+        )
+        self.assertEqual(params, {"a_0": 1, "a_1": 2, "a_2": 1, "a_2_2": 4})
 
     def test_filter_dates(self):
         params = {}
-        self.assertEqual(filter_dates('a', None, 'a', params), 'FALSE')
+        self.assertEqual(filter_dates("a", None, "a", params), "FALSE")
         self.assertEqual(params, {})
         params = {}
-        self.assertEqual(filter_dates('a', [20200101], 'a', params), '(a = :a_0)')
-        self.assertEqual(params, {'a_0': '2020-01-01'})
+        self.assertEqual(filter_dates("a", [20200101], "a", params), "(a = :a_0)")
+        self.assertEqual(params, {"a_0": "2020-01-01"})
         params = {}
-        self.assertEqual(filter_dates('a', [20200101, 20200102], 'a', params), '(a = :a_0 OR a = :a_1)')
-        self.assertEqual(params, {'a_0': '2020-01-01', 'a_1': '2020-01-02'})
+        self.assertEqual(
+            filter_dates("a", [20200101, 20200102], "a", params),
+            "(a = :a_0 OR a = :a_1)",
+        )
+        self.assertEqual(params, {"a_0": "2020-01-01", "a_1": "2020-01-02"})
         params = {}
-        self.assertEqual(filter_dates('a', [20200101, 20200102, (20200101,20200104)], 'a', params), '(a = :a_0 OR a = :a_1 OR a BETWEEN :a_2 AND :a_2_2)')
-        self.assertEqual(params, {'a_0': '2020-01-01', 'a_1': '2020-01-02', 'a_2': '2020-01-01', 'a_2_2': '2020-01-04'})
-
+        self.assertEqual(
+            filter_dates("a", [20200101, 20200102, (20200101, 20200104)], "a", params),
+            "(a = :a_0 OR a = :a_1 OR a BETWEEN :a_2 AND :a_2_2)",
+        )
+        self.assertEqual(
+            params,
+            {
+                "a_0": "2020-01-01",
+                "a_1": "2020-01-02",
+                "a_2": "2020-01-01",
+                "a_2_2": "2020-01-04",
+            },
+        )
 
     def test_filter_geo_pairs(self):
-        with self.subTest('empty'):
+        with self.subTest("empty"):
             params = {}
-            self.assertEqual(filter_geo_pairs('t', 'v', [], 'p', params), 'FALSE')
+            self.assertEqual(filter_geo_pairs("t", "v", [], "p", params), "FALSE")
             self.assertEqual(params, {})
-        with self.subTest('*'):
+        with self.subTest("*"):
             params = {}
-            self.assertEqual(filter_geo_pairs('t', 'v', [GeoPair('state', True)], 'p', params), '(t = :p_0t)')
-            self.assertEqual(params, {'p_0t': 'state'})
-        with self.subTest('single'):
+            self.assertEqual(
+                filter_geo_pairs("t", "v", [GeoPair("state", True)], "p", params),
+                "(t = :p_0t)",
+            )
+            self.assertEqual(params, {"p_0t": "state"})
+        with self.subTest("single"):
             params = {}
-            self.assertEqual(filter_geo_pairs('t', 'v', [GeoPair('state', ['KY'])], 'p', params), '((t = :p_0t AND (v = :p_0t_0)))')
-            self.assertEqual(params, {'p_0t': 'state', 'p_0t_0': 'KY'})
-        with self.subTest('multi'):
+            self.assertEqual(
+                filter_geo_pairs("t", "v", [GeoPair("state", ["KY"])], "p", params),
+                "((t = :p_0t AND (v = :p_0t_0)))",
+            )
+            self.assertEqual(params, {"p_0t": "state", "p_0t_0": "KY"})
+        with self.subTest("multi"):
             params = {}
-            self.assertEqual(filter_geo_pairs('t', 'v', [GeoPair('state', ['KY', 'AK'])], 'p', params), '((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))')
-            self.assertEqual(params, {'p_0t': 'state', 'p_0t_0': 'KY', 'p_0t_1': 'AK'})
-        with self.subTest('multiple pairs'):
+            self.assertEqual(
+                filter_geo_pairs(
+                    "t", "v", [GeoPair("state", ["KY", "AK"])], "p", params
+                ),
+                "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
+            )
+            self.assertEqual(params, {"p_0t": "state", "p_0t_0": "KY", "p_0t_1": "AK"})
+        with self.subTest("multiple pairs"):
             params = {}
-            self.assertEqual(filter_geo_pairs('t', 'v', [GeoPair('state', True), GeoPair('nation', True)], 'p', params), '(t = :p_0t OR t = :p_1t)')
-            self.assertEqual(params, {'p_0t': 'state', 'p_1t': 'nation'})
-        with self.subTest('multiple pairs with value'):
+            self.assertEqual(
+                filter_geo_pairs(
+                    "t",
+                    "v",
+                    [GeoPair("state", True), GeoPair("nation", True)],
+                    "p",
+                    params,
+                ),
+                "(t = :p_0t OR t = :p_1t)",
+            )
+            self.assertEqual(params, {"p_0t": "state", "p_1t": "nation"})
+        with self.subTest("multiple pairs with value"):
             params = {}
-            self.assertEqual(filter_geo_pairs('t', 'v', [GeoPair('state', ['AK']), GeoPair('nation', ['US'])], 'p', params), '((t = :p_0t AND (v = :p_0t_0)) OR (t = :p_1t AND (v = :p_1t_0)))')
-            self.assertEqual(params, {'p_0t': 'state', 'p_0t_0': 'AK', 'p_1t': 'nation', 'p_1t_0': 'US'})
+            self.assertEqual(
+                filter_geo_pairs(
+                    "t",
+                    "v",
+                    [GeoPair("state", ["AK"]), GeoPair("nation", ["US"])],
+                    "p",
+                    params,
+                ),
+                "((t = :p_0t AND (v = :p_0t_0)) OR (t = :p_1t AND (v = :p_1t_0)))",
+            )
+            self.assertEqual(
+                params,
+                {"p_0t": "state", "p_0t_0": "AK", "p_1t": "nation", "p_1t_0": "US"},
+            )
 
     def test_filter_source_signal_pairs(self):
-        with self.subTest('empty'):
+        with self.subTest("empty"):
             params = {}
-            self.assertEqual(filter_source_signal_pairs('t', 'v', [], 'p', params), 'FALSE')
+            self.assertEqual(
+                filter_source_signal_pairs("t", "v", [], "p", params), "FALSE"
+            )
             self.assertEqual(params, {})
-        with self.subTest('*'):
+        with self.subTest("*"):
             params = {}
-            self.assertEqual(filter_source_signal_pairs('t', 'v', [SourceSignalPair('src1', True)], 'p', params), '(t = :p_0t)')
-            self.assertEqual(params, {'p_0t': 'src1'})
-        with self.subTest('single'):
+            self.assertEqual(
+                filter_source_signal_pairs(
+                    "t", "v", [SourceSignalPair("src1", True)], "p", params
+                ),
+                "(t = :p_0t)",
+            )
+            self.assertEqual(params, {"p_0t": "src1"})
+        with self.subTest("single"):
             params = {}
-            self.assertEqual(filter_source_signal_pairs('t', 'v', [SourceSignalPair('src1', ['sig1'])], 'p', params), '((t = :p_0t AND (v = :p_0t_0)))')
-            self.assertEqual(params, {'p_0t': 'src1', 'p_0t_0': 'sig1'})
-        with self.subTest('multi'):
+            self.assertEqual(
+                filter_source_signal_pairs(
+                    "t", "v", [SourceSignalPair("src1", ["sig1"])], "p", params
+                ),
+                "((t = :p_0t AND (v = :p_0t_0)))",
+            )
+            self.assertEqual(params, {"p_0t": "src1", "p_0t_0": "sig1"})
+        with self.subTest("multi"):
             params = {}
-            self.assertEqual(filter_source_signal_pairs('t', 'v', [SourceSignalPair('src1', ['sig1', 'sig2'])], 'p', params), '((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))')
-            self.assertEqual(params, {'p_0t': 'src1', 'p_0t_0': 'sig1', 'p_0t_1': 'sig2'})
-        with self.subTest('multiple pairs'):
+            self.assertEqual(
+                filter_source_signal_pairs(
+                    "t", "v", [SourceSignalPair("src1", ["sig1", "sig2"])], "p", params
+                ),
+                "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
+            )
+            self.assertEqual(
+                params, {"p_0t": "src1", "p_0t_0": "sig1", "p_0t_1": "sig2"}
+            )
+        with self.subTest("multiple pairs"):
             params = {}
-            self.assertEqual(filter_source_signal_pairs('t', 'v', [SourceSignalPair('src1', True), SourceSignalPair('src2', True)], 'p', params), '(t = :p_0t OR t = :p_1t)')
-            self.assertEqual(params, {'p_0t': 'src1', 'p_1t': 'src2'})
-        with self.subTest('multiple pairs with value'):
+            self.assertEqual(
+                filter_source_signal_pairs(
+                    "t",
+                    "v",
+                    [SourceSignalPair("src1", True), SourceSignalPair("src2", True)],
+                    "p",
+                    params,
+                ),
+                "(t = :p_0t OR t = :p_1t)",
+            )
+            self.assertEqual(params, {"p_0t": "src1", "p_1t": "src2"})
+        with self.subTest("multiple pairs with value"):
             params = {}
-            self.assertEqual(filter_source_signal_pairs('t', 'v', [SourceSignalPair('src1', ['sig2']), SourceSignalPair('src2', ['srcx'])], 'p', params), '((t = :p_0t AND (v = :p_0t_0)) OR (t = :p_1t AND (v = :p_1t_0)))')
-            self.assertEqual(params, {'p_0t': 'src1', 'p_0t_0': 'sig2', 'p_1t': 'src2', 'p_1t_0': 'srcx'})
+            self.assertEqual(
+                filter_source_signal_pairs(
+                    "t",
+                    "v",
+                    [
+                        SourceSignalPair("src1", ["sig2"]),
+                        SourceSignalPair("src2", ["srcx"]),
+                    ],
+                    "p",
+                    params,
+                ),
+                "((t = :p_0t AND (v = :p_0t_0)) OR (t = :p_1t AND (v = :p_1t_0)))",
+            )
+            self.assertEqual(
+                params,
+                {"p_0t": "src1", "p_0t_0": "sig2", "p_1t": "src2", "p_1t_0": "srcx"},
+            )
 
     def test_filter_time_pairs(self):
-        with self.subTest('empty'):
+        with self.subTest("empty"):
             params = {}
-            self.assertEqual(filter_time_pairs('t', 'v', [], 'p', params), 'FALSE')
+            self.assertEqual(filter_time_pairs("t", "v", [], "p", params), "FALSE")
             self.assertEqual(params, {})
-        with self.subTest('*'):
+        with self.subTest("*"):
             params = {}
-            self.assertEqual(filter_time_pairs('t', 'v', [TimePair('day', True)], 'p', params), '(t = :p_0t)')
-            self.assertEqual(params, {'p_0t': 'day'})
-        with self.subTest('single'):
+            self.assertEqual(
+                filter_time_pairs("t", "v", [TimePair("day", True)], "p", params),
+                "(t = :p_0t)",
+            )
+            self.assertEqual(params, {"p_0t": "day"})
+        with self.subTest("single"):
             params = {}
-            self.assertEqual(filter_time_pairs('t', 'v', [TimePair('day', [20201201])], 'p', params), '((t = :p_0t AND (v = :p_0t_0)))')
-            self.assertEqual(params, {'p_0t': 'day', 'p_0t_0': 20201201})
-        with self.subTest('multi'):
+            self.assertEqual(
+                filter_time_pairs("t", "v", [TimePair("day", [20201201])], "p", params),
+                "((t = :p_0t AND (v = :p_0t_0)))",
+            )
+            self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20201201})
+        with self.subTest("multi"):
             params = {}
-            self.assertEqual(filter_time_pairs('t', 'v', [TimePair('day', [20201201, 20201203])], 'p', params), '((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))')
-            self.assertEqual(params, {'p_0t': 'day', 'p_0t_0': 20201201, 'p_0t_1': 20201203})
-        with self.subTest('range'):
+            self.assertEqual(
+                filter_time_pairs(
+                    "t", "v", [TimePair("day", [20201201, 20201203])], "p", params
+                ),
+                "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
+            )
+            self.assertEqual(
+                params, {"p_0t": "day", "p_0t_0": 20201201, "p_0t_1": 20201203}
+            )
+        with self.subTest("range"):
             params = {}
-            self.assertEqual(filter_time_pairs('t', 'v', [TimePair('day', [(20201201, 20201203)])], 'p', params), '((t = :p_0t AND (v BETWEEN :p_0t_0 AND :p_0t_0_2)))')
-            self.assertEqual(params, {'p_0t': 'day', 'p_0t_0': 20201201, 'p_0t_0_2': 20201203})
+            self.assertEqual(
+                filter_time_pairs(
+                    "t", "v", [TimePair("day", [(20201201, 20201203)])], "p", params
+                ),
+                "((t = :p_0t AND (v BETWEEN :p_0t_0 AND :p_0t_0_2)))",
+            )
+            self.assertEqual(
+                params, {"p_0t": "day", "p_0t_0": 20201201, "p_0t_0_2": 20201203}
+            )

--- a/tests/server/test_query.py
+++ b/tests/server/test_query.py
@@ -11,7 +11,15 @@ from delphi.epidata.server._query import (
     to_condition,
     filter_strings,
     filter_integers,
-    filter_dates
+    filter_dates,
+    filter_geo_pairs,
+    filter_source_signal_pairs,
+    filter_time_pairs,
+)
+from delphi.epidata.server._params import (
+    GeoPair,
+    TimePair,
+    SourceSignalPair,
 )
 from delphi.epidata.server._exceptions import (
     ValidationFailedException,
@@ -42,7 +50,7 @@ class UnitTests(unittest.TestCase):
         params = {}
         self.assertEqual(to_condition('a', (1, 4), 'a', params), 'a BETWEEN :a AND :a_2')
         self.assertEqual(params, {'a': 1, 'a_2': 4})
-    
+
     def test_filter_strings(self):
         params = {}
         self.assertEqual(filter_strings('a', None, 'a', params), 'FALSE')
@@ -84,3 +92,78 @@ class UnitTests(unittest.TestCase):
         params = {}
         self.assertEqual(filter_dates('a', [20200101, 20200102, (20200101,20200104)], 'a', params), '(a = :a_0 OR a = :a_1 OR a BETWEEN :a_2 AND :a_2_2)')
         self.assertEqual(params, {'a_0': '2020-01-01', 'a_1': '2020-01-02', 'a_2': '2020-01-01', 'a_2_2': '2020-01-04'})
+
+
+    def test_filter_geo_pairs(self):
+        with self.subTest('empty'):
+            params = {}
+            self.assertEqual(filter_geo_pairs('t', 'v', [], 'p', params), 'FALSE')
+            self.assertEqual(params, {})
+        with self.subTest('*'):
+            params = {}
+            self.assertEqual(filter_geo_pairs('t', 'v', [GeoPair('state', True)], 'p', params), '(t = :p_0t)')
+            self.assertEqual(params, {'p_0t': 'state'})
+        with self.subTest('single'):
+            params = {}
+            self.assertEqual(filter_geo_pairs('t', 'v', [GeoPair('state', ['KY'])], 'p', params), '((t = :p_0t AND (v = :p_0t_0)))')
+            self.assertEqual(params, {'p_0t': 'state', 'p_0t_0': 'KY'})
+        with self.subTest('multi'):
+            params = {}
+            self.assertEqual(filter_geo_pairs('t', 'v', [GeoPair('state', ['KY', 'AK'])], 'p', params), '((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))')
+            self.assertEqual(params, {'p_0t': 'state', 'p_0t_0': 'KY', 'p_0t_1': 'AK'})
+        with self.subTest('multiple pairs'):
+            params = {}
+            self.assertEqual(filter_geo_pairs('t', 'v', [GeoPair('state', True), GeoPair('nation', True)], 'p', params), '(t = :p_0t OR t = :p_1t)')
+            self.assertEqual(params, {'p_0t': 'state', 'p_1t': 'nation'})
+        with self.subTest('multiple pairs with value'):
+            params = {}
+            self.assertEqual(filter_geo_pairs('t', 'v', [GeoPair('state', ['AK']), GeoPair('nation', ['US'])], 'p', params), '((t = :p_0t AND (v = :p_0t_0)) OR (t = :p_1t AND (v = :p_1t_0)))')
+            self.assertEqual(params, {'p_0t': 'state', 'p_0t_0': 'AK', 'p_1t': 'nation', 'p_1t_0': 'US'})
+
+    def test_filter_source_signal_pairs(self):
+        with self.subTest('empty'):
+            params = {}
+            self.assertEqual(filter_source_signal_pairs('t', 'v', [], 'p', params), 'FALSE')
+            self.assertEqual(params, {})
+        with self.subTest('*'):
+            params = {}
+            self.assertEqual(filter_source_signal_pairs('t', 'v', [SourceSignalPair('src1', True)], 'p', params), '(t = :p_0t)')
+            self.assertEqual(params, {'p_0t': 'src1'})
+        with self.subTest('single'):
+            params = {}
+            self.assertEqual(filter_source_signal_pairs('t', 'v', [SourceSignalPair('src1', ['sig1'])], 'p', params), '((t = :p_0t AND (v = :p_0t_0)))')
+            self.assertEqual(params, {'p_0t': 'src1', 'p_0t_0': 'sig1'})
+        with self.subTest('multi'):
+            params = {}
+            self.assertEqual(filter_source_signal_pairs('t', 'v', [SourceSignalPair('src1', ['sig1', 'sig2'])], 'p', params), '((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))')
+            self.assertEqual(params, {'p_0t': 'src1', 'p_0t_0': 'sig1', 'p_0t_1': 'sig2'})
+        with self.subTest('multiple pairs'):
+            params = {}
+            self.assertEqual(filter_source_signal_pairs('t', 'v', [SourceSignalPair('src1', True), SourceSignalPair('src2', True)], 'p', params), '(t = :p_0t OR t = :p_1t)')
+            self.assertEqual(params, {'p_0t': 'src1', 'p_1t': 'src2'})
+        with self.subTest('multiple pairs with value'):
+            params = {}
+            self.assertEqual(filter_source_signal_pairs('t', 'v', [SourceSignalPair('src1', ['sig2']), SourceSignalPair('src2', ['srcx'])], 'p', params), '((t = :p_0t AND (v = :p_0t_0)) OR (t = :p_1t AND (v = :p_1t_0)))')
+            self.assertEqual(params, {'p_0t': 'src1', 'p_0t_0': 'sig2', 'p_1t': 'src2', 'p_1t_0': 'srcx'})
+
+    def test_filter_time_pairs(self):
+        with self.subTest('empty'):
+            params = {}
+            self.assertEqual(filter_time_pairs('t', 'v', [], 'p', params), 'FALSE')
+            self.assertEqual(params, {})
+        with self.subTest('*'):
+            params = {}
+            self.assertEqual(filter_time_pairs('t', 'v', [TimePair('day', True)], 'p', params), '(t = :p_0t)')
+            self.assertEqual(params, {'p_0t': 'day'})
+        with self.subTest('single'):
+            params = {}
+            self.assertEqual(filter_time_pairs('t', 'v', [TimePair('day', [20201201])], 'p', params), '((t = :p_0t AND (v = :p_0t_0)))')
+            self.assertEqual(params, {'p_0t': 'day', 'p_0t_0': 20201201})
+        with self.subTest('multi'):
+            params = {}
+            self.assertEqual(filter_time_pairs('t', 'v', [TimePair('day', [20201201, 20201203])], 'p', params), '((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))')
+            self.assertEqual(params, {'p_0t': 'day', 'p_0t_0': 20201201, 'p_0t_1': 20201203})
+        with self.subTest('range'):
+            params = {}
+            self.assertEqual(filter_time_pairs('t', 'v', [TimePair('day', [(20201201, 20201203)])], 'p', params), '((t = :p_0t AND (v = BETWEEN :p_0t_0 AND v = :p_0t_0_2)))')
+            self.assertEqual(params, {'p_0t': 'day', 'p_0t_0': 20201201, 'p_0t_0_2': 20201203})


### PR DESCRIPTION
closes #389

in a backward compatibility way

supports alternative way to specify the three dimensions, see google doc

e.g., `/covidcast/?signal=src1:sig1&time=day:20201202&geo=state:*`