### PR TITLE
Fix broken links in survey docs

### DIFF
--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -249,8 +249,7 @@ please contact us at <delphi-survey-info@lists.andrew.cmu.edu>.
 
 ### Reasons for Hesitancy
 
-The set of "barrier" items correspond to the set of ["hesitancy_reasons" items
-in the API](../api/covidcast-signals/fb-survey.md#reasons-for-hesitancy).
+The set of "barrier" items correspond to the set of ["hesitancy_reasons" items in the API](../api/covidcast-signals/fb-survey.md#reasons-for-hesitancy).
 
 | Indicator | Description | Survey Item |
 | --- | --- | --- |

--- a/docs/symptom-survey/survey-files.md
+++ b/docs/symptom-survey/survey-files.md
@@ -1,6 +1,6 @@
 ---
 title: Response Files
-parent: COVID-19 Trends and Impact Survey (CTIS)
+parent: COVID-19 Trends and Impact Survey
 nav_order: 3
 ---
 
@@ -9,8 +9,8 @@ nav_order: 3
 
 Users with access to the [COVID-19 Trends and Impact Survey (CTIS)](./index.md)
 individual response data should have received SFTP credentials for a private
-server where the data are stored. To connect to the server, see the [server
-access documentation](server-access.md). This documentation describes the
+server where the data are stored. To connect to the server, see the [server access documentation](
+server-access.md). This documentation describes the
 survey data available on that server.
 
 You must sign a Data Use Agreement with Facebook and with CMU to gain
@@ -43,8 +43,8 @@ Each day, we write CSV files with names following this pattern:
 
 Dates in incremental filenames are of the form `YYYY_mm_dd`. `for` refers to the
 day the survey response was started, in the Pacific time zone (UTC -
-7). `recorded` refers to the day survey data was retrieved; see the [lag
-policy](#lag-policy) for more details. Each file is compressed with gzip, and
+7). `recorded` refers to the day survey data was retrieved; see the [lag policy](
+#lag-policy) for more details. Each file is compressed with gzip, and
 the standard `gunzip` command on Linux or Mac can decompress it.
 
 Every day, we write response files for all recent days of data, with today's

--- a/docs/symptom-survey/survey-files.md
+++ b/docs/symptom-survey/survey-files.md
@@ -9,8 +9,8 @@ nav_order: 3
 
 Users with access to the [COVID-19 Trends and Impact Survey (CTIS)](./index.md)
 individual response data should have received SFTP credentials for a private
-server where the data are stored. To connect to the server, see the [server access documentation](
-server-access.md). This documentation describes the
+server where the data are stored. To connect to the server, see the 
+[server access documentation](server-access.md). This documentation describes the
 survey data available on that server.
 
 You must sign a Data Use Agreement with Facebook and with CMU to gain
@@ -43,8 +43,8 @@ Each day, we write CSV files with names following this pattern:
 
 Dates in incremental filenames are of the form `YYYY_mm_dd`. `for` refers to the
 day the survey response was started, in the Pacific time zone (UTC -
-7). `recorded` refers to the day survey data was retrieved; see the [lag policy](
-#lag-policy) for more details. Each file is compressed with gzip, and
+7). `recorded` refers to the day survey data was retrieved; see the 
+[lag policy](#lag-policy) for more details. Each file is compressed with gzip, and
 the standard `gunzip` command on Linux or Mac can decompress it.
 
 Every day, we write response files for all recent days of data, with today's

--- a/docs/symptom-survey/weights.md
+++ b/docs/symptom-survey/weights.md
@@ -8,9 +8,9 @@ nav_order: 5
 {: .no_toc}
 
 The survey's individual response files contain respondent weights calculated
-by Facebook. These weights are also used to produce our [public contingency
-tables](contingency-tables.md) and the geographic aggregates [in the COVIDcast
-Epidata API](../api/covidcast-signals/fb-survey.md).
+by Facebook. These weights are also used to produce our
+[public contingency tables](./contingency-tables.md) and the geographic aggregates
+[in the COVIDcast Epidata API](../api/covidcast-signals/fb-survey.md).
 
 Facebook has provided documentation to describe the calculation and usage of
 these weights, [available here](symptom-survey-weights.pdf). This documentation


### PR DESCRIPTION
### Summary
Fixes links broken due to inappropriately-placed whitespace. Microdata info page was not shown in sidebar after survey name change.

Fixes #626.