### PR TITLE
fix: lookup of meta data by alias

### DIFF
--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -548,7 +548,7 @@ def handle_meta():
                 continue
             if filter_time_type is not None and signal.time_type != filter_time_type:
                 continue
-            meta_data = by_signal.get(signal.key)
+            meta_data = by_signal.get((source.db_source, signal.signal))
             if not meta_data:
                 continue
             row = meta_data[0]


### PR DESCRIPTION
closes the root cause of https://github.com/cmu-delphi/www-covidcast/issues/983

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

fixes the generation of the new meta data which was buggy for the db alias in the meta lookup

i.e. the reason why chng wasn't part of https://api.covidcast.cmu.edu/epidata/covidcast/meta