### PR TITLE
fix: handle cornercases where source is not transmitted for aliases

### DIFF
--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -160,10 +160,10 @@ def handle():
 
     _handle_lag_issues_as_of(q, issues, lag, as_of)
 
-    def transform_row(row, _):
-        if is_compatibility or not alias_mapper:
+    def transform_row(row, proxy):
+        if is_compatibility or not alias_mapper or 'source' not in row:
             return row
-        row["source"] = alias_mapper(row["source"], row["signal"])
+        row["source"] = alias_mapper(row["source"], proxy["signal"])
         return row
 
     # send query
@@ -608,10 +608,10 @@ def handle_coverage():
 
     _handle_lag_issues_as_of(q, None, None, None)
 
-    def transform_row(row, _):
-        if not alias_mapper:
+    def transform_row(row, proxy):
+        if not alias_mapper or 'source' not in row:
             return row
-        row["source"] = alias_mapper(row["source"], row["signal"])
+        row["source"] = alias_mapper(row["source"], proxy["signal"])
         return row
 
     return execute_query(q.query, q.params, fields_string, fields_int, [], transform=transform_row)


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

fix a cornercases in the alias resolver which didn't consider when the source is not about to be returned