### PR TITLE
Add retry to Epidata request

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,4 +3,5 @@ black>=20.8b1
 sqlalchemy-stubs>=0.3
 mypy>=0.790
 pytest
+tenacity==7.0.0
 bump2version

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ python-dotenv==0.15.0
 orjson==3.4.7
 pandas==1.2.3
 scipy==1.6.2
+tenacity==7.0.0
 newrelic

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -11,7 +11,7 @@ Notes:
 # External modules
 import requests
 import asyncio
-import warnings
+from tenacity import retry, stop_after_attempt
 
 from aiohttp import ClientSession, TCPConnector
 from pkg_resources import get_distribution, DistributionNotFound
@@ -52,7 +52,15 @@ class Epidata:
       values = [values]
     return ','.join([Epidata._listitem(value) for value in values])
 
-  # Helper function to request and parse epidata
+  @staticmethod
+  @retry(reraise=True, stop=stop_after_attempt(2))
+  def _request_with_retry(params):
+    """Make request with a retry if an exception is thrown."""
+    req = requests.get(Epidata.BASE_URL, params, headers=_HEADERS)
+    if req.status_code == 414:
+      req = requests.post(Epidata.BASE_URL, params, headers=_HEADERS)
+    return req
+
   @staticmethod
   def _request(params):
     """Request and parse epidata.
@@ -62,13 +70,8 @@ class Epidata:
     long and returns a 414.
     """
     try:
-      # API call
-      req = requests.get(Epidata.BASE_URL, params, headers=_HEADERS)
-      if req.status_code == 414:
-        req = requests.post(Epidata.BASE_URL, params, headers=_HEADERS)
-      return req.json()
+      return Epidata._request_with_retry(params).json()
     except Exception as e:
-      # Something broke
       return {'result': 0, 'message': 'error: ' + str(e)}
 
   # Raise an Exception on error, otherwise return epidata

--- a/src/client/packaging/pypi/setup.py
+++ b/src/client/packaging/pypi/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
   install_requires=[
     'aiohttp',
     'requests>=2.7.0',
+    'tenacity'
   ],
   classifiers=[
     'Programming Language :: Python',


### PR DESCRIPTION
Add a single retry if an exception is encountered when making a request to the Epidata endpoint. If the retry fails, the exception encountered is reraised.

Also learned about reset_mock() so slipped that into an old test.


Requires https://github.com/cmu-delphi/operations/pull/66 otherwise the CI will fail on the import