### PR TITLE
Hotfix: Drop outdated tasks from deploy.json

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -11,36 +11,9 @@
 
     "// client - API",
     {
-      "type": "minimize-js",
-      "src": "src/client/delphi_epidata.js",
-      "dst": "src/client/delphi_epidata.min.js"
-    },
-    {
       "type": "copy",
       "src": "src/client/delphi_epidata.py",
       "dst": "[[package]]/client/delphi_epidata.py",
-      "add-header-comment": true
-    },
-    {
-      "type": "move",
-      "src": "src/client/",
-      "dst": "[[root_web]]/lib/",
-      "match": "^delphi_epidata.*\\.(js|py|coffee|R)$",
-      "add-header-comment": true
-    },
-
-    "// server - API (note: glob doesn't include dotfiles)",
-    {
-      "type": "move",
-      "src": "src/server/",
-      "dst": "[[root_web]]",
-      "match": "^.*\\.(html|php)$",
-      "add-header-comment": true
-    },
-    {
-      "type": "move",
-      "src": "src/server/.htaccess",
-      "dst": "[[root_web]]/.htaccess",
       "add-header-comment": true
     },
 


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [ ] Code is cleaned up and formatted

### Summary

Server is now containerized, so we don't need to do minification or any of the root_web stuff from github-deploy-repo anymore
