### PR TITLE
Add Docker BuildKit to CI and test pip caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,14 @@ jobs:
           repository: cmu-delphi/nowcast
           path: repos/delphi/nowcast
 
+      - name: Cache Python packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.OS }}-pip-
+
       - name: Build docker images
         run: |
           docker build -t delphi_database -f repos/delphi/operations/dev/docker/database/Dockerfile .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
     steps:
       - run: mkdir -p repos/undefx
       - name: Checkout undefx/py3tester

--- a/dev/docker/python/Dockerfile
+++ b/dev/docker/python/Dockerfile
@@ -1,4 +1,4 @@
 # start with the `delphi_python` image
 FROM delphi_python
 
-RUN pip install --no-cache-dir -r repos/delphi/delphi-epidata/requirements.txt -r repos/delphi/delphi-epidata/requirements.dev.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r repos/delphi/delphi-epidata/requirements.txt -r repos/delphi/delphi-epidata/requirements.dev.txt

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.source=https://github.com/cmu-delphi/delphi-epida
 RUN ln -s -f /usr/share/zoneinfo/America/New_York /etc/localtime
 
 COPY requirements.txt /app
-RUN pip install --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt
 
 # disable python stdout buffering
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
Closes #933.

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

This is a test to see if we can use [Docker BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) in CI.
