### PR TITLE
Remove newline from link

### DIFF
--- a/docs/api/covidcast-signals/indicator-combination.md
+++ b/docs/api/covidcast-signals/indicator-combination.md
@@ -21,8 +21,8 @@ calculated or composed by Delphi. It is not a primary data source.
 ## Statistical Combination Signals (Inactive)
 
 The NMF combination signals were deactivated on March 17, 2021. Documentation for
-these signals is still available on the page for [inactive indicator-combination
-signals](indicator-combination-inactive.md).
+these signals is still available on the page for 
+[inactive indicator-combination signals](indicator-combination-inactive.md).
 
 ## Compositional Signals: Confirmed Cases and Deaths
 


### PR DESCRIPTION
In theory a newline inside link text shouldn't cause a problem, but for some reason Jekyll isn't rewriting the URL on this one so maybe it's using a more conservative filter?

Fixes #531