### PR TITLE
Fix links in HHS API docs and add state_daily info

### DIFF
--- a/docs/api/covid_hosp.md
+++ b/docs/api/covid_hosp.md
@@ -6,13 +6,16 @@ parent: Epidata API (Other Diseases)
 # COVID-19 Hospitalization by State
 
 This data source is a mirror of the "COVID-19 Reported Patient Impact and
-Hospital Capacity by State Timeseries" dataset provided by the US Department of
-Health & Human Services via healthdata.gov.
+Hospital Capacity by State Timeseries" and "COVID-19 Reported Patient Impact and 
+Hospital Capacity by State" datasets provided by the US Department of
+Health & Human Services via healthdata.gov. The latter provides more frequent updates,
+so it is combined with the former to create a single dataset which is as recent as possible.
 
-See the
-[official description at healthdata.gov](https://healthdata.gov/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state-timeseries)
-for more information, including a
-[data dictionary](https://healthdata.gov/covid-19-reported-patient-impact-and-hospital-capacity-state-data-dictionary).
+For more information, see the
+[official description and data dictionary at healthdata.gov](https://healthdata.gov/Hospital/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/g62h-syeh)
+for "COVID-19 Reported Patient Impact and Hospital Capacity by State Timeseries," 
+as well as the [official description](https://healthdata.gov/dataset/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/6xf2-c3ie)
+for "COVID-19 Reported Patient Impact and Hospital Capacity by State."
 
 General topics not specific to any particular data source are discussed in the
 [API overview](README.md). Such topics include:

--- a/docs/api/covid_hosp_facility.md
+++ b/docs/api/covid_hosp_facility.md
@@ -10,9 +10,8 @@ Hospital Capacity by Facility" dataset provided by the US Department of Health
 & Human Services via healthdata.gov.
 
 See the
-[official description at healthdata.gov](https://healthdata.gov/dataset/covid-19-reported-patient-impact-and-hospital-capacity-facility)
-for more information, including a
-[data dictionary](https://healthdata.gov/covid-19-reported-patient-impact-and-hospital-capacity-facility-data-dictionary).
+[official description and data dictionary at healthdata.gov](https://healthdata.gov/Hospital/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/anag-cw7u)
+for more information.
 
 General topics not specific to any particular data source are discussed in the
 [API overview](README.md). Such topics include:

--- a/docs/api/covid_hosp_facility_lookup.md
+++ b/docs/api/covid_hosp_facility_lookup.md
@@ -14,9 +14,8 @@ Capacity by Facility" dataset provided by the US Department of Health & Human
 Services via healthdata.gov.
 
 See the
-[official description at healthdata.gov](https://healthdata.gov/dataset/covid-19-reported-patient-impact-and-hospital-capacity-facility)
-for more information, including a
-[data dictionary](https://healthdata.gov/covid-19-reported-patient-impact-and-hospital-capacity-facility-data-dictionary).
+[official description and data dictionary at healthdata.gov](https://healthdata.gov/Hospital/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/anag-cw7u)
+for more information.
 
 General topics not specific to any particular data source are discussed in the
 [API overview](README.md). Such topics include:


### PR DESCRIPTION
Forgot to change these links after #445. Fixes #505. Also adds info about how the state data is a combination of the state timeseries and state daily datasets. Wasn't sure how much info we wanted to put on that, so currently just left it as close to the original text as possible.