### PR TITLE
evaluate today only when  is run

### DIFF
--- a/src/acquisition/covidcast/csv_importer.py
+++ b/src/acquisition/covidcast/csv_importer.py
@@ -108,7 +108,7 @@ class CsvImporter:
           logger.warning(event='invalid issue directory day', detail=issue_date_value, file=path)
 
   @staticmethod
-  def find_csv_files(scan_dir, issue=(date.today(), epi.Week.fromdate(date.today())), glob=glob):
+  def find_csv_files(scan_dir, issue=None, glob=glob):
     """Recursively search for and yield covidcast-format CSV files.
 
     scan_dir: the directory to scan (recursively)
@@ -118,6 +118,9 @@ class CsvImporter:
     time_value, issue, lag) (otherwise None).
     """
     logger = get_structured_logger('find_csv_files')
+
+    if issue is None:
+      issue = (date.today(), epi.Week.fromdate(date.today()))
     issue_day,issue_epiweek=issue
     issue_day_value=int(issue_day.strftime("%Y%m%d"))
     issue_epiweek_value=int(str(issue_epiweek))


### PR DESCRIPTION
this change makes it so that when `issue` is not specified in the argument, is determined to be "today" whenever the method is run, and not bound/stuck to whatever "today" was when the file was loaded.  (in the existing pattern, the default value for the argument gets assigned once, at the time the method definition is evaluated.)  in practice, this would probably never come up, but it was bugging me.  i looked for other instances of this pattern but found none: `grep -rl '^\s*def .*(.*(' .`