### PR TITLE
add version endpoint

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 0.1.0
+commit = False
+tag = False
+
+[bumpversion:file:src/server/_config.py]

--- a/.github/workflows/create-delphi-epidata-release.yml
+++ b/.github/workflows/create-delphi-epidata-release.yml
@@ -1,0 +1,43 @@
+name: Create Delphi Epidata Release
+on:
+  workflow_dispatch:
+    inputs:
+      versionName:
+        description: 'Semantic Version Number (i.e., 5.5.0 or patch, minor, major, prepatch, preminor, premajor, prerelease)'
+        required: true
+        default: patch
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          ssh-key: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_SSH }}
+      - name: Reset dev branch
+        run: |
+          git fetch origin dev:dev
+          git reset --hard main
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Change version number
+        id: version
+        run: |
+          python -m pip install bump2version
+          echo -n "::set-output name=next_tag::"
+          bump2version --list ${{ github.event.inputs.versionName }} | grep new_version | sed -r s,"^.*=",,
+      - name: Create pull request into prod
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: release/delphi-epidata-${{ steps.version.outputs.next_tag }}
+          commit-message: 'chore: release delphi-epidata ${{ steps.version.outputs.next_tag }}'
+          base: main
+          title: Release Delphi Epidata ${{ steps.version.outputs.next_tag }}
+          labels: chore
+          reviewers: krivard
+          assignees: krivard
+          body: |
+            Releasing Delphi Epidata ${{ steps.version.outputs.next_tag }}.

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,3 +3,4 @@ black>=20.8b1
 sqlalchemy-stubs>=0.3
 mypy>=0.790
 pytest
+bump2version

--- a/src/server/_config.py
+++ b/src/server/_config.py
@@ -5,16 +5,15 @@ import json
 
 load_dotenv()
 
+VERSION = "0.1.0"
 
 MAX_RESULTS = int(10e6)
 MAX_COMPATIBILITY_RESULTS = int(3650)
 
 SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI", "sqlite:///test.db")
-SQLALCHEMY_ENGINE_OPTIONS = json.loads(
-    os.environ.get("SQLALCHEMY_ENGINE_OPTIONS", "{}")
-)
-SECRET = os.environ.get("FLASK_SECRET", 'secret')
-URL_PREFIX = os.environ.get('FLASK_PREFIX', '/')
+SQLALCHEMY_ENGINE_OPTIONS = json.loads(os.environ.get("SQLALCHEMY_ENGINE_OPTIONS", "{}"))
+SECRET = os.environ.get("FLASK_SECRET", "secret")
+URL_PREFIX = os.environ.get("FLASK_PREFIX", "/")
 
 AUTH = {
     "twitter": os.environ.get("SECRET_TWITTER"),

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -2,9 +2,9 @@ import pathlib
 import logging
 from typing import Dict, Callable
 
-from flask import request, send_file, Response, send_from_directory
+from flask import request, send_file, Response, send_from_directory, jsonify
 
-from ._config import URL_PREFIX
+from ._config import URL_PREFIX, VERSION
 from ._common import app, set_compatibility_mode
 from ._exceptions import MissingOrWrongSourceException
 from .endpoints import endpoints
@@ -37,6 +37,11 @@ def handle_generic():
 @app.route(f"{URL_PREFIX}/index.html")
 def send_index_file():
     return send_file(pathlib.Path(__file__).parent / "index.html")
+
+
+@app.route(f"{URL_PREFIX}/version")
+def send_version():
+    return jsonify(dict(version=VERSION))
 
 
 @app.route(f"{URL_PREFIX}/lib/<path:path>")


### PR DESCRIPTION
closes #529 

add a simple version endpoint `/version` which returns the current epidata version. Moreover, start with Github Release Action workflow similar to www-main or www-covidcast. For now, it is just about bumping the version and merging dev to main