### PR TITLE
Correct license for data from HHS

### DIFF
--- a/docs/api/covid_hosp.md
+++ b/docs/api/covid_hosp.md
@@ -29,7 +29,7 @@ Hospital Capacity by State Timeseries](https://healthdata.gov/Hospital/COVID-19-
   and [COVID-19 Reported Patient Impact and Hospital Capacity by State](https://healthdata.gov/dataset/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/6xf2-c3ie) (published on an irregular schedule, every 1-6 days)
 - Temporal Resolution: Daily, starting 2020-01-01
 - Spatial Resolution: US States plus DC, PR, and VI
-- Open access via [Open Data Commons Open Database License (ODbL)](https://opendatacommons.org/licenses/odbl/1.0/)
+- Open Access: [Public Domain US Government](https://www.usa.gov/government-works)
 - Versioned by Delphi according to "issue" date, which is the date that the
 dataset was published by HHS.
 

--- a/docs/api/covid_hosp_facility.md
+++ b/docs/api/covid_hosp_facility.md
@@ -24,7 +24,7 @@ This data source provides various measures of COVID-19 burden on patients and he
 - Geographic resolution: healthcare facility (address, city, zip, fips)
 - Temporal resolution: weekly (Friday -- Thursday)
 - First week: 2020-07-31
-- Open access via [Open Data Commons Open Database License (ODbL)](https://opendatacommons.org/licenses/odbl/1.0/)
+- Open Access: [Public Domain US Government](https://www.usa.gov/government-works)
 - Versioned by Delphi according to the date that the dataset was published by
 HHS. New versions are expected to be published roughly weekly.
 

--- a/docs/api/covid_hosp_facility_lookup.md
+++ b/docs/api/covid_hosp_facility_lookup.md
@@ -26,7 +26,7 @@ General topics not specific to any particular data source are discussed in the
 This data source provides metadata about healthcare facilities in the US.
 - Data source: [US Department of Health & Human Services](https://healthdata.gov/Hospital/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/anag-cw7u) (HHS)
 - Total number of facilities: 4922
-- Open access via [Open Data Commons Open Database License (ODbL)](https://opendatacommons.org/licenses/odbl/1.0/)
+- Open Access: [Public Domain US Government](https://www.usa.gov/government-works)
 
 # The API
 

--- a/docs/api/covidcast-signals/hhs.md
+++ b/docs/api/covidcast-signals/hhs.md
@@ -13,7 +13,7 @@ grand_parent: COVIDcast Epidata API
 * **Date of last change:** Never
 * **Available for:** state, hhs, nation (see [geography coding docs](../covidcast_geography.md))
 * **Time type:** day (see [date format docs](../covidcast_times.md))
-* **License:** [Open Data Commons Open Database License (ODbL)](https://opendatacommons.org/licenses/odbl/1-0/)
+* **License:** [Public Domain US Government](https://www.usa.gov/government-works)
 
 The U.S. Department of Health & Human Services (HHS) publishes several
 datasets on patient impact and hospital capacity. One of these
@@ -112,10 +112,6 @@ is first published.
 ## Source and Licensing
 
 This indicator mirrors and lightly aggregates data originally
-published by the U.S. Department of Health & Human Services under an
-[Open Data Commons Open Database License
-(ODbL)](https://opendatacommons.org/licenses/odbl/1-0/). The ODbL
-permits sharing, transformation, and redistribution of data or derived
-works so long as all public uses are distributed under the ODbL and
-attributed to the source. For more details, consult the official
-license text.
+published by the U.S. Department of Health & Human Services. 
+As a work of the US government, the original data is in the 
+[public domain](https://www.usa.gov/government-works).


### PR DESCRIPTION
closes #827 

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

The COVID-19 Patient Impact and Hospital Capacity datasets from HHS are in the public domain as works of the US Government, not ODBL.
