### PR TITLE
[Prototype] Add mandatory `meta_key` check to server

### DIFF
--- a/integrations/acquisition/covid_hosp/facility/test_scenarios.py
+++ b/integrations/acquisition/covid_hosp/facility/test_scenarios.py
@@ -2,7 +2,7 @@
 
 # standard library
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # first party
 from delphi.epidata.acquisition.covid_hosp.common.database import Database
@@ -19,6 +19,21 @@ __test_target__ = 'delphi.epidata.acquisition.covid_hosp.facility.update'
 
 NEWLINE="\n"
 
+def _request(params):
+  """Request and parse epidata.
+
+  We default to GET since it has better caching and logging
+  capabilities, but fall back to POST if the request is too
+  long and returns a 414.
+  """
+  params.update({'meta_key': 'meta_secret'})
+  try:
+    return Epidata._request_with_retry(params).json()
+  except Exception as e:
+    return {'result': 0, 'message': 'error: ' + str(e)}
+
+
+@patch.object(Epidata, '_request', _request)
 class AcquisitionTests(unittest.TestCase):
 
   def setUp(self):

--- a/integrations/acquisition/covid_hosp/state_daily/test_scenarios.py
+++ b/integrations/acquisition/covid_hosp/state_daily/test_scenarios.py
@@ -22,7 +22,21 @@ import delphi.operations.secrets as secrets
 __test_target__ = \
     'delphi.epidata.acquisition.covid_hosp.state_daily.update'
 
+def _request(params):
+  """Request and parse epidata.
 
+  We default to GET since it has better caching and logging
+  capabilities, but fall back to POST if the request is too
+  long and returns a 414.
+  """
+  params.update({'meta_key': 'meta_secret'})
+  try:
+    return Epidata._request_with_retry(params).json()
+  except Exception as e:
+    return {'result': 0, 'message': 'error: ' + str(e)}
+
+
+@patch.object(Epidata, '_request', _request)
 class AcquisitionTests(unittest.TestCase):
 
   def setUp(self):

--- a/integrations/acquisition/covid_hosp/state_timeseries/test_scenarios.py
+++ b/integrations/acquisition/covid_hosp/state_timeseries/test_scenarios.py
@@ -2,7 +2,7 @@
 
 # standard library
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # first party
 from delphi.epidata.acquisition.covid_hosp.common.database import Database
@@ -18,7 +18,21 @@ from freezegun import freeze_time
 __test_target__ = \
     'delphi.epidata.acquisition.covid_hosp.state_timeseries.update'
 
+def _request(params):
+  """Request and parse epidata.
 
+  We default to GET since it has better caching and logging
+  capabilities, but fall back to POST if the request is too
+  long and returns a 414.
+  """
+  params.update({'meta_key': 'meta_secret'})
+  try:
+    return Epidata._request_with_retry(params).json()
+  except Exception as e:
+    return {'result': 0, 'message': 'error: ' + str(e)}
+
+
+@patch.object(Epidata, '_request', _request)
 class AcquisitionTests(unittest.TestCase):
 
   def setUp(self):

--- a/integrations/acquisition/covidcast/test_delete_batch.py
+++ b/integrations/acquisition/covidcast/test_delete_batch.py
@@ -3,6 +3,7 @@
 # standard library
 from collections import namedtuple
 import unittest
+from unittest.mock import patch
 from os import path
 
 # third party
@@ -18,6 +19,21 @@ __test_target__ = 'delphi.epidata.acquisition.covidcast.database'
 
 Example = namedtuple("example", "given expected")
 
+def _request(params):
+  """Request and parse epidata.
+
+  We default to GET since it has better caching and logging
+  capabilities, but fall back to POST if the request is too
+  long and returns a 414.
+  """
+  params.update({'meta_key': 'meta_secret'})
+  try:
+    return Epidata._request_with_retry(params).json()
+  except Exception as e:
+    return {'result': 0, 'message': 'error: ' + str(e)}
+
+
+@patch.object(Epidata, '_request', _request)
 class DeleteBatch(unittest.TestCase):
     """Tests batch deletions"""
 

--- a/integrations/acquisition/covidcast/test_fill_is_latest_issue.py
+++ b/integrations/acquisition/covidcast/test_fill_is_latest_issue.py
@@ -15,7 +15,21 @@ import delphi.operations.secrets as secrets
 # py3tester coverage target (equivalent to `import *`)
 __test_target__ = 'delphi.epidata.acquisition.covidcast.fill_is_latest_issue'
 
+def _request(params):
+  """Request and parse epidata.
 
+  We default to GET since it has better caching and logging
+  capabilities, but fall back to POST if the request is too
+  long and returns a 414.
+  """
+  params.update({'meta_key': 'meta_secret'})
+  try:
+    return Epidata._request_with_retry(params).json()
+  except Exception as e:
+    return {'result': 0, 'message': 'error: ' + str(e)}
+
+
+@unittest.mock.patch.object(Epidata, '_request', _request)
 class FillIsLatestIssueTests(unittest.TestCase):
   """Tests filling is_latest_issue column"""
 

--- a/integrations/acquisition/covidcast_nowcast/test_csv_uploading.py
+++ b/integrations/acquisition/covidcast_nowcast/test_csv_uploading.py
@@ -26,7 +26,21 @@ FIXED_ISSUE_IMPORTER = partialmethod(CsvImporter.find_csv_files,
                                      issue=(date(2020, 4, 21), epi.Week.fromdate(date(2020, 4, 21)))
                                      )
 
+def _request(params):
+  """Request and parse epidata.
 
+  We default to GET since it has better caching and logging
+  capabilities, but fall back to POST if the request is too
+  long and returns a 414.
+  """
+  params.update({'meta_key': 'meta_secret'})
+  try:
+    return Epidata._request_with_retry(params).json()
+  except Exception as e:
+    return {'result': 0, 'message': 'error: ' + str(e)}
+
+
+@patch.object(Epidata, '_request', _request)
 class CsvUploadingTests(unittest.TestCase):
   """Tests covidcast nowcast CSV uploading."""
 

--- a/integrations/server/test_covid_hosp.py
+++ b/integrations/server/test_covid_hosp.py
@@ -2,13 +2,28 @@
 
 # standard library
 import unittest
+from unittest.mock import patch
 
 # first party
 from delphi.epidata.acquisition.covid_hosp.state_timeseries.database import Database
 from delphi.epidata.client.delphi_epidata import Epidata
 import delphi.operations.secrets as secrets
 
+def _request(params):
+  """Request and parse epidata.
 
+  We default to GET since it has better caching and logging
+  capabilities, but fall back to POST if the request is too
+  long and returns a 414.
+  """
+  params.update({'meta_key': 'meta_secret'})
+  try:
+    return Epidata._request_with_retry(params).json()
+  except Exception as e:
+    return {'result': 0, 'message': 'error: ' + str(e)}
+
+
+@patch.object(Epidata, '_request', _request)
 class ServerTests(unittest.TestCase):
   """Tests the `covid_hosp` endpoint."""
 

--- a/integrations/server/test_covidcast.py
+++ b/integrations/server/test_covidcast.py
@@ -67,6 +67,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': 20200414,
       'geo_value': '01234',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -163,7 +164,8 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': 20200414,
       'geo_value': '01234',
-      'format': 'csv'
+      'format': 'csv',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.text
@@ -203,7 +205,8 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': 20200414,
       'geo_value': '01234',
-      'format': 'json'
+      'format': 'json',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -251,6 +254,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': 20200414,
       'geo_value': '01234',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -284,7 +288,8 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': 20200414,
       'geo_value': '01234',
-      'fields': 'time_value,geo_value'
+      'fields': 'time_value,geo_value',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -308,7 +313,8 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': 20200414,
       'geo_value': '01234',
-      'fields': 'time_value,geo_value,dummy'
+      'fields': 'time_value,geo_value,dummy',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -336,7 +342,8 @@ class CovidcastTests(unittest.TestCase):
       'fields': (
         '-value,-stderr,-sample_size,-direction,-issue,-lag,-signal,' +
         '-missing_value,-missing_stderr,-missing_sample_size'
-      )
+      ),
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -393,6 +400,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': 20200414,
       'geo_value': '*',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -487,6 +495,7 @@ class CovidcastTests(unittest.TestCase):
         'time_type': 'day',
         'geo_type': 'county',
         'time_values': 20200414,
+        'meta_key': 'meta_secret'
       }
       if isinstance(geo_value, list):
         params['geo_values'] = ','.join(geo_value)
@@ -609,6 +618,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': '20200411-20200413',
       'geo_value': '01234',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -735,6 +745,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': 20200414,
       'geo_value': '01234',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -799,6 +810,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'state',
       'time_values': '0-9999999999',
       'geo_value': 'vi',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -865,6 +877,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': '20200411',
       'geo_value': '*',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -881,6 +894,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': '2020-04-11',
       'geo_value': '*',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -897,6 +911,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': '20200411,20200412',
       'geo_value': '*',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -913,6 +928,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': '2020-04-11,2020-04-12',
       'geo_value': '*',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -929,6 +945,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': '20200411-20200413',
       'geo_value': '*',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -945,6 +962,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': '2020-04-11:2020-04-13',
       'geo_value': '*',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()

--- a/integrations/server/test_covidcast_endpoints.py
+++ b/integrations/server/test_covidcast_endpoints.py
@@ -142,6 +142,8 @@ class CovidcastEndpointTests(unittest.TestCase):
 
     def _fetch(self, endpoint="/", **params):
         # make the request
+        if params:
+            params.update({'meta_key': 'meta_secret'})
         response = requests.get(
             f"{BASE_URL}{endpoint}",
             params=params,
@@ -297,9 +299,10 @@ class CovidcastEndpointTests(unittest.TestCase):
         first = rows[0]
         self._insert_rows(rows)
 
+        params = dict(signal=first.signal_pair, start_day="2020-04-01", end_day="2020-12-12", geo_type=first.geo_type, meta_key='meta_secret')
         response = requests.get(
             f"{BASE_URL}/csv",
-            params=dict(signal=first.signal_pair, start_day="2020-04-01", end_day="2020-12-12", geo_type=first.geo_type),
+            params=params,
         )
         response.raise_for_status()
         out = response.text

--- a/integrations/server/test_covidcast_meta.py
+++ b/integrations/server/test_covidcast_meta.py
@@ -89,7 +89,7 @@ class CovidcastMetaTests(unittest.TestCase):
     update_cache(args=None)
 
     # make the request
-    response = requests.get(BASE_URL, params={'endpoint': 'covidcast_meta'})
+    response = requests.get(BASE_URL, params={'endpoint': 'covidcast_meta', 'meta_key': 'meta_secret'})
     response.raise_for_status()
     response = response.json()
 
@@ -150,7 +150,7 @@ class CovidcastMetaTests(unittest.TestCase):
     def fetch(**kwargs):
       # make the request
       params = kwargs.copy()
-      params['endpoint'] = 'covidcast_meta'
+      params.update({'endpoint': 'covidcast_meta', 'meta_key': 'meta_secret'})
       response = requests.get(BASE_URL, params=params)
       response.raise_for_status()
       return response.json()
@@ -277,7 +277,7 @@ class CovidcastMetaTests(unittest.TestCase):
     update_cache(args=None)
 
     # make the request
-    response = requests.get(BASE_URL, params={'endpoint': 'covidcast_meta'})
+    response = requests.get(BASE_URL, params={'endpoint': 'covidcast_meta', 'meta_key': 'meta_secret'})
     response.raise_for_status()
     response = response.json()
 

--- a/integrations/server/test_covidcast_nowcast.py
+++ b/integrations/server/test_covidcast_nowcast.py
@@ -58,7 +58,8 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': 20200101,
       'geo_value': '01001',
-      'issues': 20200101
+      'issues': 20200101,
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -85,6 +86,7 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': 20200101,
       'geo_value': '01001',
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()
@@ -111,7 +113,8 @@ class CovidcastTests(unittest.TestCase):
       'geo_type': 'county',
       'time_values': 20200101,
       'geo_value': '01001',
-      'as_of': 20200101
+      'as_of': 20200101,
+      'meta_key': 'meta_secret'
     })
     response.raise_for_status()
     response = response.json()

--- a/integrations/server/test_fluview.py
+++ b/integrations/server/test_fluview.py
@@ -2,6 +2,7 @@
 
 # standard library
 import unittest
+from unittest.mock import patch
 
 # third party
 import mysql.connector
@@ -9,7 +10,21 @@ import mysql.connector
 # first party
 from delphi.epidata.client.delphi_epidata import Epidata
 
+def _request(params):
+  """Request and parse epidata.
 
+  We default to GET since it has better caching and logging
+  capabilities, but fall back to POST if the request is too
+  long and returns a 414.
+  """
+  params.update({'meta_key': 'meta_secret'})
+  try:
+    return Epidata._request_with_retry(params).json()
+  except Exception as e:
+    return {'result': 0, 'message': 'error: ' + str(e)}
+
+
+@patch.object(Epidata, '_request', _request)
 class FluviewTests(unittest.TestCase):
   """Tests the `fluview` endpoint."""
 

--- a/src/server/_config.py
+++ b/src/server/_config.py
@@ -13,6 +13,7 @@ MAX_COMPATIBILITY_RESULTS = int(3650)
 SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI", "sqlite:///test.db")
 SQLALCHEMY_ENGINE_OPTIONS = json.loads(os.environ.get("SQLALCHEMY_ENGINE_OPTIONS", "{}"))
 SECRET = os.environ.get("FLASK_SECRET", "secret")
+META_SECRET = os.environ.get("META_SECRET", "meta_secret")
 URL_PREFIX = os.environ.get("FLASK_PREFIX", "/")
 
 AUTH = {

--- a/src/server/_security.py
+++ b/src/server/_security.py
@@ -1,0 +1,9 @@
+from flask import request
+from ._config import META_SECRET
+from ._exceptions import UnAuthenticatedException
+
+def check_meta_key():
+    if request.values:
+        meta_key = request.values.get("meta_key", None)
+        if not (meta_key and meta_key == META_SECRET):
+            raise UnAuthenticatedException()

--- a/tests/server/endpoints/test_covidcast.py
+++ b/tests/server/endpoints/test_covidcast.py
@@ -34,7 +34,7 @@ class UnitTests(unittest.TestCase):
         self.assertRegex(msg["message"], r"missing parameter.*")
 
     def test_time(self):
-        rv: Response = self.client.get("/covidcast/", query_string=dict(signal="src1:*", time="day:20200101", geo="state:*"))
+        rv: Response = self.client.get("/covidcast/", query_string=dict(signal="src1:*", time="day:20200101", geo="state:*", meta_key="meta_secret"))
         msg = rv.get_json()
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(msg["result"], -2)  # no result

--- a/tests/server/endpoints/test_nidss_flu.py
+++ b/tests/server/endpoints/test_nidss_flu.py
@@ -26,20 +26,20 @@ class UnitTests(unittest.TestCase):
 
     def test_urls(self):
         with self.subTest('direct url'):
-            rv: Response = self.client.get('/nidss_flu', follow_redirects=True)
+            rv: Response = self.client.get('/nidss_flu', query_string = dict(meta_key="meta_secret"), follow_redirects=True)
             msg = rv.get_json()
             self.assertEqual(rv.status_code, 200)
             self.assertEqual(msg['result'], -1)
             self.assertRegex(msg['message'], r"missing parameter.*")
         with self.subTest('with wrapper'):
-            rv: Response = self.client.get('/api.php?endpoint=nidss_flu', follow_redirects=True)
+            rv: Response = self.client.get('/api.php?endpoint=nidss_flu&meta_key=meta_secret', follow_redirects=True)
             msg = rv.get_json()
             self.assertEqual(rv.status_code, 200)
             self.assertEqual(msg['result'], -1)
             self.assertRegex(msg['message'], r"missing parameter.*")
     
     def test_(self):
-        rv: Response = self.client.get('/nidss_flu/', query_string=dict(regions="A", epiweeks="12"))
+        rv: Response = self.client.get('/nidss_flu/', query_string=dict(regions="A", epiweeks="12", meta_key="meta_secret"))
         msg = rv.get_json()
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(msg['result'], -2)  # no result


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

This adds a prototype of a basic authentication system to the API server for meta cache computations. Since the meta computations run on a multi-user machine, with read and write privileges to the main DB, we need to make it secure. The idea here is to run the API server with `user1` and run the meta cache computations with `user2`. Both users will share a secret key, which will make sure the API server only responds to requests made by `user2`. The basic logic is to expect a secret meta_key parameter in every request.

Many tests had to be fixed. I went with a simple patching route that added the missing fake `meta_key` parameter in most requests.

This will likely be deprecated by #633, but the review and roll out of that work is still a way into the future.

Creating this PR for visibility and review, though it definitely should not be merged into `dev`. I envision that this code will continue to live on a separate branch and the meta cache computations server will just run its API server from that branch. Any updates to the JIT computations will need to be propagated to this branch too, whenever they are pushed to `dev`. The diffs shouldn't be too hard to manage. We should probably automate pulling into this branch when `dev` gets updated. We will also want to automate updating the meta cache computations API server whenever this code gets updated.

For the sake of tests passing, the `meta_key` comparison only expects a `meta_key` if [more than zero parameters were requested](https://github.com/cmu-delphi/delphi-epidata/blob/c823943338975e46ca55eb40f3f9720d2ef4ee8a/src/server/_security.py#L6) from the API. So for example, requests like `https://api.covidcast.cmu.edu/epidata/covidcast/` and `https://api.covidcast.cmu.edu/epidata/` pass. For these two, the result returns no actual data, so it's fine, but I need to double check that this won't expose information in other endpoints.