### PR TITLE
[Refactor] Clarify a few `csv_importer` types and names

### DIFF
--- a/tests/acquisition/covidcast/test_csv_to_database.py
+++ b/tests/acquisition/covidcast/test_csv_to_database.py
@@ -6,8 +6,7 @@ from typing import Iterable
 import unittest
 from unittest.mock import MagicMock
 
-from delphi.epidata.acquisition.covidcast.csv_to_database import get_argument_parser, main, \
-  collect_files, upload_archive, make_handlers
+from delphi.epidata.acquisition.covidcast.csv_to_database import get_argument_parser, main, collect_files, upload_archive, make_handlers
 
 # py3tester coverage target
 __test_target__ = 'delphi.epidata.acquisition.covidcast.csv_to_database'


### PR DESCRIPTION
A few small refactors for clarity that I couldn't help myself in making while working on #947.

Most of the changes are purely for better readability. No functionality is altered, except for the interface of `load_csv`, but this should not affect actual usage.

## Changes:
* rename RowValues to CsvRowValue
* make CsvRowValue into a dataclass
* remove `pandas` optional argument from `load_csv` that was only used for test mocks
* use `unittest.patch` to mock test instead
* update other tests
* update `csv_to_database` with a few relative imports

## Further details:
I changed 
```py
# From
def load_csv(filepath, geo_type, pandas=pandas):

# To
def load_csv(filepath, geo_type):
```
where `pandas` was just an abstract argument to the Pandas library meant for mocking. Instead of complicating this function's interface, we can just use `@patch("pandas.read_csv")` in the tests, which automatically mocks any calls to that function with our desired mock object.

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted
