### PR TITLE
add all endpoints to JS client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 *.db
 /build
 /node_modules
+.mypy_cache

--- a/docs/api/client_libraries.md
+++ b/docs/api/client_libraries.md
@@ -24,7 +24,7 @@ For anyone looking for COVIDCast data, please visit our [COVIDCast Libraries](co
 <script src="delphi_epidata.js"></script>
 <!-- Fetch data -->
 <script>
-  EpidataAsync.covidcast('fb-survey', 'smoothed_cli', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001').then((res) => {
+  EpidataAsync.covidcast('fb-survey', 'smoothed_cli', 'day', 'county', [20200401, EpidataAsync.range(20200405, 20200414)], '06001').then((res) => {
     console.log(res.result, res.message, res.epidata != null ? res.epidata.length : 0);
   });
 </script>

--- a/docs/api/flusurv.md
+++ b/docs/api/flusurv.md
@@ -115,7 +115,7 @@ The following samples show how to import the library and fetch CA FluView Clinic
 <script src="delphi_epidata.js"></script>
 <!-- Fetch data -->
 <script>
-  EpidataAsync.flusurv(['ca'], [201940, Epidata.range(202001, 202010)]).then((res) => {
+  EpidataAsync.flusurv('ca', [201940, Epidata.range(202001, 202010)]).then((res) => {
     console.log(res.result, res.message, res.epidata != null ? res.epidata.length : 0);
   });
 </script>

--- a/docs/api/fluview.md
+++ b/docs/api/fluview.md
@@ -131,7 +131,7 @@ The following samples show how to import the library and fetch national FluView 
 <script src="delphi_epidata.js"></script>
 <!-- Fetch data -->
 <script>
-  EpidataAsync.fluview(['nat'], [201440, Epidata.range(201501, 201510)]).then((res) => {
+  EpidataAsync.fluview('nat', [201440, EpidataAsync.range(201501, 201510)]).then((res) => {
     console.log(res.result, res.message, res.epidata != null ? res.epidata.length : 0);
   });
 </script>

--- a/docs/api/fluview_clinical.md
+++ b/docs/api/fluview_clinical.md
@@ -104,7 +104,7 @@ The following samples show how to import the library and fetch national FluView 
 <script src="delphi_epidata.js"></script>
 <!-- Fetch data -->
 <script>
-  EpidataAsync.fluview_clinical(['nat'], [201940, Epidata.range(202001, 202010)]).then((res) => {
+  EpidataAsync.fluview_clinical('nat', [201940, EpidataAsync.range(202001, 202010)]).then((res) => {
     console.log(res.result, res.message, res.epidata != null ? res.epidata.length : 0);
   });
 </script>

--- a/docs/api/gft.md
+++ b/docs/api/gft.md
@@ -79,7 +79,7 @@ The following samples show how to import the library and fetch Google Flu Trends
 <script src="delphi_epidata.js"></script>
 <!-- Fetch data -->
 <script>
-  EpidataAsync.gft(['nat'], [201440, Epidata.range(201501, 201510)]).then((res) => {
+  EpidataAsync.gft('nat', [201440, EpidataAsync.range(201501, 201510)]).then((res) => {
     console.log(res.result, res.message, res.epidata != null ? res.epidata.length : 0);
   });
 </script>

--- a/docs/api/nidss_dengue.md
+++ b/docs/api/nidss_dengue.md
@@ -79,7 +79,7 @@ The following samples show how to import the library and fetch national NIDSS De
 <script src="delphi_epidata.js"></script>
 <!-- Fetch data -->
 <script>
-  EpidataAsync.nidss_dengue(['nationwide'], [201440, Epidata.range(201501, 201510)]).then((res) => {
+  EpidataAsync.nidss_dengue('nationwide', [201440, EpidataAsync.range(201501, 201510)]).then((res) => {
     console.log(res.result, res.message, res.epidata != null ? res.epidata.length : 0);
   });
 </script>

--- a/docs/api/nidss_flu.md
+++ b/docs/api/nidss_flu.md
@@ -100,7 +100,7 @@ The following samples show how to import the library and fetch national NIDSS Fl
 <script src="delphi_epidata.js"></script>
 <!-- Fetch data -->
 <script>
-  EpidataAsync.nidss_flu(['nationwide'], [201440, Epidata.range(201501, 201510)]).then((res) => {
+  EpidataAsync.nidss_flu('nationwide', [201440, EpidataAsync.range(201501, 201510)]).then((res) => {
     console.log(res.result, res.message, res.epidata != null ? res.epidata.length : 0);
   });;
 </script>

--- a/docs/api/nowcast.md
+++ b/docs/api/nowcast.md
@@ -83,7 +83,7 @@ The following samples show how to import the library and fetch national ILI Near
 <script src="delphi_epidata.js"></script>
 <!-- Fetch data -->
 <script>
-  EpidataAsync.nowcast(['nat'], [201940, Epidata.range(202001, 202010)]).then((res) => {
+  EpidataAsync.nowcast('nat', [201940, EpidataAsync.range(202001, 202010)]).then((res) => {
     console.log(res.result, res.message, res.epidata != null ? res.epidata.length : 0);
   });
 </script>

--- a/docs/api/sensors.md
+++ b/docs/api/sensors.md
@@ -100,7 +100,7 @@ The following samples show how to import the library and fetch national Delphi's
 <script src="delphi_epidata.js"></script>
 <!-- Fetch data -->
 <script>
-  EpidataAsync.sensors(['nat'], ['sar3'], [201940, Epidata.range(202001, 202010)]).then((res) => {
+  EpidataAsync.sensors('nat', 'sar3', [201940, EpidataAsync.range(202001, 202010)]).then((res) => {
     console.log(res.result, res.message, res.epidata != null ? res.epidata.length : 0);
   });
 </script>

--- a/docs/api/wiki.md
+++ b/docs/api/wiki.md
@@ -120,7 +120,7 @@ epiweeks `201940` and `202001-202010` (11 weeks total) for hours 0 and 12 in Eng
 <script src="delphi_epidata.js"></script>
 <!-- Fetch data -->
 <script>
-  EpidataAsync.wiki(['influenza'], null, [201940, Epidata.range(202001, 202010)], [0, 12]).then((res) => {
+  EpidataAsync.wiki('influenza', null, [201940, Epidata.EpidataAsync(202001, 202010)], [0, 12]).then((res) => {
     console.log(res.result, res.message, res.epidata != null ? res.epidata.length : 0);
   });
 </script>

--- a/src/client/delphi_epidata.d.ts
+++ b/src/client/delphi_epidata.d.ts
@@ -15,7 +15,8 @@ declare module 'delphi_epidata' {
 
     export interface EpidataFunctions {
         readonly BASE_URL: string;
-        withURL(baseUrl?: string): EpidataFunctions;
+        range(this: void, from: string | number, to: string | number): EpiRange;
+        withURL(this: void, baseUrl?: string): EpidataFunctions;
 
         fluview(callback: EpiDataCallback, regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number, auth?: string): Promise<EpiDataResponse>;
         fluview_meta(callback: EpiDataCallback): Promise<EpiDataResponse>;
@@ -46,7 +47,8 @@ declare module 'delphi_epidata' {
 
     export interface EpidataAsyncFunctions {
         readonly BASE_URL: string;
-        withURL(baseUrl?: string): EpidataAsyncFunctions;
+        range(this: void, from: string | number, to: string | number): EpiRange;
+        withURL(this: void, baseUrl?: string): EpidataAsyncFunctions;
 
         fluview(regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number, auth?: string): Promise<EpiDataResponse>;
         fluview_meta(): Promise<EpiDataResponse>;

--- a/src/client/delphi_epidata.d.ts
+++ b/src/client/delphi_epidata.d.ts
@@ -18,29 +18,36 @@ declare module 'delphi_epidata' {
         range(this: void, from: string | number, to: string | number): EpiRange;
         withURL(this: void, baseUrl?: string): EpidataFunctions;
 
+        afhsb(callback: EpiDataCallback, auth: string, locations: StringParam, epiweeks: EpiRangeParam, flu_types: StringParam): Promise<EpiDataResponse>;
+        cdc(callback: EpiDataCallback, auth: string, epiweeks: EpiRangeParam, locations: StringParam): Promise<EpiDataResponse>;
+        covid_hosp_facility(callback: EpiDataCallback, hospital_pks: StringParam, collection_weeks: EpiRangeParam, publication_dates: EpiRangeParam): Promise<EpiDataResponse>;
+        covid_hosp_facility_lookup(callback: EpiDataCallback, state?: string, ccn?: string, city?: string, zip?: string, fips_code?: string): Promise<EpiDataResponse>;
+        // alias to covid_hosp_state_timeseries
+        covid_hosp(callback: EpiDataCallback, states: StringParam, dates: EpiRangeParam, issues: EpiRangeParam): Promise<EpiDataResponse>;
+        covid_hosp_state_timeseries(callback: EpiDataCallback, states: StringParam, dates: EpiRangeParam, issues: EpiRangeParam): Promise<EpiDataResponse>;
+        covidcast_meta(callback: EpiDataCallback): Promise<EpiDataResponse>;
+        covidcast_nowcast(callback: EpiDataCallback, data_source: string, signals: string, time_type: 'day' | 'week', geo_type: string, time_values: EpiRangeParam, as_of?: number, issues?: EpiRangeParam, format?: 'json' | 'tree' | 'classic' | 'csv'): Promise<EpiDataResponse>;
+        covidcast(callback: EpiDataCallback, data_source: string, signals: string, time_type: 'day' | 'week', geo_type: string, time_values: EpiRangeParam, as_of?: number, issues?: EpiRangeParam, format?: 'json' | 'tree' | 'classic' | 'csv'): Promise<EpiDataResponse>;
         fluview(callback: EpiDataCallback, regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number, auth?: string): Promise<EpiDataResponse>;
-        fluview_meta(callback: EpiDataCallback): Promise<EpiDataResponse>;
         fluview_clinical(callback: EpiDataCallback, regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number): Promise<EpiDataResponse>;
+        fluview_meta(callback: EpiDataCallback): Promise<EpiDataResponse>;
         flusurv(callback: EpiDataCallback, locations: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number): Promise<EpiDataResponse>;
         gft(callback: EpiDataCallback, locations: StringParam, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
         ght(callback: EpiDataCallback, auth: string, locations: StringParam, epiweeks: EpiRangeParam, query: string): Promise<EpiDataResponse>;
-        cdc(callback: EpiDataCallback, auth: string, epiweeks: EpiRangeParam, locations: StringParam): Promise<EpiDataResponse>;
-        quidel(callback: EpiDataCallback, auth: string, epiweeks: EpiRangeParam, locations: StringParam): Promise<EpiDataResponse>;
-        norostat(callback: EpiDataCallback, auth: string, location: string, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
-        meta_norostat(callback: EpiDataCallback, auth: string): Promise<EpiDataResponse>;
-        afhsb(callback: EpiDataCallback, auth: string, locations: StringParam, epiweeks: EpiRangeParam, flu_types: StringParam): Promise<EpiDataResponse>;
+        kcdc_ili(callback: EpiDataCallback, regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number): Promise<EpiDataResponse>;
         meta_afhsb(callback: EpiDataCallback, auth: string): Promise<EpiDataResponse>;
-        nidss_flu(callback: EpiDataCallback, regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number): Promise<EpiDataResponse>;
+        meta_norostat(callback: EpiDataCallback, auth: string): Promise<EpiDataResponse>;
+        meta(callback: EpiDataCallback): Promise<EpiDataResponse>;
         nidss_dengue(callback: EpiDataCallback, locations: StringParam, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
+        nidss_flu(callback: EpiDataCallback, regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number): Promise<EpiDataResponse>;
+        norostat(callback: EpiDataCallback, auth: string, location: string, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
+        nowcast(callback: EpiDataCallback, locations: StringParam, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
+        paho_dengue(callback: EpiDataCallback, regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number): Promise<EpiDataResponse>;
+        quidel(callback: EpiDataCallback, auth: string, epiweeks: EpiRangeParam, locations: StringParam): Promise<EpiDataResponse>;
         delphi(callback: EpiDataCallback, system: string, epiweek: string | number): Promise<EpiDataResponse>;
         sensors(callback: EpiDataCallback, auth: string, names: StringParam, locations: StringParam, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
-        nowcast(callback: EpiDataCallback, locations: StringParam, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
-        meta(callback: EpiDataCallback): Promise<EpiDataResponse>;
-        covidcast(callback: EpiDataCallback, data_source: string, signals: string, time_type: 'day' | 'week', geo_type: string, time_values: EpiRangeParam, as_of?: number, issues?: EpiRangeParam, format?: 'json' | 'tree' | 'classic' | 'csv'): Promise<EpiDataResponse>;
-        covidcast_meta(callback: EpiDataCallback): Promise<EpiDataResponse>;
-        covid_hosp(callback: EpiDataCallback, states: StringParam, dates: EpiRangeParam, issues: EpiRangeParam): Promise<EpiDataResponse>;
-        covid_hosp_facility(callback: EpiDataCallback, hospital_pks: StringParam, collection_weeks: EpiRangeParam, publication_dates: EpiRangeParam): Promise<EpiDataResponse>;
-        covid_hosp_facility_lookup(callback: EpiDataCallback, state?: string, ccn?: string, city?: string, zip?: string, fips_code?: string): Promise<EpiDataResponse>;
+        twitter(callback: EpiDataCallback, auth: string, locations: StringParam, dates?: EpiRangeParam, epiweeks?: EpiRangeParam): Promise<EpiDataResponse>;
+        wiki(callback: EpiDataCallback, articles: StringParam, dates?: EpiRangeParam,  epiweeks: EpiRangeParam, language?: string = 'en'): Promise<EpiDataResponse>;
     }
 
     export const Epidata: EpidataFunctions;
@@ -50,29 +57,36 @@ declare module 'delphi_epidata' {
         range(this: void, from: string | number, to: string | number): EpiRange;
         withURL(this: void, baseUrl?: string): EpidataAsyncFunctions;
 
+        afhsb(auth: string, locations: StringParam, epiweeks: EpiRangeParam, flu_types: StringParam): Promise<EpiDataResponse>;
+        cdc(auth: string, epiweeks: EpiRangeParam, locations: StringParam): Promise<EpiDataResponse>;
+        covid_hosp_facility(hospital_pks: StringParam, collection_weeks: EpiRangeParam, publication_dates: EpiRangeParam): Promise<EpiDataResponse>;
+        covid_hosp_facility_lookup(state?: string, ccn?: string, city?: string, zip?: string, fips_code?: string): Promise<EpiDataResponse>;
+        // alias to covid_hosp_state_timeseries
+        covid_hosp(states: StringParam, dates: EpiRangeParam, issues: EpiRangeParam): Promise<EpiDataResponse>;
+        covid_hosp_state_timeseries(states: StringParam, dates: EpiRangeParam, issues: EpiRangeParam): Promise<EpiDataResponse>;
+        covidcast_meta(callback: EpiDataCallback): Promise<EpiDataResponse>;
+        covidcast_nowcast(data_source: string, signals: string, time_type: 'day' | 'week', geo_type: string, time_values: EpiRangeParam, as_of?: number, issues?: EpiRangeParam, format?: 'json' | 'tree' | 'classic' | 'csv'): Promise<EpiDataResponse>;
+        covidcast(data_source: string, signals: string, time_type: 'day' | 'week', geo_type: string, time_values: EpiRangeParam, as_of?: number, issues?: EpiRangeParam, format?: 'json' | 'tree' | 'classic' | 'csv'): Promise<EpiDataResponse>;
         fluview(regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number, auth?: string): Promise<EpiDataResponse>;
-        fluview_meta(): Promise<EpiDataResponse>;
         fluview_clinical(regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number): Promise<EpiDataResponse>;
+        fluview_meta(callback: EpiDataCallback): Promise<EpiDataResponse>;
         flusurv(locations: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number): Promise<EpiDataResponse>;
         gft(locations: StringParam, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
         ght(auth: string, locations: StringParam, epiweeks: EpiRangeParam, query: string): Promise<EpiDataResponse>;
-        cdc(auth: string, epiweeks: EpiRangeParam, locations: StringParam): Promise<EpiDataResponse>;
-        quidel(auth: string, epiweeks: EpiRangeParam, locations: StringParam): Promise<EpiDataResponse>;
-        norostat(auth: string, location: string, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
-        meta_norostat(auth: string): Promise<EpiDataResponse>;
-        afhsb(auth: string, locations: StringParam, epiweeks: EpiRangeParam, flu_types: StringParam): Promise<EpiDataResponse>;
+        kcdc_ili(regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number): Promise<EpiDataResponse>;
         meta_afhsb(auth: string): Promise<EpiDataResponse>;
-        nidss_flu(regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number): Promise<EpiDataResponse>;
+        meta_norostat(auth: string): Promise<EpiDataResponse>;
+        meta(callback: EpiDataCallback): Promise<EpiDataResponse>;
         nidss_dengue(locations: StringParam, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
+        nidss_flu(regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number): Promise<EpiDataResponse>;
+        norostat(auth: string, location: string, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
+        nowcast(locations: StringParam, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
+        paho_dengue(regions: StringParam, epiweeks: EpiRangeParam, issues?: EpiRangeParam, lag?: number): Promise<EpiDataResponse>;
+        quidel(auth: string, epiweeks: EpiRangeParam, locations: StringParam): Promise<EpiDataResponse>;
         delphi(system: string, epiweek: string | number): Promise<EpiDataResponse>;
         sensors(auth: string, names: StringParam, locations: StringParam, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
-        nowcast(locations: StringParam, epiweeks: EpiRangeParam): Promise<EpiDataResponse>;
-        meta(): Promise<EpiDataResponse>;
-        covidcast(data_source: string, signals: string, time_type: 'day' | 'week', geo_type: string, time_values: EpiRangeParam, as_of?: number, issues?: EpiRangeParam, format?: 'json' | 'tree' | 'classic' | 'csv'): Promise<EpiDataResponse>;
-        covidcast_meta(): Promise<EpiDataResponse>;
-        covid_hosp(states: StringParam, dates: EpiRangeParam, issues: EpiRangeParam): Promise<EpiDataResponse>;
-        covid_hosp_facility(hospital_pks: StringParam, collection_weeks: EpiRangeParam, publication_dates: EpiRangeParam): Promise<EpiDataResponse>;
-        covid_hosp_facility_lookup(state?: string, ccn?: string, city?: string, zip?: string, fips_code?: string): Promise<EpiDataResponse>;
+        twitter(auth: string, locations: StringParam, dates?: EpiRangeParam, epiweeks?: EpiRangeParam): Promise<EpiDataResponse>;
+        wiki(articles: StringParam, dates?: EpiRangeParam, epiweeks: EpiRangeParam, language?: string = 'en'): Promise<EpiDataResponse>;
     }
 
     export const EpidataAsync: EpidataAsyncFunctions;

--- a/src/client/delphi_epidata.js
+++ b/src/client/delphi_epidata.js
@@ -21,8 +21,9 @@
     factory(root, root.fetch, root.jQuery || root.$);
   }
 })(this, function (exports, fetchImpl, jQuery) {
-  const BASE_URL = "https://delphi.cmu.edu/epidata/"; // Helper function to cast values and/or ranges to strings
+  const BASE_URL = "https://delphi.cmu.edu/epidata/";
 
+  // Helper function to cast values and/or ranges to strings
   function _listitem(value) {
     if (value == null) {
       return null;
@@ -103,6 +104,10 @@
     }
   }
 
+  function range(from, to) {
+    return {from, to};
+  }
+
   ////#region begin of views
 
   function createEpidataAsync(baseUrl) {
@@ -111,6 +116,7 @@
 
     return {
       BASE_URL: baseUrl || BASE_URL,
+      range,
       /**
        * Fetch FluView data
        */
@@ -440,9 +446,10 @@
     const r = {
       BASE_URL: api.BASE_URL,
       withURL: createEpidata,
+      range,
     };
     Object.keys(api).forEach((key) => {
-      if (key === "BASE_URL" || key === "withURL") {
+      if (key === "BASE_URL" || key === "withURL" || key === 'range') {
         return;
       }
       r[key] = function (callback) {

--- a/src/client/delphi_epidata.js
+++ b/src/client/delphi_epidata.js
@@ -105,7 +105,7 @@
   }
 
   function range(from, to) {
-    return {from, to};
+    return { from, to };
   }
 
   ////#region begin of views
@@ -116,131 +116,8 @@
 
     return {
       BASE_URL: baseUrl || BASE_URL,
+      withURL: createEpidataAsync,
       range,
-      /**
-       * Fetch FluView data
-       */
-      fluview: (regions, epiweeks, issues, lag, auth) => {
-        requireAll({ regions, epiweeks });
-        issuesOrLag(issues, lag);
-        const params = {
-          regions: _list(regions),
-          epiweeks: _list(epiweeks),
-          issues: _list(issues),
-          lag,
-          auth,
-        };
-        return _request("fluview", params);
-      },
-      /**
-       * Fetch FluView metadata
-       */
-      fluview_meta: () => {
-        return _request("fluview_meta", {});
-      },
-      /**
-       * Fetch FluView clinical data
-       */
-      fluview_clinical: (regions, epiweeks, issues, lag) => {
-        requireAll({ regions, epiweeks });
-        issuesOrLag(issues, lag);
-        const params = {
-          regions: _list(regions),
-          epiweeks: _list(epiweeks),
-          issues: _list(issues),
-          lag,
-        };
-        return _request("fluview_clinical", params);
-      },
-
-      /**
-       * Fetch FluSurv data
-       */
-      flusurv: (locations, epiweeks, issues, lag) => {
-        requireAll({ locations, epiweeks });
-        issuesOrLag(issues, lag);
-        const params = {
-          locations: _list(locations),
-          epiweeks: _list(epiweeks),
-          issues: _list(issues),
-          lag,
-        };
-        return _request("flusurv", params);
-      },
-      /**
-       * Fetch Google Flu Trends data
-       */
-      gft: (locations, epiweeks) => {
-        requireAll({ locations, epiweeks });
-        const params = {
-          locations: _list(locations),
-          epiweeks: _list(epiweeks),
-        };
-        return _request("gft", params);
-      },
-      /**
-       * Fetch Google Health Trends data
-       */
-      ght: (auth, locations, epiweeks, query) => {
-        requireAll({ auth, locations, epiweeks, query });
-        const params = {
-          auth,
-          locations: _list(locations),
-          epiweeks: _list(epiweeks),
-          query,
-        };
-        return _request("ght", params);
-      },
-
-      /**
-       * Fetch CDC page hits
-       */
-      cdc: (auth, epiweeks, locations) => {
-        requireAll({ auth, locations, epiweeks });
-        const params = {
-          auth,
-          epiweeks: _list(epiweeks),
-          locations: _list(locations),
-        };
-        return _request("cdc", params);
-      },
-      /**
-       * Fetch Quidel data
-       */
-      quidel: (auth, epiweeks, locations) => {
-        requireAll({ auth, locations, epiweeks });
-        const params = {
-          auth,
-          epiweeks: _list(epiweeks),
-          locations: _list(locations),
-        };
-        return _request("quidel", params);
-      },
-      /**
-       * Fetch NoroSTAT data (point data, no min/max)
-       */
-      norostat: (auth, location, epiweeks) => {
-        requireAll({ auth, locations, epiweeks });
-        const params = {
-          auth,
-          location,
-          epiweeks: _list(epiweeks),
-        };
-        return _request("norostat", params);
-      },
-      /**
-       * Fetch NoroSTAT metadata
-       */
-      meta_norostat: (auth) => {
-        if (auth == null) {
-          throw new Error("`auth` is required");
-        }
-        const params = {
-          auth,
-        };
-        return _request("meta_norostat", params);
-      },
-
       /**
        * Fetch AFHSB data (point data, no min/max)
        */
@@ -255,87 +132,127 @@
         return _request("afhsb", params);
       },
       /**
-       * Fetch AFHSB metadata
+       * Fetch CDC page hits
        */
-      meta_afhsb: (auth) => {
-        requireAll({ auth });
+      cdc: (auth, epiweeks, locations) => {
+        requireAll({ auth, locations, epiweeks });
         const params = {
           auth,
+          epiweeks: _list(epiweeks),
+          locations: _list(locations),
         };
-        return _request("meta_afhsb", params);
+        return _request("cdc", params);
       },
       /**
-       * Fetch NIDSS flu data
+       * Fetch COVID hospitalization data for specific facilities
        */
-      nidss_flu: (regions, epiweeks, issues, lag) => {
-        requireAll({ epiweeks, regions });
-        issuesOrLag(issues, lag);
+      covid_hosp_facility: (
+        hospital_pks,
+        collection_weeks,
+        publication_dates
+      ) => {
+        requireAll({ hospital_pks, collection_weeks });
         const params = {
-          regions: _list(regions),
-          epiweeks: _list(epiweeks),
+          hospital_pks: _list(hospital_pks),
+          collection_weeks: _list(collection_weeks),
+          publication_dates: _list(publication_dates),
+        };
+        return _request("covid_hosp_facility", params);
+      },
+
+      /**
+       * Lookup COVID hospitalization facility identifiers
+       */
+      covid_hosp_facility_lookup: (state, ccn, city, zip, fips_code) => {
+        const params = {};
+        if (state != null) {
+          params.state = state;
+        } else if (ccn != null) {
+          params.ccn = ccn;
+        } else if (city != null) {
+          params.city = city;
+        } else if (zip != null) {
+          params.zip = zip;
+        } else if (fips_code != null) {
+          params.fips_code = fips_code;
+        } else {
+          throw new Error(
+            "one of `state`, `ccn`, `city`, `zip`, or `fips_code` is required"
+          );
+        }
+        return _request("covid_hosp_facility", params);
+      },
+      /**
+       * Fetch COVID hospitalization data
+       */
+      covid_hosp: (states, dates, issues) => {
+        requireAll({ states, dates });
+        const params = {
+          states: _list(states),
+          dates: _list(dates),
           issues: _list(issues),
-          lag,
         };
-        return _request("nidss_flu", params);
+        return _request("covid_hosp_state_timeseries", params);
       },
-
       /**
-       * Fetch NIDSS dengue data
+       * Fetch COVID hospitalization data
        */
-      nidss_dengue: (locations, epiweeks) => {
-        requireAll({ locations, regions });
+      covid_hosp_state_timeseries: (states, dates, issues) => {
+        requireAll({ states, dates });
         const params = {
-          locations: _list(locations),
-          epiweeks: _list(epiweeks),
+          states: _list(states),
+          dates: _list(dates),
+          issues: _list(issues),
         };
-        return _request("nidss_dengue", params);
+        return _request("covid_hosp_state_timeseries", params);
       },
-
       /**
-       * Fetch Delphi's forecast
+       * Fetch Delphi's COVID-19 Surveillance Streams metadata
        */
-      delphi: (system, epiweek) => {
-        requireAll({ system, epiweek });
-        const params = {
-          system,
-          epiweek,
-        };
-        return _request("delphi", params);
+      covidcast_meta: () => {
+        return _request("covidcast_meta", {});
       },
-
       /**
-       * Fetch Delphi's digital surveillance sensors
+       * Fetch Delphi's COVID-19 Surveillance Streams
        */
-      sensors: (auth, names, locations, epiweeks) => {
-        requireAll({ auth, names, locations, epiweeks });
-        const params = {
-          auth,
-          names: _list(names),
-          locations: _list(locations),
-          epiweeks: _list(epiweeks),
-        };
-        return _request("sensors", params);
-      },
-
-      /**
-       * Fetch Delphi's ILI nowcast
-       */
-      nowcast: (locations, epiweeks) => {
-        requireAll({ locations, epiweeks });
-        const params = {
-          locations: _list(locations),
-          epiweeks: _list(epiweeks),
-        };
-        return _request("nowcast", params);
-      },
-
-      /**
-       * Fetch API metadata
-       */
-      meta: () => {
-        return _request({
-          endpoint: "meta",
+      covidcast_nowcast: (
+        data_source,
+        signals,
+        time_type,
+        geo_type,
+        time_values,
+        geo_value,
+        as_of,
+        issues,
+        lag,
+        format
+      ) => {
+        requireAll({
+          data_source,
+          signals,
+          time_type,
+          geo_type,
+          time_values,
+          geo_value,
         });
+        issuesOrLag(issues, lag);
+
+        const params = {
+          data_source,
+          signals,
+          time_type,
+          geo_type,
+          time_values: _list(time_values),
+          as_of,
+          issues: _list(issues),
+          format,
+        };
+        if (Array.isArray(geo_value)) {
+          params.geo_values = geo_value.join(",");
+        } else {
+          params.geo_value = geo_value;
+        }
+        return _request("covidcast_nowcast", params);
       },
       /**
        * Fetch Delphi's COVID-19 Surveillance Streams
@@ -380,63 +297,251 @@
         return _request("covidcast", params);
       },
       /**
-       * Fetch Delphi's COVID-19 Surveillance Streams metadata
+       * Fetch FluView data
        */
-      covidcast_meta: () => {
-        return _request("covidcast_meta", {});
-      },
-      /**
-       * Fetch COVID hospitalization data
-       */
-      covid_hosp: (states, dates, issues) => {
-        requireAll({ states, dates });
+      fluview: (regions, epiweeks, issues, lag, auth) => {
+        requireAll({ regions, epiweeks });
+        issuesOrLag(issues, lag);
         const params = {
-          states: _list(states),
-          dates: _list(dates),
+          regions: _list(regions),
+          epiweeks: _list(epiweeks),
           issues: _list(issues),
+          lag,
+          auth,
         };
-        return _request("covid_hosp", params);
+        return _request("fluview", params);
       },
       /**
-       * Fetch COVID hospitalization data for specific facilities
+       * Fetch FluView clinical data
        */
-      covid_hosp_facility: (
-        hospital_pks,
-        collection_weeks,
-        publication_dates
-      ) => {
-        requireAll({ hospital_pks, collection_weeks });
+      fluview_clinical: (regions, epiweeks, issues, lag) => {
+        requireAll({ regions, epiweeks });
+        issuesOrLag(issues, lag);
         const params = {
-          hospital_pks: _list(hospital_pks),
-          collection_weeks: _list(collection_weeks),
-          publication_dates: _list(publication_dates),
+          regions: _list(regions),
+          epiweeks: _list(epiweeks),
+          issues: _list(issues),
+          lag,
         };
-        return _request("covid_hosp_facility", params);
+        return _request("fluview_clinical", params);
+      },
+      /**
+       * Fetch FluView metadata
+       */
+      fluview_meta: () => {
+        return _request("fluview_meta", {});
+      },
+      /**
+       * Fetch FluSurv data
+       */
+      flusurv: (locations, epiweeks, issues, lag) => {
+        requireAll({ locations, epiweeks });
+        issuesOrLag(issues, lag);
+        const params = {
+          locations: _list(locations),
+          epiweeks: _list(epiweeks),
+          issues: _list(issues),
+          lag,
+        };
+        return _request("flusurv", params);
+      },
+      /**
+       * Fetch Google Flu Trends data
+       */
+      gft: (locations, epiweeks) => {
+        requireAll({ locations, epiweeks });
+        const params = {
+          locations: _list(locations),
+          epiweeks: _list(epiweeks),
+        };
+        return _request("gft", params);
+      },
+      /**
+       * Fetch Google Health Trends data
+       */
+      ght: (auth, locations, epiweeks, query) => {
+        requireAll({ auth, locations, epiweeks, query });
+        const params = {
+          auth,
+          locations: _list(locations),
+          epiweeks: _list(epiweeks),
+          query,
+        };
+        return _request("ght", params);
+      },
+      /**
+       * ?
+       */
+      kcdc_ili: (regions, epiweeks, issues, lag) => {
+        requireAll({ regions, epiweeks });
+        const params = {
+          regions: _list(regions),
+          epiweeks: _list(epiweeks),
+          issues: _list(issues),
+          lag,
+        };
+        return _request("kcdc_ili", params);
+      },
+      /**
+       * Fetch AFHSB metadata
+       */
+      meta_afhsb: (auth) => {
+        requireAll({ auth });
+        const params = {
+          auth,
+        };
+        return _request("meta_afhsb", params);
+      },
+      /**
+       * Fetch NoroSTAT metadata
+       */
+      meta_norostat: (auth) => {
+        if (auth == null) {
+          throw new Error("`auth` is required");
+        }
+        const params = {
+          auth,
+        };
+        return _request("meta_norostat", params);
+      },
+      /**
+       * Fetch API metadata
+       */
+      meta: () => {
+        return _request({
+          endpoint: "meta",
+        });
+      },
+      /**
+       * Fetch NIDSS dengue data
+       */
+      nidss_dengue: (locations, epiweeks) => {
+        requireAll({ locations, regions });
+        const params = {
+          locations: _list(locations),
+          epiweeks: _list(epiweeks),
+        };
+        return _request("nidss_dengue", params);
+      },
+      /**
+       * Fetch NIDSS flu data
+       */
+      nidss_flu: (regions, epiweeks, issues, lag) => {
+        requireAll({ epiweeks, regions });
+        issuesOrLag(issues, lag);
+        const params = {
+          regions: _list(regions),
+          epiweeks: _list(epiweeks),
+          issues: _list(issues),
+          lag,
+        };
+        return _request("nidss_flu", params);
+      },
+      /**
+       * Fetch NoroSTAT data (point data, no min/max)
+       */
+      norostat: (auth, location, epiweeks) => {
+        requireAll({ auth, locations, epiweeks });
+        const params = {
+          auth,
+          location,
+          epiweeks: _list(epiweeks),
+        };
+        return _request("norostat", params);
+      },
+      /**
+       * Fetch Delphi's ILI nowcast
+       */
+      nowcast: (locations, epiweeks) => {
+        requireAll({ locations, epiweeks });
+        const params = {
+          locations: _list(locations),
+          epiweeks: _list(epiweeks),
+        };
+        return _request("nowcast", params);
+      },
+      /**
+       * Fetch Quidel data
+       */
+      paho_denque: (regions, epiweeks, issues, lag) => {
+        requireAll({ regions, epiweeks });
+        const params = {
+          epiweeks: _list(epiweeks),
+          regions: _list(regions),
+          issues: _list(issues),
+          lag,
+        };
+        return _request("paho_denque", params);
+      },
+      /**
+       * Fetch Quidel data
+       */
+      quidel: (auth, epiweeks, locations) => {
+        requireAll({ auth, locations, epiweeks });
+        const params = {
+          auth,
+          epiweeks: _list(epiweeks),
+          locations: _list(locations),
+        };
+        return _request("quidel", params);
+      },
+      /**
+       * Fetch Delphi's forecast
+       */
+      delphi: (system, epiweek) => {
+        requireAll({ system, epiweek });
+        const params = {
+          system,
+          epiweek,
+        };
+        return _request("delphi", params);
       },
 
       /**
-       * Lookup COVID hospitalization facility identifiers
+       * Fetch Delphi's digital surveillance sensors
        */
-      covid_hosp_facility_lookup: (state, ccn, city, zip, fips_code) => {
-        const params = {};
-        if (state != null) {
-          params.state = state;
-        } else if (ccn != null) {
-          params.ccn = ccn;
-        } else if (city != null) {
-          params.city = city;
-        } else if (zip != null) {
-          params.zip = zip;
-        } else if (fips_code != null) {
-          params.fips_code = fips_code;
-        } else {
-          throw new Error(
-            "one of `state`, `ccn`, `city`, `zip`, or `fips_code` is required"
-          );
-        }
-        return _request("covid_hosp_facility", params);
+      sensors: (auth, names, locations, epiweeks) => {
+        requireAll({ auth, names, locations, epiweeks });
+        const params = {
+          auth,
+          names: _list(names),
+          locations: _list(locations),
+          epiweeks: _list(epiweeks),
+        };
+        return _request("sensors", params);
       },
-      withURL: createEpidataAsync,
+      /**
+       * Twitter data
+       */
+      twitter: (auth, locations, dates, epiweeks) => {
+        requireAll({ auth, locations });
+        if ((dates != null) !== (epiweeks != null)) {
+          throw new Error("one of `dates` and `epiweeks` are required");
+        }
+        const params = {
+          auth,
+          locations: _list(locations),
+          dates: _list(dates),
+          epiweeks: _list(epiweeks),
+        };
+        return _request("twitter", params);
+      },
+      /**
+       * Wikipedia data
+       */
+      wiki: (articles, dates, epiweeks, language) => {
+        requireAll({ articles });
+        if ((dates != null) !== (epiweeks != null)) {
+          throw new Error("one of `dates` and `epiweeks` are required");
+        }
+        const params = {
+          articles: _list(articles),
+          dates: _list(dates),
+          epiweeks: _list(epiweeks),
+          language,
+        };
+        return _request("wiki", params);
+      },
     };
   }
   exports.EpidataAsync = createEpidataAsync();

--- a/src/server/endpoints/wiki.py
+++ b/src/server/endpoints/wiki.py
@@ -10,11 +10,11 @@ alias = None
 
 @bp.route("/", methods=("GET", "POST"))
 def handle():
-    require_all("articles", "language")
+    require_all("articles")
     require_any("dates", "epiweeks")
 
     articles = extract_strings("articles")
-    language = request.values["language"]
+    language = request.values.get("language", "en")
     if "dates" in request.values:
         resolution = "daily"
         dates = extract_integers("dates")


### PR DESCRIPTION
except the signal_dashboard ... ones since they are more internal

added new endpoints
 * twitter
 * wiki
 * kcdc_ili

reordered the client to match the alphabetical order of the endpoints

plus: make the wiki language parameter optional similar to the R client