### PR TITLE
Increase gunicorn timeout

### DIFF
--- a/devops/gunicorn_conf.py
+++ b/devops/gunicorn_conf.py
@@ -29,6 +29,7 @@ loglevel = use_loglevel
 workers = web_concurrency
 bind = use_bind
 keepalive = 120
+timeout = 300
 
 errorlog = "-"
 accesslog = "-"


### PR DESCRIPTION
**Prerequisites**:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [X] Build is successful
- [X] Code is cleaned up and formatted

### Summary

Increases gunicorn's worker timeout to 300s (5min).

It looks like the default of 30s is too short and workers were probably being
killed prematurely. My admittedly somewhat limited testing on a single instance
running a manually edited version of the config file suggests increasing the
timeout will help.