### PR TITLE
Correct Wave 13 overlap description

### DIFF
--- a/docs/symptom-survey/coding.md
+++ b/docs/symptom-survey/coding.md
@@ -956,8 +956,8 @@ is finalized.
 ## Wave 13
 
 Wave 13 was deployed on January 30, 2022. For the following two weeks, about 15%
-of respondents (selected at random) received Wave 13 and the remainder received
-Wave 12, allowing for comparisons of responses between the two waves. Wave 13 is
+of respondents (selected at random) received Wave 12 and the remainder received
+Wave 13, allowing for comparisons of responses between the two waves. Wave 13 is
 available in English and the languages introduced in Wave 3.
 
 There are two objectives of this revision. First, we modified the COVID-19


### PR DESCRIPTION
The main sample (85%) is now receiving Wave 13, not the reverse.

**Prerequisites**:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Fix Wave 13 changelog deployment description. It'd be good to get this correction out quickly, if we can deploy the doc update.