### PR TITLE
[flask]: add /covidcast/backfill endpoint

### DIFF
--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -30,7 +30,7 @@ def _parse_common_multi_arg(key: str) -> List[Tuple[str, Union[bool, Sequence[st
     return parsed
 
 
-def _parse_single_arg(key: str) -> (str, str):
+def _parse_single_arg(key: str) -> Tuple[str, str]:
     """
     parses a single pair
     """
@@ -150,18 +150,27 @@ def parse_day_value(time_value: str) -> Union[int, Tuple[int, int]]:
     raise ValidationFailedException(msg)
 
 
+def _parse_time_pair(time_type: str, time_values: Union[bool, Sequence[str]]) -> TimePair:
+    if isinstance(time_values, bool):
+        return TimePair(time_type, time_values)
+
+    if time_type == "week":
+        return TimePair("week", [parse_week_value(t) for t in time_values])
+    elif time_type == "day":
+        return TimePair("day", [parse_day_value(t) for t in time_values])
+    raise ValidationFailedException(f'time param: {time_type} is not one of "day" or "week"')
+
+
 def parse_time_arg(key: str = "time") -> List[TimePair]:
-    def parse(time_type: str, time_values: Union[bool, Sequence[str]]) -> TimePair:
-        if isinstance(time_values, bool):
-            return TimePair(time_type, time_values)
+    return [_parse_time_pair(time_type, time_values) for [time_type, time_values] in _parse_common_multi_arg(key)]
 
-        if time_type == "week":
-            return TimePair("week", [parse_week_value(t) for t in time_values])
-        elif time_type == "day":
-            return TimePair("day", [parse_day_value(t) for t in time_values])
-        raise ValidationFailedException(f'time param: {time_type} is not one of "day" or "week"')
 
-    return [parse(time_type, time_values) for [time_type, time_values] in _parse_common_multi_arg(key)]
+def parse_single_time_arg(key: str) -> TimePair:
+    """
+    parses a single time pair with only one value
+    """
+    r = _parse_single_arg(key)
+    return _parse_time_pair(r[0], [r[1]])
 
 
 def parse_day_range_arg(key: str) -> Optional[Tuple[int, int]]:

--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -340,6 +340,7 @@ class QueryBuilder:
 
         return f"SELECT {self.fields_clause} FROM {self.table} {self.subquery} {where} {group_by} {order}"
 
+    @property
     def query(self) -> str:
         """
         returns the full query

--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime
 from typing import (
     Any,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -229,15 +230,24 @@ def run_query(p: APrinter, query_tuple: Tuple[str, Dict[str, Any]]):
     return db.execution_options(stream_results=True).execute(full_query, **params)
 
 
+def _identity_transform(row: Dict[str, Any], _: RowProxy) -> Dict[str, Any]:
+    """
+    identity transform
+    """
+    return row
+
+
 def execute_queries(
     queries: Sequence[Tuple[str, Dict[str, Any]]],
     fields_string: Sequence[str],
     fields_int: Sequence[str],
     fields_float: Sequence[str],
+    transform: Callable[[Dict[str, Any], RowProxy], Dict[str, Any]] = _identity_transform,
 ):
     """
     execute the given queries and return the response to send them
     """
+
     p = create_printer()
 
     fields_to_send = set(extract_strings("fields") or [])
@@ -258,7 +268,7 @@ def execute_queries(
 
     def gen(first_rows):
         for row in first_rows:
-            yield parse_row(row, fields_string, fields_int, fields_float)
+            yield transform(parse_row(row, fields_string, fields_int, fields_float), row)
 
         for query_params in query_list:
             if p.remaining_rows <= 0:
@@ -266,7 +276,7 @@ def execute_queries(
                 break
             r = run_query(p, query_params)
             for row in r:
-                yield parse_row(row, fields_string, fields_int, fields_float)
+                yield transform(parse_row(row, fields_string, fields_int, fields_float), row)
 
     # execute first query
     try:
@@ -284,11 +294,12 @@ def execute_query(
     fields_string: Sequence[str],
     fields_int: Sequence[str],
     fields_float: Sequence[str],
+    transform: Callable[[Dict[str, Any], RowProxy], Dict[str, Any]] = _identity_transform,
 ):
     """
     execute the given query and return the response to send it
     """
-    return execute_queries([(query, params)], fields_string, fields_int, fields_float)
+    return execute_queries([(query, params)], fields_string, fields_int, fields_float, transform)
 
 
 def _join_l(value: Union[str, List[str]]):
@@ -328,6 +339,12 @@ class QueryBuilder:
         group_by = f"GROUP BY {_join_l(self.group_by)}" if self.group_by else ""
 
         return f"SELECT {self.fields_clause} FROM {self.table} {self.subquery} {where} {group_by} {order}"
+
+    def query(self) -> str:
+        """
+        returns the full query
+        """
+        return str(self)
 
     def where(self, **kvargs: Dict[str, Any]) -> "QueryBuilder":
         for k, v in kvargs.items():

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -324,7 +324,9 @@ def handle_backfill():
     signal_pair = parse_single_source_signal_arg("signal")
     time_pair = parse_single_time_arg("time")
     geo_pair = parse_single_geo_arg("geo")
-    reference_anchor_lag = extract_integer("anchor_lag") or 60  # in days
+    reference_anchor_lag = extract_integer("anchor_lag")  # in days
+    if reference_anchor_lag is None:
+        reference_anchor_lag = 60
 
     # build query
     q = QueryBuilder("covidcast", "t")
@@ -368,9 +370,9 @@ def handle_backfill():
                         row["sample_size_rel_change"] = compute_trend_value(row["sample_size"] or 0, prev_row["sample_size"] or 0, 0)
                 if anchor_row and anchor_row["value"] is not None:
                     row["is_anchor"] = row == anchor_row
-                    row["value_completeness"] = (row["value"] or 0) / anchor_row["value"]
+                    row["value_completeness"] = (row["value"] or 0) / anchor_row["value"] if anchor_row["value"] else 1
                     if row["sample_size"] is not None:
-                        row["sample_size_completeness"] = row["sample_size"] / anchor_row["sample_size"]
+                        row["sample_size_completeness"] = row["sample_size"] / anchor_row["sample_size"] if anchor_row["sample_size"] else 1
                 yield row
 
     # execute first query

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -348,19 +348,19 @@ def handle_backfill():
         # find the row that is <= target issue
         i = bisect_right([r["issue"] for r in rows], issue)
         if i:
-            return r[i - 1]
+            return rows[i - 1]
         return None
 
     def gen(rows):
         # stream per time_value
         for time_value, group in groupby((parse_row(row, fields_string, fields_int, fields_float) for row in rows), lambda row: row["time_value"]):
             # compute data per time value
-            rows: List[Dict[str, Any]] = list(group)
-            anchor_row = find_anchor_row(rows, shift_time_value(time_value, reference_anchor_lag))
+            issues: List[Dict[str, Any]] = [r for r in group]
+            anchor_row = find_anchor_row(issues, shift_time_value(time_value, reference_anchor_lag))
 
-            for i, row in enumerate(rows):
+            for i, row in enumerate(issues):
                 if i > 0:
-                    prev_row = rows[i - 1]
+                    prev_row = issues[i - 1]
                     row["value_rel_change"] = compute_trend_value(row["value"] or 0, prev_row["value"] or 0, 0)
                     if row["sample_size"] is not None:
                         row["sample_size_rel_change"] = compute_trend_value(row["sample_size"] or 0, prev_row["sample_size"] or 0, 0)

--- a/src/server/endpoints/covidcast_utils/__init__.py
+++ b/src/server/endpoints/covidcast_utils/__init__.py
@@ -1,3 +1,3 @@
-from .trend import compute_trend
+from .trend import compute_trend, compute_trend_value
 from .dates import shift_time_value, date_to_time_value, time_value_to_iso, time_value_to_date
 from .correlation import compute_correlations

--- a/src/server/endpoints/covidcast_utils/trend.py
+++ b/src/server/endpoints/covidcast_utils/trend.py
@@ -39,10 +39,6 @@ class Trend:
 def compute_trend(geo_type: str, geo_value: str, signal_source: str, signal_signal: str, current_time: int, basis_time: int, rows: Iterable[Tuple[int, float]]) -> Trend:
     t = Trend(geo_type, geo_value, signal_source, signal_signal, basis_date=basis_time)
 
-    min_row: Optional[Tuple[int, float]] = None
-    max_row: Optional[Tuple[int, float]] = None
-    basis_row: Optional[Tuple[int, float]] = None
-
     # find all needed rows
     for time, value in rows:
         if time == current_time:


### PR DESCRIPTION
based on #484 

adds a new `/covidcast/backfill` endpoint that can be used to query all issues for a given signal/geo combo over a given period of time:

![image](https://user-images.githubusercontent.com/4129778/114456785-44becd00-9bab-11eb-8639-b4547ea1f535.png)

Based on this data, one can create a backfill profile and visualization