### PR TITLE
Split large deletion batches into smaller chunks

### DIFF
--- a/src/acquisition/covidcast/database.py
+++ b/src/acquisition/covidcast/database.py
@@ -333,7 +333,11 @@ SET `covidcast`.`is_latest_issue`=1;
       if isinstance(cc_deletions, str):
         self._cursor.execute(load_tmp_table_infile_sql)
       elif isinstance(cc_deletions, list):
-        self._cursor.executemany(load_tmp_table_insert_sql, cc_deletions)
+        def split_list(lst, n):
+          for i in range(0, len(lst), n):
+            yield lst[i:(i+n)]
+        for deletions_batch in split_list(cc_deletions, 100000):
+          self._cursor.executemany(load_tmp_table_insert_sql, deletions_batch)
       else:
         raise Exception(f"Bad deletions argument: need a filename or a list of tuples; got a {type(cc_deletions)}")
       self._cursor.execute(add_id_sql)


### PR DESCRIPTION

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

If you try to `INSERT INTO ... VALUES` with too many items, the MySQL server "goes away" and crashes the next query. "Too many" is somewhere between 100k and 400k: 100k runs, 400k does not. There are ways to address this in client and server settings, but to be less invasive, this PR splits the `VALUES` into 100k chunks. 
