### PR TITLE
build: match is required for globbing

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -266,12 +266,14 @@
       "type": "move",
       "src": "tests/server/",
       "dst": "[[stasis]]/tests/",
+      "match": "^.*\\.(py)$",
       "recursive": true
     },
     {
       "type": "move",
       "src": "integrations/server/",
       "dst": "[[stasis]]/integrations/",
+      "match": "^.*\\.(py)$",
       "recursive": true
     },
 


### PR DESCRIPTION
see https://github.com/cmu-delphi/github-deploy-repo/blob/main/src/actions/copymove.py#L138