### PR TITLE
Use `match.arg` on covidcast endpoint `format` argument in R client

### DIFF
--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -519,6 +519,7 @@ Epidata <- (function() {
     if(!missing(issues) && !missing(lag)) {
       stop('`issues` and `lag` are mutually exclusive')
     }
+    format <- match.arg(format)
     # Set up request
     params <- list(
       endpoint = 'covidcast',


### PR DESCRIPTION
Make `Epidata$covidcast` work using the default `format` argument, and make it reject unrecognized `format` arguments.

Note that this approach will require keeping the format default arg up to date with all valid options; if an additional format possibility is added but the default arg is not updated, then users attempting to use this formatting option will encounter an error message.

---

Before: default format arg produces error

```
> Epidata$covidcast("jhu-csse","confirmed_incidence_num","day","state","20210101","az")

Error in vapply(elements, encode, character(1)) :
  values must be length 1,
 but FUN(X[[7]]) result is length 2
```

Before: bogus format arg produces output

```
> Epidata$covidcast("jhu-csse","confirmed_incidence_num","day","state","20210101","az",format="bogus")

[Produces "classic"-formatted response.]
```

---

After: default format arg produces "classic" output

```
> Epidata$covidcast("jhu-csse","confirmed_incidence_num","day","state","20210101","az")

[Produces "classic"-formatted response.]
```

After: unrecognized format arg produces error message

```
> Epidata$covidcast("jhu-csse","confirmed_incidence_num","day","state","20210101","az",format="bogus")

Error in match.arg(format) : 'arg' should be one of “classic”, “tree”
```