### PR TITLE
[JIT Variant]: Reduce iterator stack on base signals

### DIFF
--- a/src/server/endpoints/covidcast_utils/model.py
+++ b/src/server/endpoints/covidcast_utils/model.py
@@ -544,6 +544,10 @@ def _generate_transformed_rows(
         base_source_name, base_signal_name, _, _ = key
         # Extract the list of derived signals; if a signal is not in the dictionary, then use the identity map.
         derived_signals: SourceSignalPair = transform_dict.get(SourceSignalPair(base_source_name, [base_signal_name]), SourceSignalPair(base_source_name, [base_signal_name]))
+        # Speed up base signals by not transforming them.
+        if derived_signals.signal == [base_signal_name]:
+            yield from source_signal_geo_rows
+            continue
         # Create a list of source-signal pairs along with the transformation required for the signal.
         signal_names_and_transforms: List[Tuple[Tuple[str, str], Callable]] = [(derived_signal, _get_base_signal_transform((base_source_name, derived_signal))) for derived_signal in derived_signals.signal]
         # Put the current time series on a contiguous time index.

--- a/src/server/endpoints/covidcast_utils/model.py
+++ b/src/server/endpoints/covidcast_utils/model.py
@@ -543,9 +543,9 @@ def _generate_transformed_rows(
     for key, source_signal_geo_rows in groupby(parsed_rows, group_keyfunc):
         base_source_name, base_signal_name, _, _ = key
         # Extract the list of derived signals; if a signal is not in the dictionary, then use the identity map.
-        derived_signal_transform_map: SourceSignalPair = transform_dict.get(SourceSignalPair(base_source_name, [base_signal_name]), SourceSignalPair(base_source_name, [base_signal_name]))
+        derived_signals: SourceSignalPair = transform_dict.get(SourceSignalPair(base_source_name, [base_signal_name]), SourceSignalPair(base_source_name, [base_signal_name]))
         # Create a list of source-signal pairs along with the transformation required for the signal.
-        signal_names_and_transforms: List[Tuple[Tuple[str, str], Callable]] = [(derived_signal, _get_base_signal_transform((base_source_name, derived_signal))) for derived_signal in derived_signal_transform_map.signal]
+        signal_names_and_transforms: List[Tuple[Tuple[str, str], Callable]] = [(derived_signal, _get_base_signal_transform((base_source_name, derived_signal))) for derived_signal in derived_signals.signal]
         # Put the current time series on a contiguous time index.
         source_signal_geo_rows = _reindex_iterable(source_signal_geo_rows, fill_value=transform_args.get("pad_fill_value"))
         # Create copies of the iterable, with smart memory usage.


### PR DESCRIPTION
This is a variant of #1026.

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Create an early exit from the JIT iterator stack for non-derived signals. The advantage of this approach is that it still relies on a single database query, instead of making multiple, like #1026.