### PR TITLE
Remove unused undefx depends from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,18 +5,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - run: mkdir -p repos/undefx
-      - name: Checkout undefx/py3tester
-        uses: actions/checkout@v2
-        with:
-          repository: undefx/py3tester
-          path: repos/undefx/py3tester
-      - name: Checkout undefx/undef-analysis
-        uses: actions/checkout@v2
-        with:
-          repository: undefx/undef-analysis
-          path: repos/undefx/undef-analysis
-
       - run: mkdir -p repos/delphi
 
       - name: Checkoutcmu-delphi/operations


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [ ] Code is cleaned up and formatted

### Summary

Downstream of [this PR](https://github.com/cmu-delphi/operations/pull/70).

Needs:
- [ ] iterate on correct list dependencies
- [ ] consider not depending on `operations`