### PR TITLE
[CTIS] Add note that current SEs are unweighted

### DIFF
--- a/docs/api/covidcast-signals/fb-survey.md
+++ b/docs/api/covidcast-signals/fb-survey.md
@@ -726,6 +726,12 @@ of zero, and in simulations improves the quality of the standard error
 estimates. See the [Appendix](#appendix) for further motivation for these
 estimators.
 
+<div style="background-color:#FCC; padding: 10px 30px;"><strong>Note:</strong>
+Currently the standard errors are calculated as though all respondent weights are
+equal. The result is that reported standard errors are artificially narrow. This
+will be corrected in a future update to the API.
+</div>
+
 The pseudo-observation is not used in $$\hat{p}$$ and $$\hat{q}$$ themselves, to
 avoid potentially large amounts of estimation bias, as $$p$$ and $$q$$ are
 expected to be small.

--- a/docs/symptom-survey/contingency-tables.md
+++ b/docs/symptom-survey/contingency-tables.md
@@ -173,7 +173,7 @@ for download, and specifies the survey questions on which they are based. See
 the <a href="coding.html">survey instrument codebook</a> for the full text of
 all questions.</div>
 
-The files contain [weighted estimates](../api/covidcast-signals/fb-survey.md#survey-weighting)
+The files contain [weighted estimates](../api/covidcast-signals/fb-survey.md#survey-weighting-and-estimation)
 of the percent of respondents who fulfill one or several criteria. Estimates are
 broken out by state, age, gender, race, ethnicity, occupation, and health
 conditions.


### PR DESCRIPTION
### Summary
- Add banner with note that current SEs are unweighted.
- Change weighted indicators link in contingency tables page to properly point to weighting discussion.