### PR TITLE
temporary patch for failing build due to Flask->itsdangerous->json 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+itsdangerous<2.1
 Flask==1.1.2
 SQLAlchemy==1.3.22
 mysqlclient==2.0.2


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

`itsdangerous` released version 2.1 today, which removed the `json` submodule. `itsdangerous.json` is used by our version of Flask, so its removal causes the web server to crash.

This PR pins `itsdangerous` to just before 2.1, so that `itsdangerous.json` is still available.

Eventually we should address #848 properly, likely by upgrading Flask, but this PR is the shortest distance to a successful build.