### PR TITLE
Revert "add minimum issue date to the metadata with some tests(merge to dev)"

### DIFF
--- a/integrations/acquisition/covidcast/test_covidcast_meta_caching.py
+++ b/integrations/acquisition/covidcast/test_covidcast_meta_caching.py
@@ -67,24 +67,14 @@ class CovidcastMetaCacheTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'state', 20200422, 'pa',
           123, 1, 2, 3, 456, 1, 20200422, 0, 1, False, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}),
         (0, 'src', 'sig', 'day', 'state', 20200422, 'wa',
           789, 1, 2, 3, 456, 1, 20200423, 1, 1, False, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING})
     ''')
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (100, 'src', 'wip_sig', 'day', 'state', 20200422, 'pa',
           456, 4, 5, 6, 789, -1, 20200422, 0, 1, True, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING})
     ''')
@@ -112,7 +102,6 @@ class CovidcastMetaCacheTests(unittest.TestCase):
         'mean_value': 1,
         'stdev_value': 0,
         'max_issue': 20200423,
-        'min_issue': 20200422,
         'min_lag': 0,
         'max_lag': 1,
       }

--- a/integrations/acquisition/covidcast/test_fill_is_latest_issue.py
+++ b/integrations/acquisition/covidcast/test_fill_is_latest_issue.py
@@ -58,12 +58,7 @@ class FillIsLatestIssueTests(unittest.TestCase):
     # direction, issue, lag, is_latest_issue, is_wip, missing_value, missing_stderr, missing_sample_size)
 
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'state', 20200228, 'ca',
           123, 2, 5, 5, 5, NULL, 20200228, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}),

--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -67,12 +67,7 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
           123, 1.5, 2.5, 3.5, 456, 4, 20200414, 0, 0, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}),
@@ -336,12 +331,7 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '11111',
           123, 10, 11, 12, 456, 13, 20200414, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}),
@@ -442,12 +432,7 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
           123, 1.5, 2.5, 3.5, 456, 4, 20200414, 0, 0, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}),
@@ -577,12 +562,7 @@ class DelphiEpidataPythonClientTests(unittest.TestCase):
   def test_async_epidata(self):
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '11111',
           123, 10, 11, 12, 456, 13, 20200414, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}),

--- a/integrations/server/test_covidcast.py
+++ b/integrations/server/test_covidcast.py
@@ -45,12 +45,7 @@ class CovidcastTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
           123, 1.5, 2.5, 3.5, 456, 4, 20200414, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING})
@@ -97,12 +92,7 @@ class CovidcastTests(unittest.TestCase):
 
   #   # insert dummy data
   #   self.cur.execute(f'''
-  #   INSERT INTO
-  #      `covidcast` (`id`, `source`, `signal`, `time_type`, 
-  #      `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-  #      `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-  #      `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-  #    VALUES
+  #     insert into covidcast values
   #       (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
   #         123, 1.5, 2.5, 3.5, 456, 4, 20200414, 0, 1, False,
   #         {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING})
@@ -139,12 +129,7 @@ class CovidcastTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
           123, 1.5, 2.5, 3.5, 456, 4, 20200414, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING})
@@ -178,12 +163,7 @@ class CovidcastTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
           123, 1.5, 2.5, 3.5, 456, 4, 20200414, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING})
@@ -225,12 +205,7 @@ class CovidcastTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
           123, 1.5, 2.5, 3.5, 456, 4, 20200414, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING})
@@ -351,12 +326,7 @@ class CovidcastTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '11111',
           123, 10, 11, 12, 456, 13, 20200414, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}),
@@ -444,12 +414,7 @@ class CovidcastTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '11111',
           123, 10, 11, 12, 456, 13, 20200414, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}),
@@ -565,12 +530,7 @@ class CovidcastTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200411, '01234',
           123, 10, 11, 12, 456, 13, 20200413, 2, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}),
@@ -658,12 +618,7 @@ class CovidcastTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
           0, 0, 0, 0, 0, 0, 20200414, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING})
@@ -673,12 +628,7 @@ class CovidcastTests(unittest.TestCase):
     # fail to insert different dummy data under the same key
     with self.assertRaises(mysql.connector.errors.IntegrityError):
       self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+        insert into covidcast values
           (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
             1, 1, 1, 1, 1, 1, 20200414, 0, 1, False,
             {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING})
@@ -686,12 +636,7 @@ class CovidcastTests(unittest.TestCase):
 
     # succeed to insert different dummy data under a different issue
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
           1, 1, 1, 1, 1, 1, 20200415, 1, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING})
@@ -702,12 +647,7 @@ class CovidcastTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'day', 'county', 20200414, '01234',
           123, 0.123, NULL, NULL, 456, NULL, 20200414, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.OTHER}, {Nans.OTHER})
@@ -753,12 +693,7 @@ class CovidcastTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, 'src', 'sig', 'hour', 'state', 2020041714, 'vi',
           123, 10, 11, 12, 456, 13, 2020041714, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}),
@@ -815,12 +750,7 @@ class CovidcastTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute(f'''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
       (0, 'src', 'sig', 'day', 'county', 20200411, '01234',
           123, 10, 11, 12, 456, 13, 20200413, 0, 1, False,
           {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}),

--- a/integrations/server/test_covidcast_endpoints.py
+++ b/integrations/server/test_covidcast_endpoints.py
@@ -127,12 +127,7 @@ class CovidcastEndpointTests(unittest.TestCase):
         sql = ",\n".join((str(r) for r in rows))
         self.cur.execute(
             f"""
-            INSERT INTO
-                `covidcast` (`id`, `source`, `signal`, `time_type`, 
-                `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-                `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-                `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-            VALUES
+            insert into covidcast values
             {sql}
             """
         )

--- a/integrations/server/test_covidcast_meta.py
+++ b/integrations/server/test_covidcast_meta.py
@@ -47,12 +47,7 @@ class CovidcastMetaTests(unittest.TestCase):
 
     # insert dummy data and accumulate expected results (in sort order)
     template = '''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, "%s", "%s", "%s", "%s", %d, "%s", 123,
         %d, 0, 0, 456, 0, %d, 0, 1, %d, %d, %d, %d)
     '''
@@ -105,12 +100,7 @@ class CovidcastMetaTests(unittest.TestCase):
 
     # insert dummy data and accumulate expected results (in sort order)
     template = '''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, "%s", "%s", "%s", "%s", %d, "%s", 123,
         %d, 0, 0, 456, 0, %d, 0, 1, %d, %d, %d, %d)
     '''
@@ -228,12 +218,7 @@ class CovidcastMetaTests(unittest.TestCase):
 
     # insert dummy data and accumulate expected results (in sort order)
     template = '''
-      INSERT INTO
-        `covidcast` (`id`, `source`, `signal`, `time_type`, 
-        `geo_type`, `time_value`, `geo_value`, `value_updated_timestamp`, 
-        `value`, `stderr`, `sample_size`, `direction_updated_timestamp`, 
-        `direction`, `issue`, `lag`, `is_latest_issue`, `is_wip`) 
-      VALUES
+      insert into covidcast values
         (0, "%s", "%s", "%s", "%s", %d, "%s", 123,
         %d, 0, 0, 456, 0, %d, 0, 1, %d, %d, %d, %d)
     '''

--- a/integrations/server/test_fluview.py
+++ b/integrations/server/test_fluview.py
@@ -48,11 +48,7 @@ class FluviewTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute('''
-      INSERT INTO 
-        `fluview` (`id`, `release_date`, `issue`, `epiweek`, `region`, 
-        `lag`, `num_ili`, `num_patients`, `num_providers`, `wili`, `ili`, 
-        `num_age_0`, `num_age_1`, `num_age_2`, `num_age_3`, `num_age_4`, `num_age_5`)
-      VALUES
+      insert into fluview values
         (0, "2020-04-07", 202021, 202020, "nat", 1, 2, 3, 4, 3.14159, 1.41421,
         10, 11, 12, 13, 14, 15)
     ''')

--- a/integrations/server/test_fluview_meta.py
+++ b/integrations/server/test_fluview_meta.py
@@ -48,11 +48,7 @@ class FluviewMetaTests(unittest.TestCase):
 
     # insert dummy data
     self.cur.execute('''
-      INSERT INTO 
-        `fluview` (`id`, `release_date`, `issue`, `epiweek`, `region`, 
-        `lag`, `num_ili`, `num_patients`, `num_providers`, `wili`, `ili`, 
-        `num_age_0`, `num_age_1`, `num_age_2`, `num_age_3`, `num_age_4`, `num_age_5`)
-      VALUES
+      insert into fluview values
         (0, "2020-04-07", 202021, 202020, "nat", 1, 2, 3, 4, 3.14159, 1.41421,
           10, 11, 12, 13, 14, 15),
         (0, "2020-04-28", 202022, 202022, "hhs1", 5, 6, 7, 8, 1.11111, 2.22222,

--- a/src/acquisition/covidcast/database.py
+++ b/src/acquisition/covidcast/database.py
@@ -16,6 +16,7 @@ from multiprocessing import cpu_count
 # first party
 import delphi.operations.secrets as secrets
 
+
 class CovidcastRow():
   """A container for all the values of a single covidcast row."""
 
@@ -297,24 +298,6 @@ class Database:
       ORDER BY
         `time_type` ASC,
         `geo_type` ASC
-      
-      UNION
-
-      SELECT
-        `time_type`,
-        `geo_type`.
-        MIN(`issue`) as `min_issue`
-      FROM 
-        `{table_name}`
-      WHERE
-        `source` = %s AND
-        `signal` = %s AND
-      GROUP BY
-        `time_type`,
-        `geo_type`
-      ORDER BY
-        `time_type` ASC,
-        `geo_type`  ASC
       '''
 
     meta = []


### PR DESCRIPTION
Reverts cmu-delphi/delphi-epidata#574, which included some untested changes. Normally we'd fix those in a new PR, but we need to do a release this morning, so i'm taking the quick-but-rude option, sorry about that