### PR TITLE
#910 CHNG-documentation

### DIFF
--- a/docs/api/covidcast-signals/chng.md
+++ b/docs/api/covidcast-signals/chng.md
@@ -191,7 +191,7 @@ all of them, and so this source only represents those encounters known to
 them. Their coverage may vary across the United States, but they report on about
 45% of all doctor's visits nationally.
 
-Standard errors are not available for this data source.
+Standard errors and sample sizes are not available for this data source.
 
 Due to changes in medical-seeking behavior on holidays, this data source has
 upward spikes in the fraction of doctor's visits that are COVID-related around

--- a/docs/api/covidcast-signals/doctor-visits.md
+++ b/docs/api/covidcast-signals/doctor-visits.md
@@ -160,7 +160,7 @@ outpatient doctor's visits, but not all of them, and so this source only
 represents those visits known to them. Their coverage may vary across the United
 States.
 
-Standard errors are not available for this data source.
+Standard errors and sample sizes are not available for this data source.
 
 Due to changes in medical-seeking behavior on holidays, this data source has
 upward spikes in the fraction of doctor's visits that are COVID-related around

--- a/docs/api/covidcast-signals/dsew-cpr.md
+++ b/docs/api/covidcast-signals/dsew-cpr.md
@@ -63,6 +63,8 @@ This data source is susceptible to large corrections that can create strange dat
 
 Not all CPRs have the same lag between the CPR date (listed in the filename) and the date for a particular signal.
 
+Standard errors and sample sizes are not applicable to these metrics.
+
 ### Differences with HHS reports
 
 An analysis comparing the 

--- a/docs/api/covidcast-signals/google-symptoms.md
+++ b/docs/api/covidcast-signals/google-symptoms.md
@@ -116,6 +116,8 @@ popularity of symptoms in searches within each geographical region individually.
 This means that the resulting values of symptom set popularity are **NOT**
 comparable across geographic regions, while the values of different symptom sets are comparable within the same location.
 
+Standard errors and sample sizes are not available for this data source.
+
 More details about the limitations of this dataset are available in [Google's Search
 Trends symptoms dataset documentation](https://storage.googleapis.com/gcp-public-data-symptom-search/COVID-19%20Search%20Trends%20symptoms%20dataset%20documentation%20.pdf).
 

--- a/docs/api/covidcast-signals/hhs.md
+++ b/docs/api/covidcast-signals/hhs.md
@@ -96,6 +96,8 @@ psychiatric and rehabilitation facilities, Indian Health Service (IHS)
 facilities, U.S. Department of Veterans Affairs (VA) facilities, Defense Health
 Agency (DHA) facilities, and religious non-medical facilities.
 
+Standard errors and sample sizes are not applicable to these metrics.
+
 ## Lag and Backfill
 
 HHS issues updates to this timeseries once a week, and occasionally more

--- a/docs/api/covidcast-signals/hospital-admissions.md
+++ b/docs/api/covidcast-signals/hospital-admissions.md
@@ -68,6 +68,8 @@ hospitalizations, but not all of them, and so this source only represents those
 hospitalizations known to them. Their coverage may vary across the United
 States.
 
+Standard errors and sample sizes are not available for this data source.
+
 ## Qualifying Admissions
 
 We receive two daily data streams of new hospital admissions recorded by the health system partners at each location. One stream is based on electronic medical records, and the other comes from claims records.

--- a/docs/api/covidcast-signals/jhu-csse.md
+++ b/docs/api/covidcast-signals/jhu-csse.md
@@ -59,6 +59,8 @@ can also change reporting standards in ways that dramatically increase the
 number of cumulative deaths, resulting in an apparent spike in incidence. This
 should be interpreted purely as an artifact of data reporting and correction.
 
+Standard errors and sample sizes are not applicable to these metrics.
+
 ## Geographical Exceptions
 
 Due to differences in state reporting standards, certain counties are not

--- a/docs/api/covidcast-signals/nchs-mortality.md
+++ b/docs/api/covidcast-signals/nchs-mortality.md
@@ -96,6 +96,10 @@ affected or delayed by COVID-19 related response activities which make death
 counts not comparable across states. We check for updates reported by NCHS every
 weekday but will report the signals weekly (on Monday).
 
+## Limitations
+
+Standard errors and sample sizes are not applicable to these metrics.
+
 ## Source and Licensing
 
 This data was originally published by the National Center for Health Statistics,

--- a/docs/api/covidcast-signals/usa-facts.md
+++ b/docs/api/covidcast-signals/usa-facts.md
@@ -63,6 +63,8 @@ Due to differences in state reporting standards, certain counties are not
 reported in the USAFacts data or are reported combined with other counties;
 these exceptions are explained below.
 
+Standard errors and sample sizes are not applicable to these metrics.
+
 ## Geographical Exceptions
 
 ### New York City


### PR DESCRIPTION
Issue: The CHNG documentation (and documentation for any other source with suppressed sample size) should document that the sample_size column is left deliberately blank, and provide reasons.

Fixes:
1. add the reason of "Standard errors and sample sizes are not available/applicable for this data source/metrics." in all there pages limitation sections.