### PR TITLE
Provide user-agent with async requests

### DIFF
--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -728,7 +728,7 @@ class Epidata:
       """Helper function to asynchronously make and aggregate Epidata GET requests."""
       tasks = []
       connector = TCPConnector(limit=batch_size)
-      async with ClientSession(connector=connector) as session:
+      async with ClientSession(connector=connector, headers=_HEADERS) as session:
         for param in param_combos:
           task = asyncio.ensure_future(async_get(param, session))
           tasks.append(task)


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Include the Epidata request headers in async request sessions, so the delphi-epidata User-Agent is used. Unfortunately I don't have a way to test this because I can't figure out how to get aiohttp to tell me the headers it sent, but it *should* work.