### PR TITLE
Change default dependency order in local dev

### DIFF
--- a/dev/local/Makefile
+++ b/dev/local/Makefile
@@ -94,6 +94,9 @@ db:
 		docker stop $(DATABASE_CONTAINER_ID);\
 	fi
 
+	@# Setup virtual network if it doesn't exist
+	@docker network ls | grep delphi-net || docker network create --driver bridge delphi-net
+
 	@# Only build prereqs if we need them
 	@docker images delphi_database | grep delphi || \
 		docker build -t delphi_database -f repos/delphi/operations/dev/docker/database/Dockerfile .
@@ -124,7 +127,7 @@ py:
 		-f repos/delphi/delphi-epidata/dev/docker/python/Dockerfile .
 
 .PHONY=all
-all: web db py
+all: db web py
 
 .PHONY=test
 test: 


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

* to be optimally kind to the web server, the db server really ought to come up first
* added virtual network setup to db target as well as web target so it works in either order