### PR TITLE
Add live debugging targets to local dev Makefile

### DIFF
--- a/dev/local/Makefile
+++ b/dev/local/Makefile
@@ -139,6 +139,20 @@ test:
 		--env "FLASK_SECRET=abc" \
 		delphi_web_python python -m pytest --import-mode importlib $(pdb) $(test) | tee test_output_$(NOW).log
 
+.PHONY=bash
+bash:
+	@docker run -it --rm --network delphi-net \
+		--mount type=bind,source=$(CWD)repos/delphi/delphi-epidata,target=/usr/src/app/repos/delphi/delphi-epidata,readonly \
+		--mount type=bind,source=$(CWD)repos/delphi/delphi-epidata/src,target=/usr/src/app/delphi/epidata,readonly \
+		--env "SQLALCHEMY_DATABASE_URI=mysql+mysqldb://user:pass@delphi_database_epidata:3306/epidata" \
+		--env "FLASK_SECRET=abc" \
+		delphi_web_python bash
+
+.PHONY=sql
+sql:
+	@docker run --rm -it --network delphi-net --cap-add=sys_nice \
+		percona mysql --user=user --password=pass --port 3306 --host delphi_database_epidata epidata
+
 .PHONY=clean
 clean:
 	@docker images -f "dangling=true" -q | xargs docker rmi >/dev/null 2>&1


### PR DESCRIPTION

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Adds two targets useful for debugging:
* `mysql` - a live mysql prompt to the dev database
* `bash` - a live bash prompt in the python environment
