### PR TITLE
Increase Gunicorn's idle timeout

### DIFF
--- a/devops/gunicorn_conf.py
+++ b/devops/gunicorn_conf.py
@@ -29,7 +29,7 @@ loglevel = use_loglevel
 workers = web_concurrency
 bind = use_bind
 keepalive = 120
-timeout = 300
+timeout = 900
 
 errorlog = "-"
 accesslog = "-"


### PR DESCRIPTION
Our query time has increased. This PR increases how long Gunicorn will wait
before deciding to terminate client connections.

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary
Increases Gunicorn's timeout parameter.

<!--
  describe what this PR changes
-->