### PR TITLE
Fix Flask Jinja dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 itsdangerous<2.1
+jinja2<3.1.0
 Flask==1.1.2
 SQLAlchemy==1.3.22
 mysqlclient==2.0.2


### PR DESCRIPTION
**Prerequisites**:

- [ ] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [x] Code is cleaned up and formatted

### Summary
Jinja is a dependency of Flask. In Jinga 3.1.0, `escape` is deprecated and should be imported from MarkupSafe. We can pin `jinja<3.1.0` to work around this for now.

Probably the better fix will be to update Flask, but since we are already pinning it to an older version it seems likely that we can't do this easily.

<!--
  describe what this PR changes
-->