### PR TITLE
Add pairwise logging for meta

### DIFF
--- a/src/acquisition/covidcast/database.py
+++ b/src/acquisition/covidcast/database.py
@@ -315,13 +315,13 @@ class Database:
       try:
         while True:
           (source, signal) = srcsigs.get_nowait() # this will throw the Empty caught below
+          logger.info("starting pair", thread=name, pair=f"({source}, {signal})")
           w_cursor.execute(inner_sql, (source, signal))
           with meta_lock:
             meta.extend(list(
               dict(zip(w_cursor.column_names, x)) for x in w_cursor
             ))
           srcsigs.task_done()
-          logger.info("completed pair", thread=name, pair=f"({source}, {signal})")
       except Empty:
         logger.info("no jobs left, thread terminating", thread=name)
       finally:

--- a/src/acquisition/covidcast/database.py
+++ b/src/acquisition/covidcast/database.py
@@ -257,6 +257,7 @@ class Database:
     n_threads = max(1, cpu_count()*9//10) # aka number of concurrent db connections, which [sh|c]ould be ~<= 90% of the #cores available to SQL server
     # NOTE: this may present a small problem if this job runs on different hardware than the db,
     #       but we should not run into that issue in prod.
+    logger.info(f"using {n_threads} workers")
 
     srcsigs = Queue() # multi-consumer threadsafe!
 
@@ -305,7 +306,8 @@ class Database:
     meta_lock = threading.Lock()
 
     def worker():
-      logger.info("starting thread: " + threading.current_thread().name)
+      name = threading.current_thread().name
+      logger.info("starting thread", thread=name)
       #  set up new db connection for thread
       worker_dbc = Database()
       worker_dbc.connect(connector_impl=self._connector_impl)
@@ -319,8 +321,9 @@ class Database:
               dict(zip(w_cursor.column_names, x)) for x in w_cursor
             ))
           srcsigs.task_done()
+          logger.info("completed pair", thread=name, pair=f"({source}, {signal})")
       except Empty:
-        logger.info("no jobs left, thread terminating: " + threading.current_thread().name)
+        logger.info("no jobs left, thread terminating", thread=name)
       finally:
         worker_dbc.disconnect(False) # cleanup
 
@@ -334,7 +337,7 @@ class Database:
     logger.info("jobs complete")
     for t in threads:
       t.join()
-    logger.error("threads terminated")
+    logger.info("all threads terminated")
 
     # sort the metadata because threaded workers dgaf
     sorting_fields = "data_source signal time_type geo_type".split()


### PR DESCRIPTION
Additional diagnostic information for 4-hour meta cache update runs the last few days.

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary
We're getting duplicate "thread started" logs for some reason, and the long runtimes seem to be because one of the threads takes ages to finish.

* Log number of threads before we start (to maybe see what is up with duplicates)
* Log after each pair is completed (i tried timing each pair but tests hung -- i suspect time() isn't thread-friendly)
