### PR TITLE
Add regex decorator to re string

### DIFF
--- a/src/server/endpoints/covidcast_utils/model.py
+++ b/src/server/endpoints/covidcast_utils/model.py
@@ -47,7 +47,7 @@ def _fix_links(link: Optional[str]) -> List[WebLink]:
     if not link:
         return []
 
-    reg = re.compile("\[(.+)\]\s*\((.*)\)")
+    reg = re.compile(r"\[(.+)\]\s*\((.*)\)")
 
     def parse(l: str) -> Optional[WebLink]:
         l = l.strip()


### PR DESCRIPTION
closes #841 

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Just adds 'r' to the `re.compile` line.
