### PR TITLE
Use BETWEEN queries in the API as much as possible

### DIFF
--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -22,6 +22,7 @@ from ._printer import create_printer, APrinter
 from ._exceptions import DatabaseErrorException
 from ._validate import DateRange, extract_strings
 from ._params import GeoPair, SourceSignalPair, TimePair
+from .utils import dates_to_ranges
 
 
 def date_string(value: int) -> str:
@@ -89,7 +90,8 @@ def filter_dates(
     param_key: str,
     params: Dict[str, Any],
 ):
-    return filter_values(field, values, param_key, params, date_string)
+    ranges = dates_to_ranges(values)
+    return filter_values(field, ranges, param_key, params, date_string)
 
 
 def filter_fields(generator: Iterable[Dict[str, Any]]):
@@ -185,7 +187,8 @@ def filter_time_pairs(
         params[type_param] = pair.time_type
         if isinstance(pair.time_values, bool) and pair.time_values:
             return f"{type_field} = :{type_param}"
-        return f"({type_field} = :{type_param} AND {filter_integers(time_field, cast(Sequence[Union[int, Tuple[int,int]]], pair.time_values), type_param, params)})"
+        ranges = dates_to_ranges(pair.time_values)
+        return f"({type_field} = :{type_param} AND {filter_integers(time_field, cast(Sequence[Union[int, Tuple[int,int]]], ranges), type_param, params)})"
 
     parts = [filter_pair(p, i) for i, p in enumerate(values)]
 

--- a/src/server/utils/__init__.py
+++ b/src/server/utils/__init__.py
@@ -1,1 +1,1 @@
-from .dates import shift_time_value, date_to_time_value, time_value_to_iso, time_value_to_date, days_in_range, weeks_in_range, shift_week_value, week_to_time_value, week_value_to_week, guess_time_value_is_day
+from .dates import shift_time_value, date_to_time_value, time_value_to_iso, time_value_to_date, days_in_range, weeks_in_range, shift_week_value, week_to_time_value, week_value_to_week, guess_time_value_is_day, dates_to_ranges

--- a/src/server/utils/dates.py
+++ b/src/server/utils/dates.py
@@ -5,8 +5,6 @@ from typing import (
     Union
 )
 from datetime import date, timedelta
-from operator import itemgetter
-from itertools import groupby
 from epiweeks import Week, Year
 
 

--- a/src/server/utils/dates.py
+++ b/src/server/utils/dates.py
@@ -85,11 +85,14 @@ def dates_to_ranges(values: Optional[Sequence[Union[Tuple[int, int], int]]]) -> 
         return values
 
     # determine whether the list is of days (YYYYMMDD) or weeks (YYYYWW) based on first element
-    if (isinstance(values[0], tuple) and guess_time_value_is_day(values[0][0]))\
-        or (isinstance(values[0], int) and guess_time_value_is_day(values[0])):
-        return days_to_ranges(values)
-    else:
-        return weeks_to_ranges(values)
+    try:
+        if (isinstance(values[0], tuple) and guess_time_value_is_day(values[0][0]))\
+            or (isinstance(values[0], int) and guess_time_value_is_day(values[0])):
+            return days_to_ranges(values)
+        else:
+            return weeks_to_ranges(values)
+    except:
+        return values
 
 def days_to_ranges(values: Sequence[Union[Tuple[int, int], int]]) -> Sequence[Union[Tuple[int, int], int]]:
     dates = []

--- a/src/server/utils/dates.py
+++ b/src/server/utils/dates.py
@@ -28,6 +28,10 @@ def guess_time_value_is_day(value: int) -> bool:
     # YYYYMMDD type and not YYYYMM
     return len(str(value)) > 6
 
+def guess_time_value_is_week(value: int) -> bool:
+    # YYYYWW type and not YYYYMMDD
+    return len(str(value)) == 6
+
 def date_to_time_value(d: date) -> int:
     return int(d.strftime("%Y%m%d"))
 
@@ -87,8 +91,11 @@ def dates_to_ranges(values: Optional[Sequence[Union[Tuple[int, int], int]]]) -> 
         if (isinstance(values[0], tuple) and guess_time_value_is_day(values[0][0]))\
             or (isinstance(values[0], int) and guess_time_value_is_day(values[0])):
             return days_to_ranges(values)
-        else:
+        elif (isinstance(values[0], tuple) and guess_time_value_is_week(values[0][0]))\
+            or (isinstance(values[0], int) and guess_time_value_is_week(values[0])):
             return weeks_to_ranges(values)
+        else:
+            return values
     except:
         return values
 

--- a/src/server/utils/dates.py
+++ b/src/server/utils/dates.py
@@ -83,7 +83,7 @@ def dates_to_ranges(values: Optional[Sequence[Union[Tuple[int, int], int]]]) -> 
     e.g. [20200101, 20200102, (20200101, 20200104), 20200106] -> [(20200101, 20200104), 20200106]
     (the first two values of the original list are merged into a single range)
     """
-    if not values or len(values) == 0:
+    if not values or len(values) <= 1:
         return values
 
     # determine whether the list is of days (YYYYMMDD) or weeks (YYYYWW) based on first element

--- a/tests/server/test_query.py
+++ b/tests/server/test_query.py
@@ -91,21 +91,39 @@ class UnitTests(unittest.TestCase):
         params = {}
         self.assertEqual(
             filter_dates("a", [20200101, 20200102], "a", params),
+            "(a BETWEEN :a_0 AND :a_0_2)",
+        )
+        self.assertEqual(params, {"a_0": "2020-01-01", "a_0_2": "2020-01-02"})
+        params = {}
+        self.assertEqual(
+            filter_dates("a", [20200101, 20200103], "a", params),
             "(a = :a_0 OR a = :a_1)",
         )
-        self.assertEqual(params, {"a_0": "2020-01-01", "a_1": "2020-01-02"})
+        self.assertEqual(params, {"a_0": "2020-01-01", "a_1": "2020-01-03"})
         params = {}
         self.assertEqual(
             filter_dates("a", [20200101, 20200102, (20200101, 20200104)], "a", params),
+            "(a BETWEEN :a_0 AND :a_0_2)",
+        )
+        self.assertEqual(
+            params,
+            {
+                "a_0": "2020-01-01",
+                "a_0_2": "2020-01-04"
+            },
+        )
+        params = {}
+        self.assertEqual(
+            filter_dates("a", [20200101, 20200103, (20200105, 20200107)], "a", params),
             "(a = :a_0 OR a = :a_1 OR a BETWEEN :a_2 AND :a_2_2)",
         )
         self.assertEqual(
             params,
             {
                 "a_0": "2020-01-01",
-                "a_1": "2020-01-02",
-                "a_2": "2020-01-01",
-                "a_2_2": "2020-01-04",
+                "a_1": "2020-01-03",
+                "a_2": "2020-01-05",
+                "a_2_2": "2020-01-07",
             },
         )
 

--- a/tests/server/test_query.py
+++ b/tests/server/test_query.py
@@ -89,6 +89,9 @@ class UnitTests(unittest.TestCase):
         self.assertEqual(filter_dates("a", [20200101], "a", params), "(a = :a_0)")
         self.assertEqual(params, {"a_0": "2020-01-01"})
         params = {}
+        self.assertEqual(filter_dates("a", [20200101, 20200101, (20200101, 20200101), 20200101], "a", params), "(a = :a_0)")
+        self.assertEqual(params, {"a_0": "2020-01-01"})
+        params = {}
         self.assertEqual(
             filter_dates("a", [20200101, 20200102], "a", params),
             "(a BETWEEN :a_0 AND :a_0_2)",

--- a/tests/server/utils/test_dates.py
+++ b/tests/server/utils/test_dates.py
@@ -2,7 +2,7 @@ import unittest
 from datetime import date
 from epiweeks import Week
 
-from delphi.epidata.server.utils.dates import time_value_to_date, date_to_time_value, shift_time_value, time_value_to_iso, days_in_range, weeks_in_range, week_to_time_value, week_value_to_week
+from delphi.epidata.server.utils.dates import time_value_to_date, date_to_time_value, shift_time_value, time_value_to_iso, days_in_range, weeks_in_range, week_to_time_value, week_value_to_week, dates_to_ranges
 
 
 class UnitTests(unittest.TestCase):
@@ -40,3 +40,17 @@ class UnitTests(unittest.TestCase):
     def test_week_to_time_value(self):
         self.assertEqual(week_to_time_value(Week(2021, 1)), 202101)
         self.assertEqual(week_to_time_value(Week(2020, 42)), 202042)
+
+    def test_dates_to_ranges(self):
+        self.assertEqual(dates_to_ranges(None), None)
+        self.assertEqual(dates_to_ranges([]), [])
+        # days
+        self.assertEqual(dates_to_ranges([20200101]), [20200101])
+        self.assertEqual(dates_to_ranges([(20200101, 20200105)]), [(20200101, 20200105)])
+        self.assertEqual(dates_to_ranges([20211231, (20211230, 20220102), 20220102]), [(20211230, 20220102)])
+        self.assertEqual(dates_to_ranges([20200101, 20200102, (20200101, 20200104), 20200106]), [(20200101, 20200104), 20200106])
+        # weeks
+        self.assertEqual(dates_to_ranges([202001]), [202001])
+        self.assertEqual(dates_to_ranges([(202001, 202005)]), [(202001, 202005)])
+        self.assertEqual(dates_to_ranges([202051, (202050, 202102), 202101]), [(202050, 202102)])
+        self.assertEqual(dates_to_ranges([202050, 202051, (202050, 202101), 202103]), [(202050, 202101), 202103])


### PR DESCRIPTION
Closes #790.

**Prerequisites**:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Currently, the API works with mixed lists of dates and date ranges for date-based filtering, e.g.:
```
[20200101, 20200102, (20200101, 20200104), 20200106, 20200107, 20200108]
```

This PR adds a utility function, `dates_to_ranges`, to optimize those lists, grouping consecutive dates into ranges (which in SQL are represented by a single `BETWEEN` filter rather than multiple `OR` filters) and removing duplicate dates.
e.g., after the function is applied, the mixed list above becomes:
```
[(20200101, 20200104), (20200106, 20200108)]
```
The first two values from the original list are merged into a range, and so are the last three.