### PR TITLE
Set test secrets in test_covidcast_meta

### DIFF
--- a/integrations/server/test_covidcast_meta.py
+++ b/integrations/server/test_covidcast_meta.py
@@ -10,6 +10,7 @@ import requests
 #first party
 from delphi_utils import Nans
 from delphi.epidata.acquisition.covidcast.covidcast_meta_cache_updater import main as update_cache
+import delphi.operations.secrets as secrets
 
 # use the local instance of the Epidata API
 BASE_URL = 'http://delphi_web_epidata/epidata/api.php'
@@ -82,6 +83,11 @@ class CovidcastMetaTests(unittest.TestCase):
     # make connection and cursor available to test cases
     self.cnx = cnx
     self.cur = cnx.cursor()
+
+    # use the local instance of the epidata database
+    secrets.db.host = 'delphi_database_epidata'
+    secrets.db.epi = ('user', 'pass')
+
 
   def tearDown(self):
     """Perform per-test teardown."""


### PR DESCRIPTION



**Prerequisites**:

- [x] Part of v4: merge against the primary v4 branch
- [x] Branch is up-to-date with the branch to be merged with
- [ ] Build is successful (v4 tests don't pass yet; these PRs will bring us closer to a successful build)
- [x] Code is cleaned up and formatted

### Summary

test_covidcast_meta used to depend on prior tests to set secrets.db.host instead of setting them itself, creating an ordering dependency. By setting secrets in each test in which they are used, we remove the ordering dependency and ensure tests pass regardless of whether they're run alone or as part of a suite.
