### PR TITLE
add a simple coverage endpoint

### DIFF
--- a/integrations/server/test_covidcast_endpoints.py
+++ b/integrations/server/test_covidcast_endpoints.py
@@ -363,10 +363,10 @@ class CovidcastEndpointTests(unittest.TestCase):
             self.assertEqual(len(out), 0)
 
     def test_coverage(self):
-        """Request a signal the /meta endpoint."""
+        """Request a signal the /coverage endpoint."""
 
         num_geos_per_date = [10, 20, 30, 40, 44]
-        dates = [20200401 + i for i in range(num_geos_per_date)]
+        dates = [20200401 + i for i in range(len(num_geos_per_date))]
         rows = [CovidcastRow(time_value=dates[i], value=i, geo_value=str(geo_value)) for i, num_geo in enumerate(num_geos_per_date) for geo_value in range(num_geo)]
         self._insert_rows(rows)
 

--- a/integrations/server/test_covidcast_endpoints.py
+++ b/integrations/server/test_covidcast_endpoints.py
@@ -369,18 +369,20 @@ class CovidcastEndpointTests(unittest.TestCase):
         dates = [20200401 + i for i in range(len(num_geos_per_date))]
         rows = [CovidcastRow(time_value=dates[i], value=i, geo_value=str(geo_value)) for i, num_geo in enumerate(num_geos_per_date) for geo_value in range(num_geo)]
         self._insert_rows(rows)
+        first = rows[0]
 
         with self.subTest("default"):
-            out = self._fetch("/coverage")
+            out = self._fetch("/coverage", signal=first.signal_pair, latest=dates[-1], format="json")
             self.assertEqual(len(out), len(num_geos_per_date))
             self.assertEqual([o["time_value"] for o in out], dates)
             self.assertEqual([o["count"] for o in out], num_geos_per_date)
 
         with self.subTest("specify window"):
-            out = self._fetch("/coverage", window="20200401-20200402")
+            out = self._fetch("/coverage", signal=first.signal_pair, window=f"{dates[0]}-{dates[1]}", format="json")
             self.assertEqual(len(out), 2)
             self.assertEqual([o["time_value"] for o in out], dates[:2])
             self.assertEqual([o["count"] for o in out], num_geos_per_date[:2])
+
         with self.subTest("invalid geo_type"):
-            out = self._fetch("/coverage", geo_type="state")
+            out = self._fetch("/coverage", signal=first.signal_pair, geo_type="state", format="json")
             self.assertEqual(len(out), 0)

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -506,7 +506,10 @@ def handle_coverage():
         time_window = parse_day_range_arg("window")
     else:
         now = date.today()
-        time_window = (date_to_time_value(now - timedelta(days=30)), date_to_time_value(now))
+        last = extract_integer("days")
+        if last is None:
+            last = 30
+        time_window = (date_to_time_value(now - timedelta(days=last)), date_to_time_value(now))
 
     q = QueryBuilder("covidcast", "c")
     q.fields = ["c.time_value", "count(c.geo_value) as count"]

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -34,7 +34,7 @@ from .._validate import (
 from .._db import sql_table_has_columns
 from .._pandas import as_pandas
 from .covidcast_utils import compute_trend, compute_trends, compute_correlations, compute_trend_value, CovidcastMetaEntry, AllSignalsMap
-from ..utils import shift_time_value, date_to_time_value, time_value_to_iso
+from ..utils import shift_time_value, date_to_time_value, time_value_to_iso, time_value_to_date
 
 # first argument is the endpoint name
 bp = Blueprint("covidcast", __name__)
@@ -505,7 +505,8 @@ def handle_coverage():
     if "window" in request.values:
         time_window = parse_day_range_arg("window")
     else:
-        now = date.today()
+        now_time = extract_date("latest")
+        now = date.today() if now_time is None else time_value_to_date(now_time)
         last = extract_integer("days")
         if last is None:
             last = 30


### PR DESCRIPTION
e.g. `/covidcast/coverage?signal=fb-survey:smoothed_cli&geo_type=state&days=20` would return the state count between today and the last 20 days.

![image](https://user-images.githubusercontent.com/4129778/121709409-d0d07080-cad8-11eb-8658-5954c0b373ec.png)

params
 * `days=<int>` optional number of days back, default = 30
 * `latest=YYYYMMDD` optional latest day, default = today
 * `geo_type=only-county` special county geo_type which filters out mega counties
 * `window=YYYYMMDD-YYYYMMDD` specify the time window to return the coverage for