### PR TITLE
Split CI tests to a separate job from build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,11 @@ jobs:
         with:
           image: "delphi_web_epidata:latest"
 
+      - name: Upload py image as workflow artifact
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: "delphi_web_python:latest"
+
   run_tests:
     needs: build
     runs-on: ubuntu-latest
@@ -82,6 +87,11 @@ jobs:
         uses: ishworkh/docker-image-artifact-download@v1
         with:
           image: "delphi_web_epidata:latest"
+
+      - name: Download py image as workflow artifact
+        uses: ishworkh/docker-image-artifact-download@v1
+        with:
+          image: "delphi_web_python:latest"
 
       - name: Start services
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,30 @@ jobs:
           docker build -t delphi_web_epidata -f ./devops/Dockerfile .
           cd ../../../
 
+      - name: Upload db image as workflow artifact
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: "delphi_database_epidata:latest"
+
+      - name: Upload web image as workflow artifact
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: "delphi_web_epidata:latest"
+
+  run_tests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download db image as workflow artifact
+        uses: ishworkh/docker-image-artifact-download@v1
+        with:
+          image: "delphi_database_epidata:latest"
+
+      - name: Download web image as workflow artifact
+        uses: ishworkh/docker-image-artifact-download@v1
+        with:
+          image: "delphi_web_epidata:latest"
+
       - name: Start services
         run: |
           docker network create --driver bridge delphi-net
@@ -83,7 +107,7 @@ jobs:
         run: |
           docker stop delphi_database_epidata delphi_web_epidata
           docker network remove delphi-net
-
+  
   build_js_client:
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [ ] Code is cleaned up and formatted

### Summary

Uploads images built during `build` job as a workflow artifact, then downloads them during `run_tests` in order to start the necessary services for ci testing.

Unblocks `image` job from depending on successful `build` incl passing tests.
