### PR TITLE
Pin jinja2 at 3.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 itsdangerous<2.1
+jinja2==3.0.3
 Flask==1.1.2
 SQLAlchemy==1.3.22
 mysqlclient==2.0.2


### PR DESCRIPTION


**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

`jinja2` is a dependency of Flask. The 3.1.0 release of `jinja2` on Mar 24, 2022 removes support for the `escape` submodule, which our version of Flask requires. The next-most-recent version of `jinja2` is 3.0.3 (released Nov 9, 2021), so this PR pins our `jinja2` version to 3.0.3 to restore the build.
