### PR TITLE
[flask]: /covidcast/trend endpoint

### DIFF
--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -131,3 +131,23 @@ def parse_time_arg() -> List[TimePair]:
         raise ValidationFailedException(f'time param: {time_type} is not one of "day" or "week"')
 
     return [parse(time_type, time_values) for [time_type, time_values] in _parse_common_multi_arg("time")]
+
+
+def parse_day_range_arg(key: str) -> Optional[Tuple[int, int]]:
+    v = request.values.get(key)
+    if not v:
+        return None
+    r = parse_day_value(v)
+    if not isinstance(r, tuple):
+        raise ValidationFailedException(f"{key} must match YYYYMMDD-YYYYMMDD or YYYY-MM-DD--YYYY-MM-DD")
+    return r
+
+
+def parse_day_arg(key: str) -> Optional[int]:
+    v = request.values.get(key)
+    if not v:
+        return None
+    r = parse_day_value(v)
+    if not isinstance(r, int):
+        raise ValidationFailedException(f"{key} must match YYYYMMDD or YYYY-MM-DD")
+    return r

--- a/src/server/_validate.py
+++ b/src/server/_validate.py
@@ -41,9 +41,7 @@ def require_all(*values: str) -> bool:
     """
     for value in values:
         if not request.values.get(value):
-            raise ValidationFailedException(
-                f"missing parameter: need [{', '.join(values)}]"
-            )
+            raise ValidationFailedException(f"missing parameter: need [{', '.join(values)}]")
     return True
 
 
@@ -55,9 +53,7 @@ def require_any(*values: str, empty=False) -> bool:
     for value in values:
         if request.values.get(value) or (empty and value in request.values):
             return True
-    raise ValidationFailedException(
-        f"missing parameter: need one of [{', '.join(values)}]"
-    )
+    raise ValidationFailedException(f"missing parameter: need one of [{', '.join(values)}]")
 
 
 def _extract_value(key: Union[str, Sequence[str]]) -> Optional[str]:
@@ -99,7 +95,6 @@ def extract_integer(key: Union[str, Sequence[str]]) -> Optional[int]:
         return int(s)
     except ValueError as e:
         raise ValidationFailedException(f"{key}: not a number: {s}")
-
 
 
 def extract_integers(key: Union[str, Sequence[str]]) -> Optional[List[IntRange]]:

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -117,3 +117,30 @@ def handle():
 
     # send query
     return execute_query(str(q), q.params, fields_string, fields_int, fields_float)
+
+
+@bp.route("/trend", methods=("GET", "POST"))
+def handle_trend():
+    source_signal_pairs = parse_source_signal_pairs()
+    geo_pairs = parse_geo_pairs()
+
+    # TODO date
+
+    # build query
+    q = QueryBuilder("covidcast", "t")
+
+    fields_string = ["geo_value", "signal"]
+    fields_int = ["time_value"]
+    fields_float = ["value"]
+    q.set_fields(fields_string, fields_int, fields_float)
+    q.set_order('signal', 'time_value', 'geo_value')
+
+    q.where_source_signal_pairs('source','signal',source_signal_pairs)
+    q.where_geo_pairs('geo_type','geo_value',geo_pairs)
+    # q.where_time_pairs('time_type','time_value',time_pairs)
+
+    # fetch most recent issue fast
+    q.conditions.append(f"({q.alias}.is_latest_issue IS TRUE)")
+
+    # send query
+    return execute_query(str(q), q.params, fields_string, fields_int, fields_float)

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -140,7 +140,7 @@ def handle_trend():
     fields_int = ["time_value"]
     fields_float = ["value"]
     q.set_fields(fields_string, fields_int, fields_float)
-    q.set_order("source", "signal", "geo_value", "time_value")
+    q.set_order("geo_type", "geo_value", "source", "signal", "time_value")
 
     q.where_source_signal_pairs("source", "signal", source_signal_pairs)
     q.where_geo_pairs("geo_type", "geo_value", geo_pairs)

--- a/src/server/endpoints/covidcast_utils/__init__.py
+++ b/src/server/endpoints/covidcast_utils/__init__.py
@@ -1,1 +1,2 @@
 from .trend import compute_trend
+from .dates import shift_time_value

--- a/src/server/endpoints/covidcast_utils/__init__.py
+++ b/src/server/endpoints/covidcast_utils/__init__.py
@@ -1,0 +1,1 @@
+from .trend import compute_trend

--- a/src/server/endpoints/covidcast_utils/dates.py
+++ b/src/server/endpoints/covidcast_utils/dates.py
@@ -1,0 +1,18 @@
+from datetime import date, timedelta
+
+
+def time_value_to_date(value: int) -> date:
+    year, month, day = value // 10000, (value % 10000) // 100, value % 100
+    return date(year=year, month=month, day=day)
+
+
+def date_to_time_value(d: date) -> int:
+    return int(d.strftime("%Y%m%d"))
+
+
+def shift_time_value(time_value: int, days: int) -> int:
+    if days == 0:
+        return time_value
+    d = time_value_to_date(time_value)
+    shifted = d + timedelta(days=days)
+    return date_to_time_value(shifted)

--- a/src/server/endpoints/covidcast_utils/trend.py
+++ b/src/server/endpoints/covidcast_utils/trend.py
@@ -20,15 +20,15 @@ class Trend:
 
     value: Optional[float] = None
 
-    basis_date: Optional[date] = None
+    basis_date: Optional[int] = None
     basis_value: Optional[float] = None
     basis_trend: TrendEnum = TrendEnum.unknown
 
-    min_date: Optional[date] = None
+    min_date: Optional[int] = None
     min_value: Optional[float] = None
     min_trend: TrendEnum = TrendEnum.unknown
 
-    max_date: Optional[date] = None
+    max_date: Optional[int] = None
     max_value: Optional[float] = None
     max_trend: TrendEnum = TrendEnum.unknown
 
@@ -36,7 +36,48 @@ class Trend:
         return asdict(self)
 
 
-def compute_trend(geo_type: str, geo_value: str, signal_source: str, signal_signal: str, time_value: int, rows: Iterable[Tuple[int, float]]) -> Trend:
-    t = Trend(geo_type, geo_value, signal_source, signal_signal)
-    # TODO
+def compute_trend(geo_type: str, geo_value: str, signal_source: str, signal_signal: str, current_time: int, basis_time: int, rows: Iterable[Tuple[int, float]]) -> Trend:
+    t = Trend(geo_type, geo_value, signal_source, signal_signal, basis_date=basis_time)
+
+    min_row: Optional[Tuple[int, float]] = None
+    max_row: Optional[Tuple[int, float]] = None
+    basis_row: Optional[Tuple[int, float]] = None
+
+    # find all needed rows
+    for time, value in rows:
+        if time == current_time:
+            t.value = value
+        if time == basis_time:
+            t.basis_value = value
+        if t.min_value is None or t.min_value > value:
+            t.min_date = time
+            t.min_value = value
+        if t.max_value is None or t.max_value < value:
+            t.max_date = time
+            t.max_value = value
+
+    if t.value is None or t.min_value is None:
+        # cannot compute trend if current time is not found
+        return t
+
+    t.basis_trend = compute_trend_value(t.value, t.basis_value, t.min_value) if t.basis_value else TrendEnum.unknown
+    t.min_trend = compute_trend_value(t.value, t.min_value, t.min_value)
+    t.max_trend = compute_trend_value(t.value, t.max_value, t.min_value) if t.max_value else TrendEnum.unknown
+
     return t
+
+
+def compute_trend_value(current: float, basis: float, min_value: float) -> TrendEnum:
+    # based on www-covidcast
+    normalized_basis = basis - min_value
+    normalized_current = current - min_value
+    if normalized_basis == normalized_current:
+        return TrendEnum.steady
+    if normalized_basis == 0:
+        return TrendEnum.increasing
+    normalized_change = normalized_current / normalized_basis - 1
+    if normalized_change >= 0.1:
+        return TrendEnum.increasing
+    if normalized_change <= -0.1:
+        return TrendEnum.decreasing
+    return TrendEnum.steady

--- a/src/server/endpoints/covidcast_utils/trend.py
+++ b/src/server/endpoints/covidcast_utils/trend.py
@@ -60,24 +60,27 @@ def compute_trend(geo_type: str, geo_value: str, signal_source: str, signal_sign
         # cannot compute trend if current time is not found
         return t
 
-    t.basis_trend = compute_trend_value(t.value, t.basis_value, t.min_value) if t.basis_value else TrendEnum.unknown
-    t.min_trend = compute_trend_value(t.value, t.min_value, t.min_value)
-    t.max_trend = compute_trend_value(t.value, t.max_value, t.min_value) if t.max_value else TrendEnum.unknown
+    t.basis_trend = compute_trend_class(compute_trend_value(t.value, t.basis_value, t.min_value)) if t.basis_value else TrendEnum.unknown
+    t.min_trend = compute_trend_class(compute_trend_value(t.value, t.min_value, t.min_value))
+    t.max_trend = compute_trend_class(compute_trend_value(t.value, t.max_value, t.min_value)) if t.max_value else TrendEnum.unknown
 
     return t
 
 
-def compute_trend_value(current: float, basis: float, min_value: float) -> TrendEnum:
+def compute_trend_value(current: float, basis: float, min_value: float) -> float:
     # based on www-covidcast
     normalized_basis = basis - min_value
     normalized_current = current - min_value
     if normalized_basis == normalized_current:
-        return TrendEnum.steady
+        return 0
     if normalized_basis == 0:
+        return 1
+    return normalized_current / normalized_basis - 1
+
+
+def compute_trend_class(trend_value: float) -> TrendEnum:
+    if trend_value >= 0.1:
         return TrendEnum.increasing
-    normalized_change = normalized_current / normalized_basis - 1
-    if normalized_change >= 0.1:
-        return TrendEnum.increasing
-    if normalized_change <= -0.1:
+    if trend_value <= -0.1:
         return TrendEnum.decreasing
     return TrendEnum.steady

--- a/src/server/endpoints/covidcast_utils/trend.py
+++ b/src/server/endpoints/covidcast_utils/trend.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, asdict
+from typing import Optional, Iterable, Tuple
+from datetime import date
+from enum import Enum
+
+
+class TrendEnum(str, Enum):
+    unknown = "unknown"
+    increasing = "increasing"
+    decreasing = "decreasing"
+    steady = "steady"
+
+
+@dataclass
+class Trend:
+    geo_type: str
+    geo_value: str
+    signal_source: str
+    signal_signal: str
+
+    value: Optional[float] = None
+
+    basis_date: Optional[date] = None
+    basis_value: Optional[float] = None
+    basis_trend: TrendEnum = TrendEnum.unknown
+
+    min_date: Optional[date] = None
+    min_value: Optional[float] = None
+    min_trend: TrendEnum = TrendEnum.unknown
+
+    max_date: Optional[date] = None
+    max_value: Optional[float] = None
+    max_trend: TrendEnum = TrendEnum.unknown
+
+    def asdict(self):
+        return asdict(self)
+
+
+def compute_trend(geo_type: str, geo_value: str, signal_source: str, signal_signal: str, time_value: int, rows: Iterable[Tuple[int, float]]) -> Trend:
+    t = Trend(geo_type, geo_value, signal_source, signal_signal)
+    # TODO
+    return t

--- a/tests/server/endpoints/covidcast_utils/test_dates.py
+++ b/tests/server/endpoints/covidcast_utils/test_dates.py
@@ -1,0 +1,18 @@
+import unittest
+from datetime import date
+
+from delphi.epidata.server.endpoints.covidcast_utils.dates import time_value_to_date, date_to_time_value, shift_time_value
+
+
+class UnitTests(unittest.TestCase):
+    def test_time_value_to_date(self):
+        self.assertEqual(time_value_to_date(20201010), date(2020, 10, 10))
+        self.assertEqual(time_value_to_date(20190201), date(2019, 2, 1))
+
+    def test_date_to_time_value(self):
+        self.assertEqual(date_to_time_value(date(2020, 10, 10)), 20201010)
+        self.assertEqual(date_to_time_value(date(2019, 2, 1)), 20190201)
+
+    def test_shift_time_value(self):
+        self.assertEqual(shift_time_value(20201010, -3), 20201007)
+        self.assertEqual(shift_time_value(20201010, -12), 20200928)

--- a/tests/server/endpoints/covidcast_utils/test_trend.py
+++ b/tests/server/endpoints/covidcast_utils/test_trend.py
@@ -27,6 +27,10 @@ class UnitTests(unittest.TestCase):
             self.assertAlmostEqual(compute_trend_value(9.5 + 5, 10 + 5, 5), -0.05)
             self.assertAlmostEqual(compute_trend_value(9 + 5, 10 + 5, 5), -0.1)
             self.assertAlmostEqual(compute_trend_value(8 + 5, 10 + 5, 5), -0.2)
+        with self.subTest("basis is min"):
+            self.assertAlmostEqual(compute_trend_value(11, 10, 10), 1)
+        with self.subTest("current is min"):
+            self.assertAlmostEqual(compute_trend_value(10, 15, 10), -1)
 
     def test_compute_trend_class(self):
         self.assertEqual(compute_trend_class(-0.3), TrendEnum.decreasing)

--- a/tests/server/endpoints/covidcast_utils/test_trend.py
+++ b/tests/server/endpoints/covidcast_utils/test_trend.py
@@ -1,10 +1,61 @@
 # standard library
 import unittest
 
-from delphi.epidata.server.endpoints.covidcast_utils import compute_trend
+from delphi.epidata.server.endpoints.covidcast_utils.trend import compute_trend_value, compute_trend_class, TrendEnum, compute_trend, Trend
 
 
 class UnitTests(unittest.TestCase):
+    def test_compute_trend_value(self):
+        with self.subTest("same"):
+            self.assertEqual(compute_trend_value(0, 0, 0), 0.0)
+            self.assertEqual(compute_trend_value(5, 5, 0), 0.0)
+            self.assertEqual(compute_trend_value(5, 5, 2), 0.0)
+
+        with self.subTest("with min 0"):
+            self.assertAlmostEqual(compute_trend_value(12, 10, 0), 0.2)
+            self.assertAlmostEqual(compute_trend_value(11, 10, 0), 0.1)
+            self.assertAlmostEqual(compute_trend_value(10.5, 10, 0), 0.05)
+            self.assertAlmostEqual(compute_trend_value(10, 10, 0), 0.0)
+            self.assertAlmostEqual(compute_trend_value(9.5, 10, 0), -0.05)
+            self.assertAlmostEqual(compute_trend_value(9, 10, 0), -0.1)
+            self.assertAlmostEqual(compute_trend_value(8, 10, 0), -0.2)
+        with self.subTest("with min 5"):
+            self.assertAlmostEqual(compute_trend_value(12 + 5, 10 + 5, 5), 0.2)
+            self.assertAlmostEqual(compute_trend_value(11 + 5, 10 + 5, 5), 0.1)
+            self.assertAlmostEqual(compute_trend_value(10.5 + 5, 10 + 5, 5), 0.05)
+            self.assertAlmostEqual(compute_trend_value(10 + 5, 10 + 5, 5), 0.0)
+            self.assertAlmostEqual(compute_trend_value(9.5 + 5, 10 + 5, 5), -0.05)
+            self.assertAlmostEqual(compute_trend_value(9 + 5, 10 + 5, 5), -0.1)
+            self.assertAlmostEqual(compute_trend_value(8 + 5, 10 + 5, 5), -0.2)
+
+    def test_compute_trend_class(self):
+        self.assertEqual(compute_trend_class(-0.3), TrendEnum.decreasing)
+        self.assertEqual(compute_trend_class(-0.2), TrendEnum.decreasing)
+        self.assertEqual(compute_trend_class(-0.1), TrendEnum.decreasing)
+        self.assertEqual(compute_trend_class(-0.05), TrendEnum.steady)
+        self.assertEqual(compute_trend_class(0), TrendEnum.steady)
+        self.assertEqual(compute_trend_class(0.05), TrendEnum.steady)
+        self.assertEqual(compute_trend_class(0.1), TrendEnum.increasing)
+        self.assertEqual(compute_trend_class(0.2), TrendEnum.increasing)
+        self.assertEqual(compute_trend_class(0.3), TrendEnum.increasing)
+
     def test_compute_trend(self):
-        # TODO
-        self.assertEqual(0, 0)
+        self.assertEqual(
+            compute_trend("gt", "gv", "so", "si", 10, 8, [(10, 12), (8, 10), (0, 0)]),
+            Trend(
+                "gt",
+                "gv",
+                "so",
+                "si",
+                value=12,
+                basis_date=8,
+                basis_value=10,
+                basis_trend=TrendEnum.increasing,
+                min_date=0,
+                min_value=0,
+                min_trend=TrendEnum.increasing,
+                max_date=10,
+                max_value=12,
+                max_trend=TrendEnum.steady,
+            ),
+        )

--- a/tests/server/endpoints/covidcast_utils/test_trend.py
+++ b/tests/server/endpoints/covidcast_utils/test_trend.py
@@ -1,0 +1,10 @@
+# standard library
+import unittest
+
+from delphi.epidata.server.endpoints.covidcast_utils import compute_trend
+
+
+class UnitTests(unittest.TestCase):
+    def test_compute_trend(self):
+        # TODO
+        self.assertEqual(0, 0)


### PR DESCRIPTION
based on #481 

adds a new custom endpoint `/covidcast/trend` which computes the trend for a given date and window.

e.g.

http://localhost:5000/covidcast/trend?signal=fb-survey:smoothed_cli&geo=state:ny&date=20210401&window=20200101-20210402

will result in: 
![image](https://user-images.githubusercontent.com/4129778/114038699-15792a80-9850-11eb-9274-6663188595cd.png)


note: I just have limited local test data, so results may vary in your system