### PR TITLE
[CTIS] Wave 13 V2d incorrectly referred to as V2a

### DIFF
--- a/docs/symptom-survey/coding.md
+++ b/docs/symptom-survey/coding.md
@@ -993,7 +993,7 @@ Files:
     awareness of this is uneven, which is why item V2b (below) does not
     distinguish between booster and additional doses.
 
-* Item V2a asks respondents about the doses of the COVID-19 vaccination they
+* Item V2d asks respondents about the doses of the COVID-19 vaccination they
   received in their initial sequence. This is a revision from previous item V2
   and the response options distinguish between one dose vaccines, two dose
   vaccines, and incomplete 2 dose vaccine sequences.


### PR DESCRIPTION
### Summary
Wave 13 V2d incorrectly referred to as V2a