### PR TITLE
Update docs to refer to survey as COVID Trends and Impact Survey instead of COVID Symptom Survey

### DIFF
--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -1,10 +1,10 @@
 ---
-title: Symptom Surveys
+title: COVID Trends and Impact Survey
 parent: Data Sources and Signals
 grand_parent: COVIDcast Epidata API
 ---
 
-# Symptom Surveys
+# COVID Trends and Impact Survey
 {: .no_toc}
 
 * **Source name:** `fb-survey`
@@ -17,9 +17,10 @@ grand_parent: COVIDcast Epidata API
 
 ## Overview
 
-This data source is based on symptom surveys run by the Delphi group at Carnegie
-Mellon. Facebook directs a random sample of its users to these surveys, which
-are voluntary. Users age 18 or older are eligible to complete the surveys, and
+This data source is based on the [COVID Trends and Impact Survey
+(CTIS)](../../symptom-survey/) run by the Delphi group at Carnegie Mellon.
+Facebook directs a random sample of its users to these surveys, which are
+voluntary. Users age 18 or older are eligible to complete the surveys, and
 their survey responses are held by CMU and are sharable with other health
 researchers under a data use agreement. No individual survey responses are
 shared back to Facebook. See our [surveys
@@ -575,7 +576,7 @@ $$
 
 where $$\pi_i$$ is an estimated probability (produced by Facebook) that an
 individual with the same state-by-age-gender profile as user $$i$$ would be a
-Facebook user and take our CMU survey. The adjustment we make follows a standard
+Facebook user and take our survey. The adjustment we make follows a standard
 inverse probability weighting strategy (this being a special case of importance
 sampling).
 

--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -1,10 +1,10 @@
 ---
-title: COVID Trends and Impact Survey
+title: COVID-19 Trends and Impact Survey
 parent: Data Sources and Signals
 grand_parent: COVIDcast Epidata API
 ---
 
-# COVID Trends and Impact Survey
+# COVID-19 Trends and Impact Survey
 {: .no_toc}
 
 * **Source name:** `fb-survey`
@@ -17,7 +17,7 @@ grand_parent: COVIDcast Epidata API
 
 ## Overview
 
-This data source is based on the [COVID Trends and Impact Survey
+This data source is based on the [COVID-19 Trends and Impact Survey
 (CTIS)](../../symptom-survey/) run by the Delphi group at Carnegie Mellon.
 Facebook directs a random sample of its users to these surveys, which are
 voluntary. Users age 18 or older are eligible to complete the surveys, and

--- a/docs/symptom-survey/coding.md
+++ b/docs/symptom-survey/coding.md
@@ -7,9 +7,9 @@ nav_order: 6
 # Questions and Coding
 {: .no_toc}
 
-The surveys have been deployed in several waves. We have tried to ensure the
-coding of waves is consistent. This page provides the full survey text and
-coding schemes.
+The COVID-19 Trends and Impacts Survey (CTIS) has been deployed in several waves.
+We have tried to ensure the coding of waves is consistent. This page provides
+the full survey text and coding schemes.
 
 
 ## Table of contents
@@ -467,7 +467,7 @@ new items were meant to capture reasons for vaccine hesitancy among respondents.
   when you use responses from multiple waves of this survey, since they may
   shift which occupations respondents choose.
 * C14a is a revision of item C14, changed from "the past 5 days" to "the past
-  7 days" to be consistent with other items on the COVID Symptom Survey.
+  7 days" to be consistent with other items on CTIS.
   C14a replaces C14.
 * C17a is a revision of item C17, which asked respondents if they have had a
   flu vaccination since June 2020. C17a changed the date to July 1, 2020 and

--- a/docs/symptom-survey/coding.md
+++ b/docs/symptom-survey/coding.md
@@ -1,14 +1,14 @@
 ---
 title: Questions and Coding
-parent: COVID Symptom Survey
+parent: COVID Trends and Impact Survey
 nav_order: 6
 ---
 
 # Questions and Coding
 {: .no_toc}
 
-The symptom surveys have been deployed in several waves. We have tried to ensure
-the coding of waves is consistent. This page provides the full survey text and
+The surveys have been deployed in several waves. We have tried to ensure the
+coding of waves is consistent. This page provides the full survey text and
 coding schemes.
 
 

--- a/docs/symptom-survey/coding.md
+++ b/docs/symptom-survey/coding.md
@@ -1,6 +1,6 @@
 ---
 title: Questions and Coding
-parent: COVID Trends and Impact Survey
+parent: COVID-19 Trends and Impact Survey
 nav_order: 6
 ---
 

--- a/docs/symptom-survey/collaboration-revision.md
+++ b/docs/symptom-survey/collaboration-revision.md
@@ -18,7 +18,7 @@ If there is a revision or question you would like us to consider, please fill
 out [this form requesting details about your
 proposal](https://forms.gle/q6NS8fPJJofKQ9mM8). This request can be submitted by
 researchers regardless of whether they have a signed Data Use Agreement for the
-individual responses to the COVID Symptom Survey.
+individual responses to the COVID Trends and Impact Survey.
 
 ## Collaboration Meetings
 

--- a/docs/symptom-survey/collaboration-revision.md
+++ b/docs/symptom-survey/collaboration-revision.md
@@ -1,16 +1,16 @@
 ---
 title: Collaboration and Survey Revision
-parent: COVID Trends and Impact Survey
+parent: COVID-19 Trends and Impact Survey
 nav_order: 1
 ---
 
 # Collaboration and Survey Revision
 
-Delphi continues to revise the COVID Trends and Impact Survey (CTIS)
-instruments in order to prioritize items that have the greatest utility for
-the response to the COVID-19 pandemic. We conduct revisions in collaboration
-with data users, fellow researchers, and public health officials, to ensure
-the survey data best serves public health and research goals.
+Delphi continues to revise the COVID-19 Trends and Impact Survey (CTIS)
+instruments in order to prioritize items that have the greatest utility for the
+response to the COVID-19 pandemic. We conduct revisions in collaboration with
+data users, fellow researchers, and public health officials, to ensure the
+survey data best serves public health and research goals.
 
 ## Proposing Revisions
 
@@ -18,7 +18,7 @@ If there is a revision or question you would like us to consider, please fill
 out [this form requesting details about your
 proposal](https://forms.gle/q6NS8fPJJofKQ9mM8). This request can be submitted by
 researchers regardless of whether they have a signed Data Use Agreement for the
-individual responses to the COVID Trends and Impact Survey.
+individual responses to the COVID-19 Trends and Impact Survey.
 
 ## Collaboration Meetings
 

--- a/docs/symptom-survey/collaboration-revision.md
+++ b/docs/symptom-survey/collaboration-revision.md
@@ -1,16 +1,16 @@
 ---
 title: Collaboration and Survey Revision
-parent: COVID Symptom Survey
+parent: COVID Trends and Impact Survey
 nav_order: 1
 ---
 
 # Collaboration and Survey Revision
 
-Delphi continues to revise the COVID-19 Symptom Survey instruments in order to
-prioritize items that have the greatest utility for the response to the COVID-19
-pandemic. We conduct revisions in collaboration with data users, fellow
-researchers, and public health officials, to ensure the survey data best serves
-public health and research goals.
+Delphi continues to revise the COVID Trends and Impact Survey (CTIS)
+instruments in order to prioritize items that have the greatest utility for
+the response to the COVID-19 pandemic. We conduct revisions in collaboration
+with data users, fellow researchers, and public health officials, to ensure
+the survey data best serves public health and research goals.
 
 ## Proposing Revisions
 

--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -1,6 +1,6 @@
 ---
 title: Contingency Tables
-parent: COVID Symptom Survey
+parent: COVID Trends and Impact Survey
 nav_order: 4
 ---
 
@@ -8,7 +8,7 @@ nav_order: 4
 {: .no_toc}
 
 This documentation describes the fine-resolution contingency tables produced by
-grouping [COVID Symptom Survey](./index.md) individual responses by various
+grouping [COVID Trends and Impact Survey (CTIS)](./index.md) individual responses by various
 self-reported demographic features.
 
 * [Weekly files](https://www.cmu.edu/delphi-web/surveys/weekly-rollup/)
@@ -119,6 +119,7 @@ Within a CSV, the first few columns store metadata of the aggregation:
 | `ISO_3` | Three-letter ISO country code ("USA") |
 | `GID_0` | GADM level 0 ID |
 | `state` | State name; "Overall" if aggregation not grouped at the state level |
+| `GID_1` | GADM level 1 ID |
 | `state_fips` | State FIPS code; `NA` if aggregation not grouped at the state level |
 | `county` | County name; "Overall" if aggregation not grouped at the county level |
 | `county_fips` | County FIPS code; `NA` if aggregation not grouped at the county level |

--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -1,6 +1,6 @@
 ---
 title: Contingency Tables
-parent: COVID Trends and Impact Survey
+parent: COVID-19 Trends and Impact Survey
 nav_order: 4
 ---
 
@@ -8,7 +8,7 @@ nav_order: 4
 {: .no_toc}
 
 This documentation describes the fine-resolution contingency tables produced by
-grouping [COVID Trends and Impact Survey (CTIS)](./index.md) individual responses by various
+grouping [COVID-19 Trends and Impact Survey (CTIS)](./index.md) individual responses by various
 self-reported demographic features.
 
 * [Weekly files](https://www.cmu.edu/delphi-web/surveys/weekly-rollup/)

--- a/docs/symptom-survey/data-access.md
+++ b/docs/symptom-survey/data-access.md
@@ -1,13 +1,13 @@
 ---
 title: Getting Data Access
-parent: COVID Trends and Impact Survey
+parent: COVID-19 Trends and Impact Survey
 nav_order: 0
 ---
 
 # Getting Data Access
 
 The Delphi Research Group at Carnegie Mellon University (CMU), in partnership
-with Facebook, has conducted the COVID Trends and Impact Survey (CTIS) to
+with Facebook, has conducted the COVID-19 Trends and Impact Survey (CTIS) to
 better understand the spread of COVID-19 and its effects on public health and
 well-being. This may help improve our local and national responses to the
 pandemic and our understanding of how it has affected society.

--- a/docs/symptom-survey/data-access.md
+++ b/docs/symptom-survey/data-access.md
@@ -1,16 +1,16 @@
 ---
 title: Getting Data Access
-parent: COVID Symptom Survey
+parent: COVID Trends and Impact Survey
 nav_order: 0
 ---
 
 # Getting Data Access
 
 The Delphi Research Group at Carnegie Mellon University (CMU), in partnership
-with Facebook, has conducted the COVID Symptom Survey to better understand the
-spread of COVID-19 and its effects on public health and well-being. This may
-help improve our local and national responses to the pandemic and our
-understanding of how it has affected society.
+with Facebook, has conducted the COVID Trends and Impact Survey (CTIS) to
+better understand the spread of COVID-19 and its effects on public health and
+well-being. This may help improve our local and national responses to the
+pandemic and our understanding of how it has affected society.
 
 [High-level aggregates](../api/covidcast.md) of select survey items are
 publicly available in the [COVIDcast API](../api/covidcast-signals/fb-survey.md).
@@ -25,9 +25,9 @@ Agreement (DUA). To request access to the data please submit the information
 requested in [Facebook's page on obtaining data
 access](https://dataforgood.fb.com/docs/covid-19-symptom-survey-request-for-data-access/),
 which sets out the basic conditions and provides a form to request access. An
-[international version of the COVID Symptom Survey](https://covidmap.umd.edu/)
-is conducted by the University of Maryland (UMD) and access can be requested
-through the same form.
+[international version of CTIS](https://covidmap.umd.edu/) is conducted by the
+University of Maryland (UMD) and access can be requested through the same
+form.
 
 The United States survey protocol has been reviewed by the Carnegie Mellon
 University Institutional Review Board with IRB ID STUDY2020_00000162.

--- a/docs/symptom-survey/index.md
+++ b/docs/symptom-survey/index.md
@@ -6,7 +6,7 @@ nav_order: 2
 
 # COVID-19 Trends and Impact Survey
 
-Since April 2020, Delphi has conducted a voluntary COVID-19 symptom survey,
+Since April 2020, Delphi has conducted a voluntary survey about COVID-19,
 distributed daily to users in the United States via a partnership with Facebook.
 This survey asks respondents about COVID-like symptoms, their behavior (such as
 social distancing), mental health, and economic and health impacts they have

--- a/docs/symptom-survey/index.md
+++ b/docs/symptom-survey/index.md
@@ -1,10 +1,10 @@
 ---
-title: COVID Trends and Impact Survey
+title: COVID-19 Trends and Impact Survey
 has_children: true
 nav_order: 2
 ---
 
-# COVID Trends and Impact Survey
+# COVID-19 Trends and Impact Survey
 
 Since April 2020, Delphi has conducted a voluntary COVID-19 symptom survey,
 distributed daily to users in the United States via a partnership with Facebook.
@@ -29,7 +29,7 @@ If you have questions about the survey or getting access to data, contact us at
 
 ## Credits
 
-The COVID Trends and Impact Survey (CTIS) is a project of the [Delphi
+The COVID-19 Trends and Impact Survey (CTIS) is a project of the [Delphi
 Group](https://delphi.cmu.edu/) at Carnegie Mellon University. The Principal
 Investigator is [Alex Reinhart](https://www.refsmmat.com/); Wichada La
 Motte-Kerr is Survey Coordinator. The survey protocol is reviewed by the
@@ -59,7 +59,7 @@ the survey in publications based on the data. Specifically, we ask that you:
 2. Cite this web page for details about the survey. For example, you may cite it
    as
 
-    > Delphi Group (2021). COVID Trends and Impact Survey.
+    > Delphi Group (2021). COVID-19 Trends and Impact Survey.
     > <https://cmu-delphi.github.io/delphi-epidata/symptom-survey/>
 
     A journal article describing the survey and its methods is currently in

--- a/docs/symptom-survey/index.md
+++ b/docs/symptom-survey/index.md
@@ -81,7 +81,7 @@ When referring to the survey in text, we prefer the following formats:
   partnership with Facebook".
 * Short form (used after the long form has been introduced): "The U.S. COVID-19
   Trends and Impact Survey"
-* Acronym form: Delphi US CTIS
+* Acronym form: "Delphi US CTIS"
 
 Prior to July 2021, the survey was known as the COVID Symptom Survey (CSS), and
 some older documentation and publication may still refer to this name. We prefer

--- a/docs/symptom-survey/index.md
+++ b/docs/symptom-survey/index.md
@@ -1,10 +1,10 @@
 ---
-title: COVID Symptom Survey
+title: COVID Trends and Impact Survey
 has_children: true
 nav_order: 2
 ---
 
-# COVID Symptom Survey
+# COVID Trends and Impact Survey
 
 Since April 2020, Delphi has conducted a voluntary COVID-19 symptom survey,
 distributed daily to users in the United States via a partnership with Facebook.
@@ -29,7 +29,7 @@ If you have questions about the survey or getting access to data, contact us at
 
 ## Credits
 
-The COVID Symptom Survey is a project of the [Delphi
+The COVID Trends and Impact Survey (CTIS) is a project of the [Delphi
 Group](https://delphi.cmu.edu/) at Carnegie Mellon University. The Principal
 Investigator is [Alex Reinhart](https://www.refsmmat.com/); Wichada La
 Motte-Kerr is Survey Coordinator. The survey protocol is reviewed by the
@@ -59,7 +59,7 @@ the survey in publications based on the data. Specifically, we ask that you:
 2. Cite this web page for details about the survey. For example, you may cite it
    as
 
-    > Delphi Group (2021). COVID Symptom Survey.
+    > Delphi Group (2021). COVID Trends and Impact Survey.
     > <https://cmu-delphi.github.io/delphi-epidata/symptom-survey/>
 
     A journal article describing the survey and its methods is currently in

--- a/docs/symptom-survey/index.md
+++ b/docs/symptom-survey/index.md
@@ -65,12 +65,24 @@ the survey in publications based on the data. Specifically, we ask that you:
     A journal article describing the survey and its methods is currently in
     preparation, and we will update this page when it is available so that you
     can cite it instead.
-3. Send a copy of your publication, once it appears publicly as a preprint or
-   journal article, to <delphi-survey-info@lists.andrew.cmu.edu>.
+3. The data use agreement requires that if you disclose survey microdata, Delphi
+   must agree on the aggregation method that you will use to ensure reported
+   estimates do not disclose any individual identifiable information, including
+   individual survey results. If you are unsure whether a particular aggregation
+   will prevent disclosure of individual survey results, please email us at
+   <delphi-survey-info@lists.andrew.cmu.edu>.
+4. Finally, send a copy of your publication, once it appears publicly as a
+   preprint or journal article, to <delphi-survey-info@lists.andrew.cmu.edu>.
 
-Additionally, please note that the data use agreement requires that if you
-disclose survey microdata, Delphi must agree on the aggregation method that you
-will use to ensure reported estimates do not disclose any individual
-identifiable information, including individual survey results. If you are unsure
-whether a particular aggregation will prevent disclosure of individual survey
-results, please email us at <delphi-survey-info@lists.andrew.cmu.edu>.
+When referring to the survey in text, we prefer the following formats:
+
+* Long form (such as in an introduction or methods description): "The Delphi
+  Group at Carnegie Mellon University U.S. COVID-19 Trends and Impact Survey, in
+  partnership with Facebook".
+* Short form (used after the long form has been introduced): "The U.S. COVID-19
+  Trends and Impact Survey"
+* Acronym form: Delphi US CTIS
+
+Prior to July 2021, the survey was known as the COVID Symptom Survey (CSS), and
+some older documentation and publication may still refer to this name. We prefer
+that new publications and materials refer to the new name.

--- a/docs/symptom-survey/modules.md
+++ b/docs/symptom-survey/modules.md
@@ -1,17 +1,17 @@
 ---
 title: Survey Modules & Randomization
-parent: COVID Symptom Survey
+parent: COVID Trends and Impact Survey
 nav_order: 7
 ---
 
 # Questions and Coding
 {: .no_toc}
 
-To reduce the overall length of the instrument and minimize response burden, the
-COVID Symptom Survey will consist of a block of daily core questions and will
-use a randomized module approach for the other topics. Implementation of this
-approach started in [Wave 11](coding.md#wave-11), which launched on May 20,
-2021.
+To reduce the overall length of the instrument and minimize response burden,
+the COVID Trends and Impact Survey (CTIS) will consist of a block of daily
+core questions and will use a randomized module approach for the other topics.
+Implementation of this approach started in [Wave 11](coding.md#wave-11), which
+launched on May 20, 2021.
 
 Each respondent invited to take the survey will be asked the daily core
 questions. The daily core questions for Wave 11 include:

--- a/docs/symptom-survey/modules.md
+++ b/docs/symptom-survey/modules.md
@@ -1,6 +1,6 @@
 ---
 title: Survey Modules & Randomization
-parent: COVID Trends and Impact Survey
+parent: COVID-19 Trends and Impact Survey
 nav_order: 7
 ---
 
@@ -8,7 +8,7 @@ nav_order: 7
 {: .no_toc}
 
 To reduce the overall length of the instrument and minimize response burden,
-the COVID Trends and Impact Survey (CTIS) will consist of a block of daily
+the COVID-19 Trends and Impact Survey (CTIS) will consist of a block of daily
 core questions and will use a randomized module approach for the other topics.
 Implementation of this approach started in [Wave 11](coding.md#wave-11), which
 launched on May 20, 2021.

--- a/docs/symptom-survey/problems.md
+++ b/docs/symptom-survey/problems.md
@@ -1,13 +1,13 @@
 ---
 title: Problems and Data Errors
-parent: COVID Trends and Impact Survey
+parent: COVID-19 Trends and Impact Survey
 nav_order: 8
 ---
 
 # Problems and Data Errors
 {: .no_toc}
 
-Given the scale of the COVID Trends and Impact Survey (CTIS), we occasionally
+Given the scale of the COVID-19 Trends and Impact Survey (CTIS), we occasionally
 encounter data errors or survey implementation problems that affect the
 interpretation of results. All problems will be logged here.
 

--- a/docs/symptom-survey/problems.md
+++ b/docs/symptom-survey/problems.md
@@ -1,15 +1,15 @@
 ---
 title: Problems and Data Errors
-parent: COVID Symptom Survey
+parent: COVID Trends and Impact Survey
 nav_order: 8
 ---
 
 # Problems and Data Errors
 {: .no_toc}
 
-Given the scale of the COVID Symptom Survey, we occasionally encounter data
-errors or survey implementation problems that affect the interpretation of
-results. All problems will be logged here.
+Given the scale of the COVID Trends and Impact Survey (CTIS), we occasionally
+encounter data errors or survey implementation problems that affect the
+interpretation of results. All problems will be logged here.
 
 ## Table of contents
 {: .no_toc .text-delta}

--- a/docs/symptom-survey/server-access.md
+++ b/docs/symptom-survey/server-access.md
@@ -1,15 +1,16 @@
 ---
 title: SFTP Server Access
-parent: COVID Symptom Survey
+parent: COVID Trends and Impact Survey
 nav_order: 2
 ---
 
 # SFTP Server Access
 
-Researchers with data use agreements to access the raw data from the COVID-19
-symptom survey can access the data over SFTP. (If you do not have a data use
-agreement, see the [main survey page](index.md) for information about getting
-access and about aggregate data that is available for public download.)
+Researchers with data use agreements to access the raw data from the COVID
+Trends and Impact Survey (CTIS) can access the data over SFTP. (If you do not
+have a data use agreement, see the [main survey page](index.md) for
+information about getting access and about aggregate data that is available
+for public download.)
 
 If you're not familiar with SFTP, it is a protocol for securely accessing and downloading
 large amounts of data from remote servers. The instructions below explain how to

--- a/docs/symptom-survey/server-access.md
+++ b/docs/symptom-survey/server-access.md
@@ -1,12 +1,12 @@
 ---
 title: SFTP Server Access
-parent: COVID Trends and Impact Survey
+parent: COVID-19 Trends and Impact Survey
 nav_order: 2
 ---
 
 # SFTP Server Access
 
-Researchers with data use agreements to access the raw data from the COVID
+Researchers with data use agreements to access the raw data from the COVID-19
 Trends and Impact Survey (CTIS) can access the data over SFTP. (If you do not
 have a data use agreement, see the [main survey page](index.md) for
 information about getting access and about aggregate data that is available

--- a/docs/symptom-survey/survey-files.md
+++ b/docs/symptom-survey/survey-files.md
@@ -1,16 +1,17 @@
 ---
 title: Response Files
-parent: COVID Symptom Survey
+parent: COVID Trends and Impact Survey (CTIS)
 nav_order: 3
 ---
 
 # Response Files
 {: .no_toc}
 
-Users with access to the [COVID Symptom Survey](./index.md) individual response
-data should have received SFTP credentials for a private server where the data
-are stored. To connect to the server, see the [server access documentation](server-access.md).
-This documentation describes the survey data available on that server.
+Users with access to the [COVID Trends and Impact Survey (CTIS)](./index.md)
+individual response data should have received SFTP credentials for a private
+server where the data are stored. To connect to the server, see the [server
+access documentation](server-access.md). This documentation describes the
+survey data available on that server.
 
 You must sign a Data Use Agreement with Facebook and with CMU to gain
 access to the individual survey responses. If you have not done so, aggregate

--- a/docs/symptom-survey/survey-files.md
+++ b/docs/symptom-survey/survey-files.md
@@ -1,13 +1,13 @@
 ---
 title: Response Files
-parent: COVID Trends and Impact Survey (CTIS)
+parent: COVID-19 Trends and Impact Survey (CTIS)
 nav_order: 3
 ---
 
 # Response Files
 {: .no_toc}
 
-Users with access to the [COVID Trends and Impact Survey (CTIS)](./index.md)
+Users with access to the [COVID-19 Trends and Impact Survey (CTIS)](./index.md)
 individual response data should have received SFTP credentials for a private
 server where the data are stored. To connect to the server, see the [server
 access documentation](server-access.md). This documentation describes the

--- a/docs/symptom-survey/weights.md
+++ b/docs/symptom-survey/weights.md
@@ -1,15 +1,16 @@
 ---
 title: Survey Weights
-parent: COVID Symptom Survey
+parent: COVID Trends and Impact Survey
 nav_order: 5
 ---
 
 # Survey Weights
 {: .no_toc}
 
-The symptom survey individual response files contain survey weights calculated
-by Facebook. These weights are also used to produce our [public contingency tables](contingency-tables.md)
-and the geographic aggregates [in the COVIDcast Epidata API](../api/covidcast-signals/fb-survey.md).
+The survey's individual response files contain respondent weights calculated
+by Facebook. These weights are also used to produce our [public contingency
+tables](contingency-tables.md) and the geographic aggregates [in the COVIDcast
+Epidata API](../api/covidcast-signals/fb-survey.md).
 
 Facebook has provided documentation to describe the calculation and usage of
 these weights, [available here](symptom-survey-weights.pdf). This documentation

--- a/docs/symptom-survey/weights.md
+++ b/docs/symptom-survey/weights.md
@@ -1,6 +1,6 @@
 ---
 title: Survey Weights
-parent: COVID Trends and Impact Survey
+parent: COVID-19 Trends and Impact Survey
 nav_order: 5
 ---
 


### PR DESCRIPTION
### Summary
Change survey name from COVID Symptom Survey to COVID-19 Trends and Impact Survey. Wait to merge until the official name change date, July 9.

### Changes
- Switch all doc references to use "COVID-19 Trends and Impact Survey".
- Switch docs API menu name from "Symptom Survey" to "COVID-19 Trends and Impact Survey"
- Switch docs survey menu name from "COVID Symptom Survey" to "COVID-19 Trends and Impact Survey"

**Pending** We also need to change the link to FB's data access form once they do the survey name update on their end. Timeline is TBD, so that will happen in a separate PR.