### PR TITLE
Signals dash generator: store a longer time series by using covidcast/coverage endpoint

### DIFF
--- a/src/acquisition/covidcast/signal_dash_data_generator.py
+++ b/src/acquisition/covidcast/signal_dash_data_generator.py
@@ -18,7 +18,7 @@ import delphi.operations.secrets as secrets
 from delphi.epidata.acquisition.covidcast.logger import get_structured_logger
 
 
-LOOKBACK_DAYS_FOR_COVERAGE = 52
+LOOKBACK_DAYS_FOR_COVERAGE = 56
 BASE_COVIDCAST = covidcast.covidcast.Epidata.BASE_URL[:-len("api.php")] + "covidcast"
 COVERAGE_URL = f"{BASE_COVIDCAST}/coverage?format=csv&signal={{source}}:{{signal}}&days={LOOKBACK_DAYS_FOR_COVERAGE}"
 

--- a/tests/acquisition/covidcast/test_signal_dash_data_generator.py
+++ b/tests/acquisition/covidcast/test_signal_dash_data_generator.py
@@ -182,7 +182,8 @@ class UnitTests(unittest.TestCase):
         data_date = get_latest_time_value_from_metadata(signal, metadata)
         self.assertEqual(data_date, date(2021, 1, 1))
 
-    @patch("covidcast.signal")
+    #@patch("covidcast.signal")
+    @patch("pandas.read_csv")
     def test_get_coverage(self, mock_signal):
         signal = DashboardSignal(
             db_id=1, name="Change", source="chng",
@@ -198,18 +199,16 @@ class UnitTests(unittest.TestCase):
                 'signal'])
 
         epidata_data = [
-            ['chng', 'chng-sig', pd.Timestamp("2020-01-01"), "state", "PA"],
-            ['chng', 'chng-sig', pd.Timestamp("2020-01-01"), "state", "NY"],
-            ['chng', 'chng-sig', pd.Timestamp("2020-01-02"), "state", "NY"],
+            ['chng', 'chng-sig', 20200101, 2],
+            ['chng', 'chng-sig', 20200102, 1],
         ]
         epidata_df = pd.DataFrame(
             epidata_data,
             columns=[
-                'data_source',
+                'source',
                 'signal',
                 'time_value',
-                'geo_type',
-                'geo_value'])
+                'count'])
 
         mock_signal.return_value = epidata_df
 
@@ -222,7 +221,7 @@ class UnitTests(unittest.TestCase):
                     2020,
                     1,
                     1),
-                geo_type='state',
+                geo_type='county',
                 count=2),
             DashboardSignalCoverage(
                 signal_id=1,
@@ -230,51 +229,6 @@ class UnitTests(unittest.TestCase):
                     2020,
                     1,
                     2),
-                geo_type='state',
-                count=1),    
-            ]
-
-        self.assertListEqual(coverage, expected_coverage)
-
-    @patch("covidcast.signal")
-    def test_get_coverage_megacounties_dropped(self, mock_signal):
-        signal = DashboardSignal(
-            db_id=1, name="Change", source="chng",
-            covidcast_signal="chng-sig",
-            latest_coverage_update=date(2021, 1, 1),
-            latest_status_update=date(2021, 1, 1))
-        data = [['chng', pd.Timestamp("2020-01-01"), "chng-sig"]]
-        metadata = pd.DataFrame(
-            data,
-            columns=[
-                'data_source',
-                'max_time',
-                'signal'])
-
-        epidata_data = [
-            ['chng', 'chng-sig', pd.Timestamp("2020-01-01"), "county", "11111"],
-            ['chng', 'chng-sig', pd.Timestamp("2020-01-01"), "county", "10000"],
-        ]
-        epidata_df = pd.DataFrame(
-            epidata_data,
-            columns=[
-                'data_source',
-                'signal',
-                'time_value',
-                'geo_type',
-                'geo_value'])
-
-        mock_signal.return_value = epidata_df
-
-        coverage = get_coverage(signal, metadata)
-
-        expected_coverage = [
-            DashboardSignalCoverage(
-                signal_id=1,
-                date=date(
-                    2020,
-                    1,
-                    1),
                 geo_type='county',
                 count=1),    
             ]


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Most of this PR is for switching the signals dashboard data generator over to the `covidcast/coverage` endpoint instead of pulling the regional data and counting sizes in a massive groupby. Since `coverage` isn't available natively in the covidcast library (and won't be; that's all going into the new delphi_epidata library/ies) we have to do this by constructing the URL, calling `pandas.read_csv`, and parsing the `time_value` column.

With that change, it makes it less of a big deal to double the length of the coverage time series -- the true goal of this PR.