### PR TITLE
ci: add release helper

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,24 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "enhancement"
+      - "feature"
+  - title: "🐛 Bugs Fixes"
+    labels:
+      - "bug"
+  - title: "📕 Documentation"
+    labels:
+      - "documentation"
+  - title: "🧰 Development"
+    labels:
+      - "chore"
+      - "documentation"
+      - "dependencies"
+change-template: "- #$NUMBER $TITLE"
+change-title-escapes: '\<*_&`#@'
+template: |
+  $CHANGES
+
+  Thanks to $CONTRIBUTORS

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,13 +1,19 @@
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 categories:
-  - title: "🚀 Features"
+  - title: "🚀 API Changes"
     labels:
-      - "enhancement"
-      - "feature"
-  - title: "🐛 Bugs Fixes"
+      - "api change"
+  - title: "🚀 Python Client Changes"
     labels:
-      - "bug"
+      - "python client"
+  - title: "🚀 R Client Changes"
+    labels:
+      - "r client"
+  - title: "🚀 JavaScript Client Changes"
+    labels:
+      - "js client"
+      - "javascript"
   - title: "📕 Documentation"
     labels:
       - "documentation"
@@ -16,6 +22,7 @@ categories:
       - "chore"
       - "documentation"
       - "dependencies"
+      - "acquisition"
 change-template: "- #$NUMBER $TITLE"
 change-title-escapes: '\<*_&`#@'
 template: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,4 @@
-name: Create Delphi Epidata Release
+name: Create Release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-helper.yml
+++ b/.github/workflows/release-helper.yml
@@ -79,7 +79,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.DELPHI_PYPI_PROD_TOKEN }}
           packages_dir: src/client/packaging/pypi/dist/
           skip_existing: true
           # repository_url: https://test.pypi.org/legacy/
@@ -121,7 +121,7 @@ jobs:
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v1
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          token: ${{ secrets.DELPHI_NPM_TOKEN }}
           package: src/client/packaging/npm/package.json
           access: public
           check-version: true

--- a/.github/workflows/release-helper.yml
+++ b/.github/workflows/release-helper.yml
@@ -1,0 +1,153 @@
+name: Release Helper
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  correct_repository:
+    runs-on: ubuntu-latest
+    steps:
+      - name: fail on fork
+        if: github.repository_owner != 'cmu-delphi'
+        run: exit 1
+
+  create_release:
+    needs: correct_repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_SSH }}
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Extract version
+        id: extract_version
+        run: |
+          python -m pip install bump2version
+          echo -n "::set-output name=version::"
+          bump2version --dry-run --list patch | grep ^current_version | sed -r s,"^.*=",,
+      - name: Create Release
+        id: create_release
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: ${{ steps.extract_version.outputs.version }}
+          publish: true
+    outputs:
+      version: ${{ steps.extract_version.outputs.version }}
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      tag_name: ${{ steps.create_release.outputs.tag_name }}
+
+  release_python_client:
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel twine
+      - name: Prepare package
+        run: |
+          cp src/client/*.py src/client/packaging/pypi/delphi_epidata/
+      - name: Create release
+        working-directory: src/client/packaging/pypi
+        run: |
+          python setup.py sdist bdist_wheel
+      - uses: actions/upload-artifact@v2
+        with:
+          name: delphi_epidata_py
+          path: src/client/packaging/pypi/dist/*.tar.gz
+      - name: Upload Release Asset
+        uses: AButler/upload-release-assets@v2.0
+        with:
+          files: "src/client/packaging/pypi/dist/*.tar.gz"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          release-tag: ${{ needs.create_release.outputs.tag_name }}
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: src/client/packaging/pypi/dist/
+          skip_existing: true
+          # repository_url: https://test.pypi.org/legacy/
+
+  release_js_client:
+    needs: create_release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/client/packaging/npm
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.OS }}-node2-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node2-
+      - run: npm ci
+      - run: npm test
+      - run: npm pack
+      - name: Rename to a different name
+        run: for f in *.tgz; do mv "$f" "$(echo "$f" | sed s/delphi_epidata-/delphi_epidata_js-/)"; done
+      - uses: actions/upload-artifact@v2
+        with:
+          name: delphi_epidata_js
+          path: src/client/packaging/npm/*.tgz
+      - name: Upload Release Asset
+        uses: AButler/upload-release-assets@v2.0
+        with:
+          files: "src/client/packaging/npm/*.tgz"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          release-tag: ${{ needs.create_release.outputs.tag_name }}
+      - name: Publish to NPM
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: src/client/packaging/npm/package.json
+          access: public
+          check-version: true
+
+  sync_dev:
+    needs: correct_repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          ref: dev
+          ssh-key: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_SSH }}
+      - name: Reset dev branch
+        run: |
+          git fetch origin main:main
+          git reset --hard main
+      - name: Create pull request into dev
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: bot/sync-main-dev
+          commit-message: "chore: sync main-dev"
+          base: dev
+          title: "chore: sync main->dev"
+          labels: chore
+          reviewers: krivard
+          assignees: krivard
+          body: |
+            Syncing Main->Dev.

--- a/src/client/packaging/npm/.gitignore
+++ b/src/client/packaging/npm/.gitignore
@@ -1,2 +1,3 @@
 /delphi_epidata.*
 /node_modules
+/*.tgz

--- a/src/client/packaging/npm/LICENSE
+++ b/src/client/packaging/npm/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 The Delphi Group at Carnegie Mellon University
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/client/packaging/npm/README.md
+++ b/src/client/packaging/npm/README.md
@@ -1,0 +1,6 @@
+# Delphi Epidata API Client
+
+This package provides a programmatic interface to
+[Delphi](https://delphi.cmu.edu/)'s epidemiological data ("epidata")
+API. Source code and usage information can be found at
+[https://github.com/cmu-delphi/delphi-epidata](https://github.com/cmu-delphi/delphi-epidata).

--- a/src/client/packaging/npm/package.json
+++ b/src/client/packaging/npm/package.json
@@ -3,9 +3,22 @@
   "description": "Delphi Epidata API Client",
   "authors": "Delphi Group",
   "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/cmu-delphi/delphi-epidata",
+  "bugs": {
+    "url": "https://github.com/cmu-delphi/delphi-epidata/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cmu-delphi/delphi-epidata.git"
+  },
   "main": "delphi_epidata.js",
   "types": "delphi_epidata.d.ts",
   "browser": "delphi_epidata.js",
+  "files": [
+    "delphi_epidata.js",
+    "delphi_epidata.d.ts"
+  ],
   "scripts": {
     "prepack": "npx shx cp -f ../../delphi_epidata.js ../../delphi_epidata.d.ts ./",
     "test": "npm run prepack && jest"

--- a/src/client/packaging/pypi/.gitignore
+++ b/src/client/packaging/pypi/.gitignore
@@ -1,0 +1,6 @@
+delphi_epidata/*
+!delphi_epidata/__init__.py
+.eggs
+/build
+/dist
+/*.egg-info


### PR DESCRIPTION
for releasing to pypi and npm + sync dev/main

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

add a release helper workflow (pipeline) similar to www-main and others. steps taken

 * use release-drafter (like www-main) to create release notes and git tag
 * publish epidata client to PyPi -> requires `PYPI_API_TOKEN` secret
 * publish epidata JS client to NPM -> requires `NPM_TOKEN` secret -> do we have an account?
 * create a PR that merges the main back to dev

In addition, small tunings for the definition of the Epidata JS client