### PR TITLE
Server: fix unbound exception variable

### DIFF
--- a/src/server/_printer.py
+++ b/src/server/_printer.py
@@ -58,7 +58,7 @@ class APrinter:
                     r = self._print_row(row)
                     if r is not None:
                         yield r
-            except:
+            except Exception as e:
                 get_structured_logger('server_error').error("Exception while executing printer", exception=e)
                 self.result = -1
                 yield self._error(e)


### PR DESCRIPTION
Small accident, quick fix. Likely gets caught somewhere else anyway, but better to be explicit.

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

An exception variable got unbound, even though it is used.