### PR TITLE
Convert covidcast signal OR clauses to UNION

### DIFF
--- a/tests/server/test_query.py
+++ b/tests/server/test_query.py
@@ -195,21 +195,21 @@ class UnitTests(unittest.TestCase):
             params = {}
             self.assertEqual(
                 filter_source_signal_pairs("t", "v", [SourceSignalPair("src1", True)], "p", params),
-                "(t = :p_0t)",
+                ["t = :p_0t"]
             )
             self.assertEqual(params, {"p_0t": "src1"})
         with self.subTest("single"):
             params = {}
             self.assertEqual(
                 filter_source_signal_pairs("t", "v", [SourceSignalPair("src1", ["sig1"])], "p", params),
-                "((t = :p_0t AND (v = :p_0t_0)))",
+                ["(t = :p_0t AND v = :p_0t_0)"]
             )
             self.assertEqual(params, {"p_0t": "src1", "p_0t_0": "sig1"})
         with self.subTest("multi"):
             params = {}
             self.assertEqual(
                 filter_source_signal_pairs("t", "v", [SourceSignalPair("src1", ["sig1", "sig2"])], "p", params),
-                "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
+                ["(t = :p_0t AND v = :p_0t_0)", "(t = :p_0t AND v = :p_0t_1)"]
             )
             self.assertEqual(params, {"p_0t": "src1", "p_0t_0": "sig1", "p_0t_1": "sig2"})
         with self.subTest("multiple pairs"):
@@ -222,7 +222,7 @@ class UnitTests(unittest.TestCase):
                     "p",
                     params,
                 ),
-                "(t = :p_0t OR t = :p_1t)",
+                ["t = :p_0t", "t = :p_1t"]
             )
             self.assertEqual(params, {"p_0t": "src1", "p_1t": "src2"})
         with self.subTest("multiple pairs with value"):
@@ -238,7 +238,7 @@ class UnitTests(unittest.TestCase):
                     "p",
                     params,
                 ),
-                "((t = :p_0t AND (v = :p_0t_0)) OR (t = :p_1t AND (v = :p_1t_0)))",
+                ["(t = :p_0t AND v = :p_0t_0)", "(t = :p_1t AND v = :p_1t_0)"]
             )
             self.assertEqual(
                 params,


### PR DESCRIPTION
closes #763

**Prerequisites**:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [X] Build is successful
- [X] Code is cleaned up and formatted

### Summary

1. Refactored the QueryBuilder to convert covidcast signal OR clauses to UNION
2. Edited test_query.py accordingly to test filters changed in server code
