### PR TITLE
[JIT]: remove stream_results from db options for speed tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
   image:
     needs: build
     # only on main and dev branch
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/ds/dev-no-streaming'
 
     runs-on: ubuntu-latest
     steps:
@@ -131,6 +131,9 @@ jobs:
           if [ "$imageTag" = "main" ] ; then
             imageTag="latest"
           fi
+          if [ "$imageTag" = "ds/dev-no-streaming" ] ; then
+            imageTag="dev-no-streaming"
+          fi           
           echo "::set-output name=tag::$imageTag"
           echo "::set-output name=repo::ghcr.io/${{ github.repository }}"
       - name: Push Dev Tag

--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -239,7 +239,7 @@ def run_query(p: APrinter, query_tuple: Tuple[str, Dict[str, Any]]):
     query, params = query_tuple
     # limit rows + 1 for detecting whether we would have more
     full_query = text(limit_query(query, p.remaining_rows + 1))
-    return db.execution_options(stream_results=True).execute(full_query, **params)
+    return db.execute(full_query, **params)
 
 
 def _identity_transform(row: Dict[str, Any], _: Row) -> Dict[str, Any]:


### PR DESCRIPTION
As part of benchmarking #646, this removes the streaming option from the database call.

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

The database should no longer stream the results to the server and instead serve them fully.

The Docker image built here is called `dev-no-streaming`.