### PR TITLE
Enable New Relic APM (application performance monitoring) reporting for the flask container

### DIFF
--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -20,5 +20,5 @@ COPY ./src/server/ /app/app/
 COPY --from=builder ./src/build/lib/ /app/app/lib/
 RUN rm -rf /app/app/__pycache__ /app/app/*.php && chmod -R o+r /app/app
 
-ENTRYPOINT [ "/bin/sh entrypoint.sh" ]
-CMD [ "/bin/sh start_wrapper.sh" ]
+ENTRYPOINT [ "/usr/bin/env sh /entrypoint.sh" ]
+CMD [ "/usr/bin/env sh /start_wrapper.sh" ]

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -15,6 +15,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 ENV PYTHONUNBUFFERED 1
 
 COPY ./devops/gunicorn_conf.py /app
+COPY ./devops/start_wrapper.sh /
 COPY ./src/server/ /app/app/
 COPY --from=builder ./src/build/lib/ /app/app/lib/
 RUN rm -rf /app/app/__pycache__ /app/app/*.php && chmod -R o+r /app/app
+
+ENTRYPOINT [ "/usr/bin/env sh entrypoint.sh" ]
+CMD [ "/usr/bin/env sh start_wrapper.sh" ]

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -18,7 +18,9 @@ COPY ./devops/gunicorn_conf.py /app
 COPY ./devops/start_wrapper.sh /
 COPY ./src/server/ /app/app/
 COPY --from=builder ./src/build/lib/ /app/app/lib/
-RUN rm -rf /app/app/__pycache__ /app/app/*.php && chmod -R o+r /app/app
+RUN rm -rf /app/app/__pycache__ /app/app/*.php \
+      && chmod -R o+r /app/app \
+      && chmod 755 /start_wrapper.sh
 
-ENTRYPOINT [ "/bin/sh /entrypoint.sh" ]
-CMD [ "/bin/sh /start_wrapper.sh" ]
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "/start_wrapper.sh" ]

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -20,5 +20,5 @@ COPY ./src/server/ /app/app/
 COPY --from=builder ./src/build/lib/ /app/app/lib/
 RUN rm -rf /app/app/__pycache__ /app/app/*.php && chmod -R o+r /app/app
 
-ENTRYPOINT [ "/usr/bin/env sh /entrypoint.sh" ]
-CMD [ "/usr/bin/env sh /start_wrapper.sh" ]
+ENTRYPOINT [ "/bin/sh /entrypoint.sh" ]
+CMD [ "/bin/sh /start_wrapper.sh" ]

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -20,5 +20,5 @@ COPY ./src/server/ /app/app/
 COPY --from=builder ./src/build/lib/ /app/app/lib/
 RUN rm -rf /app/app/__pycache__ /app/app/*.php && chmod -R o+r /app/app
 
-ENTRYPOINT [ "/usr/bin/env sh entrypoint.sh" ]
-CMD [ "/usr/bin/env sh start_wrapper.sh" ]
+ENTRYPOINT [ "/bin/sh entrypoint.sh" ]
+CMD [ "/bin/sh start_wrapper.sh" ]

--- a/devops/start_wrapper.sh
+++ b/devops/start_wrapper.sh
@@ -3,8 +3,8 @@ set -e
 
 # If a New Relic license key is found then we start with custom New Relic
 # commands, otherwise we start via start.sh.
-if [[ -z "${NEW_RELIC_LICENSE_KEY}" ]]; then
-  sh start.sh
+if [ -z "${NEW_RELIC_LICENSE_KEY}" ]; then
+  sh /start.sh
 else
   newrelic-admin run-command start.sh
 fi

--- a/devops/start_wrapper.sh
+++ b/devops/start_wrapper.sh
@@ -6,5 +6,5 @@ set -e
 if [ -z "${NEW_RELIC_LICENSE_KEY}" ]; then
   sh /start.sh
 else
-  newrelic-admin run-command start.sh
+  newrelic-admin run-command /start.sh
 fi

--- a/devops/start_wrapper.sh
+++ b/devops/start_wrapper.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -e
+
+# If a New Relic license key is found then we start with custom New Relic
+# commands, otherwise we start via start.sh.
+if [[ -z "${NEW_RELIC_LICENSE_KEY}" ]]; then
+  sh start.sh
+else
+  newrelic-admin run-command start.sh
+fi

--- a/devops/start_wrapper.sh
+++ b/devops/start_wrapper.sh
@@ -6,5 +6,5 @@ set -e
 if [ -z "${NEW_RELIC_LICENSE_KEY}" ]; then
   sh /start.sh
 else
-  newrelic-admin run-command /start.sh
+  newrelic-admin run-program /start.sh
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ SQLAlchemy==1.3.22
 mysqlclient==2.0.2
 python-dotenv==0.15.0
 orjson==3.4.7
+newrelic


### PR DESCRIPTION
This PR does the following:

- Installs the New Relic Python agent.

- Adds a simple wrapper to help determine if we should start via `start.sh` or
  with `new-relic run-program start.sh`.

  - The wrapper makes a decision based on the existence of the `NEW_RELIC_LICENSE_KEY`
    environment variable. This is configued in `delphi-ansible-web`. Additional
    New Relic-specific configuration can be supplied in that repository as well.

  - When enabled and started with the NR commands the container will log useful
    APM data to Delphi's New Relic account.
    
    See [https://docs.newrelic.com/docs/agents/python-agent/installation/install-python-agent-docker/]