### PR TITLE
Update `README.md` with dev quickstart recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,28 @@ In the directory where you want to work run the following:
 ```sh
 # Make folder structure, download dependent repos, and symlink Makefile
 $ curl "https://raw.githubusercontent.com/cmu-delphi/delphi-epidata/dev/dev/local/install.sh" | bash
+```
 
+You should now have the following directory structure:
+
+```sh
+├── driver
+│   ├── .dockerignore -> repos/delphi/delphi-epidata/dev/local/.dockerignore
+│   ├── Makefile -> repos/delphi/delphi-epidata/dev/local/Makefile
+│   ├── repos
+│   │   └── delphi
+│   │       ├── delphi-epidata
+│   │       ├── flu-contest
+│   │       ├── github-deploy-repo
+│   │       ├── nowcast
+│   │       ├── operations
+│   │       └── utils
+```
+
+and you should now be in the `driver` directory.
+You can now execute make commands
+
+```sh
 # Create all docker containers: db, web, and python
 $ [sudo] make all
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,34 @@ For a high-level introduction to the COVIDcast API, see our recent
 
 # Contributing
 
-If you are interested in contributing:
+If you are interested in contributing, we have a quick way for you to make a dev environment.
 
-- For development of the API itself, see the
+## Development Quickstart
+
+Requires: Docker, possibly sudo access (depending on your Docker installation and OS).
+
+In the directory where you want to work run the following:
+
+```sh
+# Make folder structure, download dependent repos, and symlink Makefile
+$ curl "https://raw.githubusercontent.com/cmu-delphi/delphi-epidata/dev/dev/local/install.sh" | bash
+
+# Create all docker containers: db, web, and python
+$ [sudo] make all
+
+# Run tests
+$ [sudo] make test
+
+# To drop into debugger on error
+$ [sudo] make test pdb=1
+
+# To test only a subset of tests
+$ [sudo] make test test=repos/delphi/delphi-epidata/integrations/acquisition
+```
+
+## Further Documentation
+
+- For more details on the dev environment and the API itself, see the
   [development guide](docs/epidata_development.md).
 - To suggest changes, additions, or other ways to improve,
   [open an issue](https://github.com/cmu-delphi/delphi-epidata/issues/new)

--- a/docs/epidata_development.md
+++ b/docs/epidata_development.md
@@ -5,16 +5,23 @@ nav_order: 4
 
 # Epidata API Development Guide
 
-## Quickstart
+## Development Quickstart
 
 In the directory where you want to work run the following
 
-```
+```sh
+# Make folder structure, download dependent repos, and symlink Makefile
 $ curl "https://raw.githubusercontent.com/cmu-delphi/delphi-epidata/dev/dev/local/install.sh" | bash
+
+# Create all docker containers: db, web, and python
 $ [sudo] make all
+
+# Run tests
 $ [sudo] make test
+
 # To drop into debugger on error
 $ [sudo] make test pdb=1
+
 # To test only a subset of tests
 $ [sudo] make test test=repos/delphi/delphi-epidata/integrations/acquisition
 ```

--- a/docs/epidata_development.md
+++ b/docs/epidata_development.md
@@ -7,12 +7,35 @@ nav_order: 4
 
 ## Development Quickstart
 
-In the directory where you want to work run the following
+Requires: Docker, possibly sudo access (depending on your Docker installation and OS).
+
+In the directory where you want to work run the following:
 
 ```sh
 # Make folder structure, download dependent repos, and symlink Makefile
 $ curl "https://raw.githubusercontent.com/cmu-delphi/delphi-epidata/dev/dev/local/install.sh" | bash
+```
 
+You should now have the following directory structure:
+
+```sh
+├── driver
+│   ├── .dockerignore -> repos/delphi/delphi-epidata/dev/local/.dockerignore
+│   ├── Makefile -> repos/delphi/delphi-epidata/dev/local/Makefile
+│   ├── repos
+│   │   └── delphi
+│   │       ├── delphi-epidata
+│   │       ├── flu-contest
+│   │       ├── github-deploy-repo
+│   │       ├── nowcast
+│   │       ├── operations
+│   │       └── utils
+```
+
+and you should now be in the `driver` directory.
+You can now execute make commands
+
+```sh
 # Create all docker containers: db, web, and python
 $ [sudo] make all
 
@@ -25,7 +48,6 @@ $ [sudo] make test pdb=1
 # To test only a subset of tests
 $ [sudo] make test test=repos/delphi/delphi-epidata/integrations/acquisition
 ```
-(sudo requirement depends on your Docker installation and operating system)
 
 ## Long version
 


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Puts our new dev quickstart recipes and tools in the main README, where developers are more likely to find them.

Should I merge this into `main` as a docs hotfix?