### PR TITLE
Pin werkzeug before the 2.1 release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 itsdangerous<2.1
 jinja2==3.0.3
+werkzeug<2.1
 Flask==1.1.2
 SQLAlchemy==1.3.22
 mysqlclient==2.0.2


### PR DESCRIPTION
werkzeug 2.1 breaks our BaseResponse imports

closes <!--list issues closed by this PR -->

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [ ] Code is cleaned up and formatted

### Summary

<!--
  describe what this PR changes
-->
