### PR TITLE
DBLoadStateException: halt acquisition when unexpected data found in load table

### DIFF
--- a/src/acquisition/covidcast/csv_to_database.py
+++ b/src/acquisition/covidcast/csv_to_database.py
@@ -7,7 +7,7 @@ import time
 
 # first party
 from delphi.epidata.acquisition.covidcast.csv_importer import CsvImporter
-from delphi.epidata.acquisition.covidcast.database import Database, CovidcastRow
+from delphi.epidata.acquisition.covidcast.database import Database, CovidcastRow, DBLoadStateException
 from delphi.epidata.acquisition.covidcast.file_archiver import FileArchiver
 from delphi.epidata.acquisition.covidcast.logger import get_structured_logger
 
@@ -120,6 +120,10 @@ def upload_archive(
         if modified_row_count is None or modified_row_count: # else would indicate zero rows inserted
           total_modified_row_count += (modified_row_count if modified_row_count else 0)
           database.commit()
+      except DBLoadStateException as e:
+        # if the db is in a state that is not fit for loading new data,
+        # then we should stop processing any more files
+        raise e
       except Exception as e:
         all_rows_valid = False
         logger.exception('exception while inserting rows', exc_info=e)

--- a/tests/acquisition/covidcast/test_database.py
+++ b/tests/acquisition/covidcast/test_database.py
@@ -94,6 +94,7 @@ class UnitTests(unittest.TestCase):
     """Test that the row count is returned"""
     mock_connector = MagicMock()
     database = Database()
+    database.count_all_load_rows = lambda:0 # simulate an empty load table
     database.connect(connector_impl=mock_connector)
     connection = mock_connector.connect()
     cursor = connection.cursor() 
@@ -107,6 +108,7 @@ class UnitTests(unittest.TestCase):
     """Test that None is returned when row count cannot be returned"""
     mock_connector = MagicMock()
     database = Database()
+    database.count_all_load_rows = lambda:0 # simulate an empty load table
     database.connect(connector_impl=mock_connector)
     connection = mock_connector.connect()
     cursor = connection.cursor() 


### PR DESCRIPTION
addresses #941

a question remains about how to handle the new exception in `csv_to_database.py:upload_archive` -- i would argue the behavior i have here is correct: it stops processing any more files and leaves them where they are.  the exception condition would arise because of a problem with the database (and not with the files) so it should not handle unprocessed files with `archive_as_failed`.  if this breaks some filesystem maintenance paradigm though, im fine with changing it.