### PR TITLE
Implement API key scrubbing and structured logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ requests==2.26.0
 epiweeks==2.1.2
 Flask-Limiter==1.4
 redis==3.5.3
+structlog

--- a/src/server/_logger.py
+++ b/src/server/_logger.py
@@ -1,0 +1,94 @@
+"""Structured logger utility for creating JSON logs in Delphi pipelines."""
+import logging
+import sys
+import threading
+import structlog
+
+
+def handle_exceptions(logger):
+    """Handle exceptions using the provided logger."""
+    def exception_handler(etype, value, traceback):
+        logger.exception("Top-level exception occurred",
+                         exc_info=(etype, value, traceback))
+
+    def multithread_exception_handler(args):
+        exception_handler(args.exc_type, args.exc_value, args.exc_traceback)
+
+    sys.excepthook = exception_handler
+    threading.excepthook = multithread_exception_handler
+
+
+def get_structured_logger(name=__name__,
+                          filename=None,
+                          log_exceptions=True):
+    """Create a new structlog logger.
+
+    Use the logger returned from this in indicator code using the standard
+    wrapper calls, e.g.:
+
+    logger = get_structured_logger(__name__)
+    logger.warning("Error", type="Signal too low").
+
+    The output will be rendered as JSON which can easily be consumed by logs
+    processors.
+
+    See the structlog documentation for details.
+
+    Parameters
+    ---------
+    name: Name to use for logger (included in log lines), __name__ from caller
+    is a good choice.
+    filename: An (optional) file to write log output.
+    """
+    # Configure the underlying logging configuration
+    handlers = [logging.StreamHandler()]
+    if filename:
+        handlers.append(logging.FileHandler(filename))
+
+    logging.basicConfig(
+        format="%(message)s",
+        level=logging.INFO,
+        handlers=handlers
+        )
+    
+    
+
+    # Configure structlog. This uses many of the standard suggestions from
+    # the structlog documentation.
+    structlog.configure(
+        processors=[
+            # Filter out log levels we are not tracking.
+            structlog.stdlib.filter_by_level,
+            # Include logger name in output.
+            structlog.stdlib.add_logger_name,
+            # Include log level in output.
+            structlog.stdlib.add_log_level,
+            # Allow formatting into arguments e.g., logger.info("Hello, %s",
+            # name)
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            # Add timestamps.
+            structlog.processors.TimeStamper(fmt="iso"),
+            # Match support for exception logging in the standard logger.
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            # Decode unicode characters
+            structlog.processors.UnicodeDecoder(),
+            # Render as JSON
+            structlog.processors.JSONRenderer()
+        ],
+        # Use a dict class for keeping track of data.
+        context_class=dict,
+        # Use a standard logger for the actual log call.
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        # Use a standard wrapper class for utilities like log.warning()
+        wrapper_class=structlog.stdlib.BoundLogger,
+        # Cache the logger
+        cache_logger_on_first_use=True,
+    )
+
+    logger = structlog.get_logger(name)
+
+    if log_exceptions:
+        handle_exceptions(logger)
+
+    return logger

--- a/src/server/_logger.py
+++ b/src/server/_logger.py
@@ -23,7 +23,7 @@ def get_structured_logger(name=__name__,
                           log_exceptions=True):
     """Create a new structlog logger.
 
-    Use the logger returned from this in indicator code using the standard
+    Use the logger returned from this in server code using the standard
     wrapper calls, e.g.:
 
     logger = get_structured_logger(__name__)

--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -235,7 +235,7 @@ def run_query(p: APrinter, query_tuple: Tuple[str, Dict[str, Any]]):
     query, params = query_tuple
     # limit rows + 1 for detecting whether we would have more
     full_query = text(f"{query} LIMIT {p.remaining_rows + 1}")
-    current_user.log_info({"full_query" : str(full_query), "params" : params})
+    current_user.log_info("Running query", full_query=str(full_query), params=params)
     return db.execution_options(stream_results=True).execute(full_query, **params)
 
 

--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -235,7 +235,7 @@ def run_query(p: APrinter, query_tuple: Tuple[str, Dict[str, Any]]):
     query, params = query_tuple
     # limit rows + 1 for detecting whether we would have more
     full_query = text(f"{query} LIMIT {p.remaining_rows + 1}")
-    current_user.log_info("full_query: %s, params: %s", full_query, params)
+    current_user.log_info({"full_query" : str(full_query), "params" : params})
     return db.execution_options(stream_results=True).execute(full_query, **params)
 
 

--- a/src/server/_security.py
+++ b/src/server/_security.py
@@ -14,9 +14,6 @@ from ._exceptions import MissingAPIKeyException, UnAuthenticatedException
 from ._db import metadata, TABLE_OPTIONS
 from ._logger import get_structured_logger
 
-# Change to False to test API Key requirement setting
-#app.config['TESTING'] = True
-
 API_KEY_HARD_WARNING = API_KEY_REQUIRED_STARTING_AT - timedelta(days=14)
 API_KEY_SOFT_WARNING = API_KEY_HARD_WARNING - timedelta(days=14)
 
@@ -179,7 +176,7 @@ def _find_user(api_key: Optional[str]) -> User:
     if not api_key:
         return ANONYMOUS_USER
     stmt = user_table.select().where(user_table.c.api_key == api_key)
-    user = db.execution_options(stream_results=False).execute(stmt).first()    
+    user = db.execution_options(stream_results=False).execute(stmt).first()
     if user is None:
         return ANONYMOUS_USER
     else:

--- a/src/server/_security.py
+++ b/src/server/_security.py
@@ -142,7 +142,10 @@ class User:
         self.roles = roles
         self.tracking = tracking
         self.registered = registered
-        
+    
+    def get_apikey(self) -> str:
+        return self.api_key
+
     def is_authenticated(self) -> bool:
         return self.authenticated
 
@@ -160,9 +163,9 @@ class User:
         logger = get_structured_logger("api_key_logs", filename="api_key_logs.log")
         if self.is_authenticated():
             if self.is_tracking():
-                logger.info({"api_key" : self.api_key, "request" : msg}, *args, **kwargs)
+                logger.info(msg, *args, **dict(kwargs, apikey=self.get_apikey()))
             else:
-                logger.info({"api_key" : "*****", "request" : msg}, *args, **kwargs)
+                logger.info(msg, *args, **dict(kwargs, apikey="*****"))
         else:
             logger.info(msg, *args, **kwargs)
 
@@ -200,7 +203,7 @@ def _get_current_user() -> User:
         user = _find_user(api_key)
         if not user.is_authenticated() and require_api_key():
             raise MissingAPIKeyException()
-        user.log_info(request.full_path)
+        user.log_info(request.full_path, test="HERE")
         g.user = user
     return g.user
 

--- a/src/server/_security.py
+++ b/src/server/_security.py
@@ -211,12 +211,12 @@ def _get_current_user() -> User:
         g.user = user
     return g.user
 
-def mask_apikey(msg: str) -> str:
-    # Function to mask API key query string from a URL
+def mask_apikey(path: str) -> str:
+    # Function to mask API key query string from a request path
     regexp = re.compile(r'[\\?&]api_key=([^&#]*)')
-    if regexp.search(msg):
-        msg = re.sub(regexp, "&api_key=*****", msg)
-    return msg
+    if regexp.search(path):
+        path = re.sub(regexp, "&api_key=*****", path)
+    return path
 
 
 current_user: User = cast(User, LocalProxy(_get_current_user))

--- a/src/server/_security.py
+++ b/src/server/_security.py
@@ -160,12 +160,10 @@ class User:
         logger = get_structured_logger("api_key_logs", filename="api_key_logs.log")
         if self.is_authenticated():
             if self.is_tracking():
-                #app.logger.info(f"api_key: {self.api_key}, {msg}", *args, **kwargs)
                 logger.info({"api_key" : self.api_key, "request" : msg}, *args, **kwargs)
             else:
                 logger.info({"api_key" : "*****", "request" : msg}, *args, **kwargs)
         else:
-            #app.logger.info(msg, *args, **kwargs)
             logger.info(msg, *args, **kwargs)
 
 

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -69,5 +69,5 @@ else:
     app.logger.setLevel(gunicorn_logger.level)
     sqlalchemy_logger = logging.getLogger("sqlalchemy")
     sqlalchemy_logger.handlers = gunicorn_logger.handlers
+    # Change SQLAlchemy logging level to "ERROR" in order to prevent query details of API keys from being logged 
     sqlalchemy_logger.setLevel(logging.ERROR)
-    #sqlalchemy_logger.setLevel(gunicorn_logger.level)

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -69,4 +69,5 @@ else:
     app.logger.setLevel(gunicorn_logger.level)
     sqlalchemy_logger = logging.getLogger("sqlalchemy")
     sqlalchemy_logger.handlers = gunicorn_logger.handlers
-    sqlalchemy_logger.setLevel(gunicorn_logger.level)
+    sqlalchemy_logger.setLevel(logging.ERROR)
+    #sqlalchemy_logger.setLevel(gunicorn_logger.level)


### PR DESCRIPTION
### Summary

- [x] Adds structured logging module to parse server logs in JSON format
- [x] Applies API key scrubbing / masking for Flask logs according to User authentication and no-track status
- [x] Adds additional getter functions for User class: is_authenticated() and is_tracking()
- [x] Elevates SQLAlchemy logging level to "ERROR" to prevent API keys to show up in query logs

### Notes

This PR implements API key scrubbing for logs in the application layer (Flask + gunicorn). If the user is authorized and tracked, the API key will be logged whenever the user makes an API request. If the user is not tracked, the API key parameter will be masked / scrubbed out. 

For logs in the web server layer (NGINX), the API key will be shown as a query string during client requests. This will need to be filtered by creating a custom filter or ingestion pipeline on Filebeat before ingesting to Elasticsearch.

### TODO in separate PR:
- Create an ingestion pipeline / filter in Filebeat to scrub the "api_key" query string from the incoming NGINX logs.
- Make Flask logs more useful (analytics-friendly) for Kibana by adding more parameters such as list of COVIDcast data sources, etc.

