### PR TITLE
Fix Makefile grep command and package-lock.json

### DIFF
--- a/dev/local/Makefile
+++ b/dev/local/Makefile
@@ -113,7 +113,7 @@ db:
 
 	@# Block until DB is ready
 	@while true; do \
-		sed -n '/Temporary server stopped/,/mysqld: ready for connections/p' $(LOG_DB) | grep "ready for connections" && break; \
+		sed -n '/mysqld: ready for connections/p' $(LOG_DB) | grep "ready for connections" && break; \
 		tail -1 $(LOG_DB); \
 		sleep 1; \
 	done

--- a/package-lock.json
+++ b/package-lock.json
@@ -231,7 +231,7 @@
             "dev": true
         },
         "delphi-cmu-buildtools": {
-            "version": "git+ssh://git@github.com/sgratzl/delphi-cmu-buildtools.git#c8d0e495f7b2f6aed842976860c7b00b0d65af70",
+            "version": "git+https://git@github.com/sgratzl/delphi-cmu-buildtools.git#c8d0e495f7b2f6aed842976860c7b00b0d65af70",
             "dev": true,
             "from": "delphi-cmu-buildtools@git+https://github.com/sgratzl/delphi-cmu-buildtools.git",
             "requires": {


### PR DESCRIPTION
closes <!--list issues closed by this PR -->

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Because we updated MYSQL version, the line we search in the logs to detect that the DB is ready has changed. So change it in the Makefile here.