### PR TITLE
Update development guide to correct images

### DIFF
--- a/docs/epidata_development.md
+++ b/docs/epidata_development.md
@@ -82,8 +82,12 @@ From the root of your workspace, all of the images can be built as follows:
 docker build -t delphi_web \
   -f repos/delphi/operations/dev/docker/web/Dockerfile .
 
-docker build -t delphi_web_epidata \
-  -f repos/delphi/delphi-epidata/dev/docker/web/epidata/Dockerfile .
+docker build -t delphi_web_python \
+  -f repos/delphi/delphi-epidata/dev/docker/python/Dockerfile .
+
+cd ./repos/delphi/delphi-epidata
+docker build -t delphi_web_epidata -f ./devops/Dockerfile .
+cd ../../../
 
 docker build -t delphi_database \
   -f repos/delphi/operations/dev/docker/database/Dockerfile .

--- a/docs/epidata_development.md
+++ b/docs/epidata_development.md
@@ -85,9 +85,8 @@ docker build -t delphi_web \
 docker build -t delphi_web_python \
   -f repos/delphi/delphi-epidata/dev/docker/python/Dockerfile .
 
-cd ./repos/delphi/delphi-epidata
-docker build -t delphi_web_epidata -f ./devops/Dockerfile .
-cd ../../../
+docker build -t delphi_web_epidata \
+   -f repos/delphi/delphi-epidata/devops/Dockerfile .
 
 docker build -t delphi_database \
   -f repos/delphi/operations/dev/docker/database/Dockerfile .


### PR DESCRIPTION
Update development guide to use correct python images based on CI recipe

Edit: made the delphi_web_epidata image command more concise
