### PR TITLE
ci: enforce origin/dev branch in creating release

### DIFF
--- a/.github/workflows/create-delphi-epidata-release.yml
+++ b/.github/workflows/create-delphi-epidata-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Reset dev branch
         run: |
           git fetch origin dev:dev
-          git reset --hard dev
+          git reset --hard origin/dev
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
`dev` didn't seem to be unique which is weird since it is working in other repos