### PR TITLE
API server code health pass - rename *Pair classes to *Set

### DIFF
--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -57,7 +57,7 @@ class GeoSet:
 
     def count(self) -> float:
         """
-        returns the count of items in this pair
+        returns the count of items in this set
         """
         if isinstance(self.geo_values, bool):
             return inf if self.geo_values else 0
@@ -70,7 +70,7 @@ def parse_geo_arg(key: str = "geo") -> List[GeoSet]:
 
 def parse_single_geo_arg(key: str) -> GeoSet:
     """
-    parses a single geo pair with only one value
+    parses a single geo set with only one value
     """
     r = _parse_single_arg(key)
     return GeoSet(r[0], [r[1]])
@@ -86,7 +86,7 @@ class SourceSignalSet:
 
     def count(self) -> float:
         """
-        returns the count of items in this pair
+        returns the count of items in this set
         """
         if isinstance(self.signal, bool):
             return inf if self.signal else 0
@@ -99,7 +99,7 @@ def parse_source_signal_arg(key: str = "signal") -> List[SourceSignalSet]:
 
 def parse_single_source_signal_arg(key: str) -> SourceSignalSet:
     """
-    parses a single source signal pair with only one value
+    parses a single source signal set with only one value
     """
     r = _parse_single_arg(key)
     return SourceSignalSet(r[0], [r[1]])
@@ -121,7 +121,7 @@ class TimeSet:
 
     def count(self) -> float:
         """
-        returns the count of items in this pair
+        returns the count of items in this set
         """
         if isinstance(self.time_values, bool):
             return inf if self.time_values else 0
@@ -131,7 +131,7 @@ class TimeSet:
 
     def to_ranges(self):
         """
-        returns this pair with times converted to ranges
+        returns this set with times converted to ranges
         """
         if isinstance(self.time_values, bool):
             return TimeSet(self.time_type, self.time_values)
@@ -204,7 +204,7 @@ def parse_day_value(time_value: str) -> IntRange:
     raise ValidationFailedException(msg)
 
 
-def _parse_time_pair(time_type: str, time_values: Union[bool, Sequence[str]]) -> TimeSet:
+def _parse_time_set(time_type: str, time_values: Union[bool, Sequence[str]]) -> TimeSet:
     if isinstance(time_values, bool):
         return TimeSet(time_type, time_values)
 
@@ -216,35 +216,35 @@ def _parse_time_pair(time_type: str, time_values: Union[bool, Sequence[str]]) ->
 
 
 def parse_time_arg(key: str = "time") -> Optional[TimeSet]:
-    time_pairs = [_parse_time_pair(time_type, time_values) for [time_type, time_values] in _parse_common_multi_arg(key)]
+    time_sets = [_parse_time_set(time_type, time_values) for [time_type, time_values] in _parse_common_multi_arg(key)]
 
     # single value
-    if len(time_pairs) == 0:
+    if len(time_sets) == 0:
         return None
-    if len(time_pairs) == 1:
-        return time_pairs[0]
+    if len(time_sets) == 1:
+        return time_sets[0]
 
     # make sure 'day' and 'week' aren't mixed
-    time_types = set(time_pair.time_type for time_pair in time_pairs)
+    time_types = set(time_set.time_type for time_set in time_sets)
     if len(time_types) >= 2:
-        raise ValidationFailedException(f'{key}: {time_pairs} mixes "day" and "week" time types')
+        raise ValidationFailedException(f'{key}: {time_sets} mixes "day" and "week" time types')
 
-    # merge all time pairs into one
+    # merge all time sets into one
     merged = []
-    for time_pair in time_pairs:
-        if time_pair.time_values is True:
-            return time_pair
+    for time_set in time_sets:
+        if time_set.time_values is True:
+            return time_set
         else:
-            merged.extend(time_pair.time_values)
-    return TimeSet(time_pairs[0].time_type, merged).to_ranges()
+            merged.extend(time_set.time_values)
+    return TimeSet(time_sets[0].time_type, merged).to_ranges()
 
 
 def parse_single_time_arg(key: str) -> TimeSet:
     """
-    parses a single time pair with only one value
+    parses a single time set with only one value
     """
     r = _parse_single_arg(key)
-    return _parse_time_pair(r[0], [r[1]])
+    return _parse_time_set(r[0], [r[1]])
 
 
 def parse_day_range_arg(key: str) -> Tuple[int, int]:

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -48,7 +48,7 @@ def _parse_single_arg(key: str) -> Tuple[str, str]:
 
 
 @dataclass
-class GeoPair:
+class GeoSet:
     geo_type: str
     geo_values: Union[bool, Sequence[str]]
 
@@ -64,20 +64,20 @@ class GeoPair:
         return len(self.geo_values)
 
 
-def parse_geo_arg(key: str = "geo") -> List[GeoPair]:
-    return [GeoPair(geo_type, geo_values) for [geo_type, geo_values] in _parse_common_multi_arg(key)]
+def parse_geo_arg(key: str = "geo") -> List[GeoSet]:
+    return [GeoSet(geo_type, geo_values) for [geo_type, geo_values] in _parse_common_multi_arg(key)]
 
 
-def parse_single_geo_arg(key: str) -> GeoPair:
+def parse_single_geo_arg(key: str) -> GeoSet:
     """
     parses a single geo pair with only one value
     """
     r = _parse_single_arg(key)
-    return GeoPair(r[0], [r[1]])
+    return GeoSet(r[0], [r[1]])
 
 
 @dataclass
-class SourceSignalPair:
+class SourceSignalSet:
     source: str
     signal: Union[bool, Sequence[str]]
 
@@ -93,20 +93,20 @@ class SourceSignalPair:
         return len(self.signal)
 
 
-def parse_source_signal_arg(key: str = "signal") -> List[SourceSignalPair]:
-    return [SourceSignalPair(source, signals) for [source, signals] in _parse_common_multi_arg(key)]
+def parse_source_signal_arg(key: str = "signal") -> List[SourceSignalSet]:
+    return [SourceSignalSet(source, signals) for [source, signals] in _parse_common_multi_arg(key)]
 
 
-def parse_single_source_signal_arg(key: str) -> SourceSignalPair:
+def parse_single_source_signal_arg(key: str) -> SourceSignalSet:
     """
     parses a single source signal pair with only one value
     """
     r = _parse_single_arg(key)
-    return SourceSignalPair(r[0], [r[1]])
+    return SourceSignalSet(r[0], [r[1]])
 
 
 @dataclass
-class TimePair:
+class TimeSet:
     time_type: str
     time_values: Union[bool, TimeValues]
 
@@ -134,10 +134,10 @@ class TimePair:
         returns this pair with times converted to ranges
         """
         if isinstance(self.time_values, bool):
-            return TimePair(self.time_type, self.time_values)
+            return TimeSet(self.time_type, self.time_values)
         if self.time_type == 'week':
-            return TimePair(self.time_type, weeks_to_ranges(self.time_values))
-        return TimePair(self.time_type, days_to_ranges(self.time_values))
+            return TimeSet(self.time_type, weeks_to_ranges(self.time_values))
+        return TimeSet(self.time_type, days_to_ranges(self.time_values))
 
 
 def _verify_range(start: int, end: int) -> IntRange:
@@ -204,18 +204,18 @@ def parse_day_value(time_value: str) -> IntRange:
     raise ValidationFailedException(msg)
 
 
-def _parse_time_pair(time_type: str, time_values: Union[bool, Sequence[str]]) -> TimePair:
+def _parse_time_pair(time_type: str, time_values: Union[bool, Sequence[str]]) -> TimeSet:
     if isinstance(time_values, bool):
-        return TimePair(time_type, time_values)
+        return TimeSet(time_type, time_values)
 
     if time_type == "week":
-        return TimePair("week", [parse_week_value(t) for t in time_values])
+        return TimeSet("week", [parse_week_value(t) for t in time_values])
     elif time_type == "day":
-        return TimePair("day", [parse_day_value(t) for t in time_values])
+        return TimeSet("day", [parse_day_value(t) for t in time_values])
     raise ValidationFailedException(f'time param: {time_type} is not one of "day" or "week"')
 
 
-def parse_time_arg(key: str = "time") -> Optional[TimePair]:
+def parse_time_arg(key: str = "time") -> Optional[TimeSet]:
     time_pairs = [_parse_time_pair(time_type, time_values) for [time_type, time_values] in _parse_common_multi_arg(key)]
 
     # single value
@@ -236,10 +236,10 @@ def parse_time_arg(key: str = "time") -> Optional[TimePair]:
             return time_pair
         else:
             merged.extend(time_pair.time_values)
-    return TimePair(time_pairs[0].time_type, merged).to_ranges()
+    return TimeSet(time_pairs[0].time_type, merged).to_ranges()
 
 
-def parse_single_time_arg(key: str) -> TimePair:
+def parse_single_time_arg(key: str) -> TimeSet:
     """
     parses a single time pair with only one value
     """
@@ -285,20 +285,20 @@ def parse_week_range_arg(key: str) -> Tuple[int, int]:
         raise ValidationFailedException(f"{key} must match YYYYWW-YYYYWW")
     return r
 
-def parse_day_or_week_arg(key: str, default_value: Optional[int] = None) -> TimePair:
+def parse_day_or_week_arg(key: str, default_value: Optional[int] = None) -> TimeSet:
     v = request.values.get(key)
     if not v:
         if default_value is not None:
             time_type = "day" if guess_time_value_is_day(default_value) else "week"
-            return TimePair(time_type, [default_value])
+            return TimeSet(time_type, [default_value])
         raise ValidationFailedException(f"{key} param is required")
     # format is either YYYY-MM-DD or YYYYMMDD or YYYYMM
     is_week = guess_time_value_is_week(v)
     if is_week:
-        return TimePair("week", [parse_week_arg(key)])
-    return TimePair("day", [parse_day_arg(key)])
+        return TimeSet("week", [parse_week_arg(key)])
+    return TimeSet("day", [parse_day_arg(key)])
 
-def parse_day_or_week_range_arg(key: str) -> TimePair:
+def parse_day_or_week_range_arg(key: str) -> TimeSet:
     v = request.values.get(key)
     if not v:
         raise ValidationFailedException(f"{key} param is required")
@@ -306,5 +306,5 @@ def parse_day_or_week_range_arg(key: str) -> TimePair:
     # so if the first before the - has length 6, it must be a week
     is_week = guess_time_value_is_week(v.split('-', 2)[0])
     if is_week:
-        return TimePair("week", [parse_week_range_arg(key)])
-    return TimePair("day", [parse_day_range_arg(key)])
+        return TimeSet("week", [parse_week_range_arg(key)])
+    return TimeSet("day", [parse_day_range_arg(key)])

--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -19,7 +19,7 @@ from ._common import db
 from ._printer import create_printer, APrinter
 from ._exceptions import DatabaseErrorException
 from ._validate import extract_strings
-from ._params import GeoPair, SourceSignalPair, TimePair
+from ._params import GeoSet, SourceSignalSet, TimeSet
 from .utils import time_values_to_ranges, IntRange, TimeValues
 
 
@@ -118,7 +118,7 @@ def filter_fields(generator: Iterable[Dict[str, Any]]):
 def filter_geo_pairs(
     type_field: str,
     value_field: str,
-    values: Sequence[GeoPair],
+    values: Sequence[GeoSet],
     param_key: str,
     params: Dict[str, Any],
 ) -> str:
@@ -126,7 +126,7 @@ def filter_geo_pairs(
     returns the SQL sub query to filter by the given geo pairs
     """
 
-    def filter_pair(pair: GeoPair, i) -> str:
+    def filter_pair(pair: GeoSet, i) -> str:
         type_param = f"{param_key}_{i}t"
         params[type_param] = pair.geo_type
         if isinstance(pair.geo_values, bool) and pair.geo_values:
@@ -145,7 +145,7 @@ def filter_geo_pairs(
 def filter_source_signal_pairs(
     source_field: str,
     signal_field: str,
-    values: Sequence[SourceSignalPair],
+    values: Sequence[SourceSignalSet],
     param_key: str,
     params: Dict[str, Any],
 ) -> str:
@@ -153,7 +153,7 @@ def filter_source_signal_pairs(
     returns the SQL sub query to filter by the given source signal pairs
     """
 
-    def filter_pair(pair: SourceSignalPair, i) -> str:
+    def filter_pair(pair: SourceSignalSet, i) -> str:
         source_param = f"{param_key}_{i}t"
         params[source_param] = pair.source
         if isinstance(pair.signal, bool) and pair.signal:
@@ -172,7 +172,7 @@ def filter_source_signal_pairs(
 def filter_time_pair(
     type_field: str,
     time_field: str,
-    pair: Optional[TimePair],
+    pair: Optional[TimeSet],
     param_key: str,
     params: Dict[str, Any],
 ) -> str:
@@ -410,7 +410,7 @@ class QueryBuilder:
         self,
         type_field: str,
         value_field: str,
-        values: Sequence[GeoPair],
+        values: Sequence[GeoSet],
         param_key: Optional[str] = None,
     ) -> "QueryBuilder":
         fq_type_field = self._fq_field(type_field)
@@ -430,7 +430,7 @@ class QueryBuilder:
         self,
         type_field: str,
         value_field: str,
-        values: Sequence[SourceSignalPair],
+        values: Sequence[SourceSignalSet],
         param_key: Optional[str] = None,
     ) -> "QueryBuilder":
         fq_type_field = self._fq_field(type_field)
@@ -450,7 +450,7 @@ class QueryBuilder:
         self,
         type_field: str,
         value_field: str,
-        values: Optional[TimePair],
+        values: Optional[TimeSet],
         param_key: Optional[str] = None,
     ) -> "QueryBuilder":
         fq_type_field = self._fq_field(type_field)

--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -411,8 +411,8 @@ class QueryBuilder:
         type_field: str,
         value_field: str,
         values: Sequence[GeoSet],
-        param_key: Optional[str] = None
-    ):
+        param_key: Optional[str] = None,
+    ) -> "QueryBuilder":
         fq_type_field = self._fq_field(type_field)
         fq_value_field = self._fq_field(value_field)
         self.conditions.append(
@@ -431,8 +431,8 @@ class QueryBuilder:
         type_field: str,
         value_field: str,
         values: Sequence[SourceSignalSet],
-        param_key: Optional[str] = None
-    ):
+        param_key: Optional[str] = None,
+    ) -> "QueryBuilder":
         fq_type_field = self._fq_field(type_field)
         fq_value_field = self._fq_field(value_field)
         self.conditions.append(
@@ -452,7 +452,7 @@ class QueryBuilder:
         value_field: str,
         values: Optional[TimeSet],
         param_key: Optional[str] = None,
-    ):
+    ) -> "QueryBuilder":
         fq_type_field = self._fq_field(type_field)
         fq_value_field = self._fq_field(value_field)
         self.conditions.append(
@@ -466,20 +466,20 @@ class QueryBuilder:
         )
         return self
 
-    def apply_lag_filter(self, history_table: str, lag: Optional[int]):
+    def apply_lag_filter(self, history_table: str, lag: Optional[int]) -> "QueryBuilder":
         if lag is not None:
             self.retable(history_table)
             # history_table has full spectrum of lag values to search from whereas the latest_table does not
             self.where(lag=lag)
         return self
 
-    def apply_issues_filter(self, history_table: str, issues: Optional[TimeValues]):
+    def apply_issues_filter(self, history_table: str, issues: Optional[TimeValues]) -> "QueryBuilder":
         if issues:
             self.retable(history_table)
             self.where_integers("issue", issues)
         return self
 
-    def apply_as_of_filter(self, history_table: str, as_of: Optional[int]):
+    def apply_as_of_filter(self, history_table: str, as_of: Optional[int]) -> "QueryBuilder":
         if as_of is not None:
             self.retable(history_table)
             sub_condition_asof = "(issue <= :as_of)"
@@ -495,7 +495,7 @@ class QueryBuilder:
         self.fields = [f"{self.alias}.{field}" for field_list in fields for field in field_list]
         return self
 
-    def set_sort_order(self, *args: str):
+    def set_sort_order(self, *args: str) -> "QueryBuilder":
         """
         sets the order for the given fields (as key word arguments), True = ASC, False = DESC
         """

--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -126,12 +126,12 @@ def filter_geo_sets(
     returns the SQL sub query to filter by the given geo sets
     """
 
-    def filter_set(set: GeoSet, i) -> str:
+    def filter_set(gset: GeoSet, i) -> str:
         type_param = f"{param_key}_{i}t"
-        params[type_param] = set.geo_type
-        if isinstance(set.geo_values, bool) and set.geo_values:
+        params[type_param] = gset.geo_type
+        if isinstance(gset.geo_values, bool) and gset.geo_values:
             return f"{type_field} = :{type_param}"
-        return f"({type_field} = :{type_param} AND {filter_strings(value_field, cast(Sequence[str], set.geo_values), type_param, params)})"
+        return f"({type_field} = :{type_param} AND {filter_strings(value_field, cast(Sequence[str], gset.geo_values), type_param, params)})"
 
     parts = [filter_set(p, i) for i, p in enumerate(values)]
 
@@ -153,12 +153,12 @@ def filter_source_signal_sets(
     returns the SQL sub query to filter by the given source signal sets
     """
 
-    def filter_set(set: SourceSignalSet, i) -> str:
+    def filter_set(ssset: SourceSignalSet, i) -> str:
         source_param = f"{param_key}_{i}t"
-        params[source_param] = set.source
-        if isinstance(set.signal, bool) and set.signal:
+        params[source_param] = ssset.source
+        if isinstance(ssset.signal, bool) and ssset.signal:
             return f"{source_field} = :{source_param}"
-        return f"({source_field} = :{source_param} AND {filter_strings(signal_field, cast(Sequence[str], set.signal), source_param, params)})"
+        return f"({source_field} = :{source_param} AND {filter_strings(signal_field, cast(Sequence[str], ssset.signal), source_param, params)})"
 
     parts = [filter_set(p, i) for i, p in enumerate(values)]
 
@@ -172,7 +172,7 @@ def filter_source_signal_sets(
 def filter_time_set(
     type_field: str,
     time_field: str,
-    set: Optional[TimeSet],
+    tset: Optional[TimeSet],
     param_key: str,
     params: Dict[str, Any],
 ) -> str:
@@ -180,15 +180,15 @@ def filter_time_set(
     returns the SQL sub query to filter by the given time set
     """
     # safety path; should normally not be reached as time sets are enforced by the API
-    if not set:
+    if not tset:
         return "FALSE"
 
     type_param = f"{param_key}_0t"
-    params[type_param] = set.time_type
-    if isinstance(set.time_values, bool) and set.time_values:
+    params[type_param] = tset.time_type
+    if isinstance(tset.time_values, bool) and tset.time_values:
         parts =  f"{type_field} = :{type_param}"
     else:
-        ranges = set.to_ranges().time_values
+        ranges = tset.to_ranges().time_values
         parts = f"({type_field} = :{type_param} AND {filter_integers(time_field, ranges, type_param, params)})"
 
     return f"({parts})"

--- a/src/server/_query.py
+++ b/src/server/_query.py
@@ -424,6 +424,7 @@ class QueryBuilder:
                 self.params,
             )
         )
+        return self
 
     def apply_source_signal_filters(
         self,
@@ -443,6 +444,7 @@ class QueryBuilder:
                 self.params,
             )
         )
+        return self
 
     def apply_time_filter(
         self,
@@ -462,6 +464,7 @@ class QueryBuilder:
                 self.params,
             )
         )
+        return self
 
     def apply_lag_filter(self, history_table: str, lag: Optional[int]):
         if lag is not None:

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -422,7 +422,7 @@ def handle_backfill():
     is_day = time_set.is_day
     _verify_argument_time_type_matches(is_day, daily_signals, weekly_signals)
 
-    get_set = parse_single_geo_arg("geo")
+    geo_set = parse_single_geo_arg("geo")
     reference_anchor_lag = extract_integer("anchor_lag")  # in days or weeks
     if reference_anchor_lag is None:
         reference_anchor_lag = 60
@@ -438,7 +438,7 @@ def handle_backfill():
     q.set_fields(fields_string, fields_int, fields_float, ["is_latest_issue"])
 
     q.apply_source_signal_filters("source", "signal", source_signal_sets)
-    q.apply_geo_filters("geo_type", "geo_value", [get_set])
+    q.apply_geo_filters("geo_type", "geo_value", [geo_set])
     q.apply_time_filter("time_type", "time_value", time_set)
 
     p = create_printer()

--- a/src/server/endpoints/covidcast_utils/model.py
+++ b/src/server/endpoints/covidcast_utils/model.py
@@ -243,11 +243,11 @@ def count_signal_time_types(source_signals: List[SourceSignalSet]) -> Tuple[int,
     """
     weekly = 0
     daily = 0
-    for pair in source_signals:
-        if pair.signal == True:
+    for set in source_signals:
+        if set.signal == True:
             continue
-        for s in pair.signal:
-            signal = data_signals_by_key.get((pair.source, s))
+        for s in set.signal:
+            signal = data_signals_by_key.get((set.source, s))
             if not signal:
                 continue
             if signal.time_type == TimeType.week:
@@ -259,19 +259,19 @@ def count_signal_time_types(source_signals: List[SourceSignalSet]) -> Tuple[int,
 
 def create_source_signal_alias_mapper(source_signals: List[SourceSignalSet]) -> Tuple[List[SourceSignalSet], Optional[Callable[[str, str], str]]]:
     alias_to_data_sources: Dict[str, List[DataSource]] = {}
-    transformed_pairs: List[SourceSignalSet] = []
-    for pair in source_signals:
-        source = data_source_by_id.get(pair.source)
+    transformed_sets: List[SourceSignalSet] = []
+    for set in source_signals:
+        source = data_source_by_id.get(set.source)
         if not source or not source.uses_db_alias:
-            transformed_pairs.append(pair)
+            transformed_sets.append(set)
             continue
         # uses an alias
         alias_to_data_sources.setdefault(source.db_source, []).append(source)
-        if pair.signal is True:
+        if set.signal is True:
             # list all signals of this source (*) so resolve to a plain list of all in this alias
-            transformed_pairs.append(SourceSignalSet(source.db_source, [s.signal for s in source.signals]))
+            transformed_sets.append(SourceSignalSet(source.db_source, [s.signal for s in source.signals]))
         else:
-            transformed_pairs.append(SourceSignalSet(source.db_source, pair.signal))
+            transformed_sets.append(SourceSignalSet(source.db_source, set.signal))
 
     if not alias_to_data_sources:
         # no alias needed
@@ -294,4 +294,4 @@ def create_source_signal_alias_mapper(source_signals: List[SourceSignalSet]) -> 
             signal_source = possible_data_sources[0]
         return signal_source.source
 
-    return transformed_pairs, map_row
+    return transformed_sets, map_row

--- a/src/server/endpoints/covidcast_utils/model.py
+++ b/src/server/endpoints/covidcast_utils/model.py
@@ -243,11 +243,11 @@ def count_signal_time_types(source_signals: List[SourceSignalSet]) -> Tuple[int,
     """
     weekly = 0
     daily = 0
-    for set in source_signals:
-        if set.signal == True:
+    for ssset in source_signals:
+        if ssset.signal == True:
             continue
-        for s in set.signal:
-            signal = data_signals_by_key.get((set.source, s))
+        for s in ssset.signal:
+            signal = data_signals_by_key.get((ssset.source, s))
             if not signal:
                 continue
             if signal.time_type == TimeType.week:
@@ -260,18 +260,18 @@ def count_signal_time_types(source_signals: List[SourceSignalSet]) -> Tuple[int,
 def create_source_signal_alias_mapper(source_signals: List[SourceSignalSet]) -> Tuple[List[SourceSignalSet], Optional[Callable[[str, str], str]]]:
     alias_to_data_sources: Dict[str, List[DataSource]] = {}
     transformed_sets: List[SourceSignalSet] = []
-    for set in source_signals:
-        source = data_source_by_id.get(set.source)
+    for ssset in source_signals:
+        source = data_source_by_id.get(ssset.source)
         if not source or not source.uses_db_alias:
-            transformed_sets.append(set)
+            transformed_sets.append(ssset)
             continue
         # uses an alias
         alias_to_data_sources.setdefault(source.db_source, []).append(source)
-        if set.signal is True:
+        if ssset.signal is True:
             # list all signals of this source (*) so resolve to a plain list of all in this alias
             transformed_sets.append(SourceSignalSet(source.db_source, [s.signal for s in source.signals]))
         else:
-            transformed_sets.append(SourceSignalSet(source.db_source, set.signal))
+            transformed_sets.append(SourceSignalSet(source.db_source, ssset.signal))
 
     if not alias_to_data_sources:
         # no alias needed

--- a/src/server/endpoints/covidcast_utils/model.py
+++ b/src/server/endpoints/covidcast_utils/model.py
@@ -6,7 +6,7 @@ import re
 import pandas as pd
 import numpy as np
 
-from ..._params import SourceSignalPair
+from ..._params import SourceSignalSet
 
 
 class HighValuesAre(str, Enum):
@@ -236,7 +236,7 @@ for d in data_signals:
         data_signals_by_key[(source.db_source, d.signal)] = d
 
 
-def count_signal_time_types(source_signals: List[SourceSignalPair]) -> Tuple[int, int]:
+def count_signal_time_types(source_signals: List[SourceSignalSet]) -> Tuple[int, int]:
     """
     count the number of signals in this query for each time type
     @returns daily counts, weekly counts
@@ -257,9 +257,9 @@ def count_signal_time_types(source_signals: List[SourceSignalPair]) -> Tuple[int
     return daily, weekly
 
 
-def create_source_signal_alias_mapper(source_signals: List[SourceSignalPair]) -> Tuple[List[SourceSignalPair], Optional[Callable[[str, str], str]]]:
+def create_source_signal_alias_mapper(source_signals: List[SourceSignalSet]) -> Tuple[List[SourceSignalSet], Optional[Callable[[str, str], str]]]:
     alias_to_data_sources: Dict[str, List[DataSource]] = {}
-    transformed_pairs: List[SourceSignalPair] = []
+    transformed_pairs: List[SourceSignalSet] = []
     for pair in source_signals:
         source = data_source_by_id.get(pair.source)
         if not source or not source.uses_db_alias:
@@ -269,9 +269,9 @@ def create_source_signal_alias_mapper(source_signals: List[SourceSignalPair]) ->
         alias_to_data_sources.setdefault(source.db_source, []).append(source)
         if pair.signal is True:
             # list all signals of this source (*) so resolve to a plain list of all in this alias
-            transformed_pairs.append(SourceSignalPair(source.db_source, [s.signal for s in source.signals]))
+            transformed_pairs.append(SourceSignalSet(source.db_source, [s.signal for s in source.signals]))
         else:
-            transformed_pairs.append(SourceSignalPair(source.db_source, pair.signal))
+            transformed_pairs.append(SourceSignalSet(source.db_source, pair.signal))
 
     if not alias_to_data_sources:
         # no alias needed

--- a/tests/server/endpoints/test_covidcast.py
+++ b/tests/server/endpoints/test_covidcast.py
@@ -5,11 +5,6 @@ from flask.testing import FlaskClient
 from flask import Response
 from delphi.epidata.server.main import app
 
-from delphi.epidata.server._params import (
-    GeoPair,
-    TimePair,
-)
-
 # py3tester coverage target
 __test_target__ = "delphi.epidata.server.endpoints.covidcast"
 

--- a/tests/server/test_params.py
+++ b/tests/server/test_params.py
@@ -38,7 +38,7 @@ class UnitTests(unittest.TestCase):
         app.config["WTF_CSRF_ENABLED"] = False
         app.config["DEBUG"] = False
 
-    def test_geo_pair(self):
+    def test_geo_set(self):
         with self.subTest("*"):
             p = GeoSet("hrr", True)
             self.assertTrue(p.matches("hrr", "any"))
@@ -54,7 +54,7 @@ class UnitTests(unittest.TestCase):
             self.assertEqual(GeoSet("a", False).count(), 0)
             self.assertEqual(GeoSet("a", ["a", "b"]).count(), 2)
 
-    def test_source_signal_pair(self):
+    def test_source_signal_set(self):
         with self.subTest("*"):
             p = SourceSignalSet("src1", True)
             self.assertTrue(p.matches("src1", "any"))
@@ -70,7 +70,7 @@ class UnitTests(unittest.TestCase):
             self.assertEqual(SourceSignalSet("a", False).count(), 0)
             self.assertEqual(SourceSignalSet("a", ["a", "b"]).count(), 2)
 
-    def test_time_pair(self):
+    def test_time_set(self):
         with self.subTest("count"):
             self.assertEqual(TimeSet("day", True).count(), inf)
             self.assertEqual(TimeSet("day", False).count(), 0)

--- a/tests/server/test_params.py
+++ b/tests/server/test_params.py
@@ -16,9 +16,9 @@ from delphi.epidata.server._params import (
     parse_week_value,
     parse_day_range_arg,
     parse_day_arg,
-    GeoPair,
-    TimePair,
-    SourceSignalPair,
+    GeoSet,
+    TimeSet,
+    SourceSignalSet,
 )
 from delphi.epidata.server._exceptions import (
     ValidationFailedException,
@@ -40,44 +40,44 @@ class UnitTests(unittest.TestCase):
 
     def test_geo_pair(self):
         with self.subTest("*"):
-            p = GeoPair("hrr", True)
+            p = GeoSet("hrr", True)
             self.assertTrue(p.matches("hrr", "any"))
             self.assertFalse(p.matches("msa", "any"))
         with self.subTest("subset"):
-            p = GeoPair("hrr", ["a", "b"])
+            p = GeoSet("hrr", ["a", "b"])
             self.assertTrue(p.matches("hrr", "a"))
             self.assertTrue(p.matches("hrr", "b"))
             self.assertFalse(p.matches("hrr", "c"))
             self.assertFalse(p.matches("msa", "any"))
         with self.subTest("count"):
-            self.assertEqual(GeoPair("a", True).count(), inf)
-            self.assertEqual(GeoPair("a", False).count(), 0)
-            self.assertEqual(GeoPair("a", ["a", "b"]).count(), 2)
+            self.assertEqual(GeoSet("a", True).count(), inf)
+            self.assertEqual(GeoSet("a", False).count(), 0)
+            self.assertEqual(GeoSet("a", ["a", "b"]).count(), 2)
 
     def test_source_signal_pair(self):
         with self.subTest("*"):
-            p = SourceSignalPair("src1", True)
+            p = SourceSignalSet("src1", True)
             self.assertTrue(p.matches("src1", "any"))
             self.assertFalse(p.matches("src2", "any"))
         with self.subTest("subset"):
-            p = SourceSignalPair("src1", ["a", "b"])
+            p = SourceSignalSet("src1", ["a", "b"])
             self.assertTrue(p.matches("src1", "a"))
             self.assertTrue(p.matches("src1", "b"))
             self.assertFalse(p.matches("src1", "c"))
             self.assertFalse(p.matches("src2", "any"))
         with self.subTest("count"):
-            self.assertEqual(SourceSignalPair("a", True).count(), inf)
-            self.assertEqual(SourceSignalPair("a", False).count(), 0)
-            self.assertEqual(SourceSignalPair("a", ["a", "b"]).count(), 2)
+            self.assertEqual(SourceSignalSet("a", True).count(), inf)
+            self.assertEqual(SourceSignalSet("a", False).count(), 0)
+            self.assertEqual(SourceSignalSet("a", ["a", "b"]).count(), 2)
 
     def test_time_pair(self):
         with self.subTest("count"):
-            self.assertEqual(TimePair("day", True).count(), inf)
-            self.assertEqual(TimePair("day", False).count(), 0)
-            self.assertEqual(TimePair("day", [20200202, 20200201]).count(), 2)
-            self.assertEqual(TimePair("day", [(20200201, 20200202)]).count(), 2)
-            self.assertEqual(TimePair("day", [(20200201, 20200205)]).count(), 5)
-            self.assertEqual(TimePair("day", [(20200201, 20200205), 20201212]).count(), 6)
+            self.assertEqual(TimeSet("day", True).count(), inf)
+            self.assertEqual(TimeSet("day", False).count(), 0)
+            self.assertEqual(TimeSet("day", [20200202, 20200201]).count(), 2)
+            self.assertEqual(TimeSet("day", [(20200201, 20200202)]).count(), 2)
+            self.assertEqual(TimeSet("day", [(20200201, 20200205)]).count(), 5)
+            self.assertEqual(TimeSet("day", [(20200201, 20200205), 20201212]).count(), 6)
 
     def test_parse_geo_arg(self):
         with self.subTest("empty"):
@@ -85,32 +85,32 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(parse_geo_arg(), [])
         with self.subTest("single"):
             with app.test_request_context("/?geo=state:*"):
-                self.assertEqual(parse_geo_arg(), [GeoPair("state", True)])
+                self.assertEqual(parse_geo_arg(), [GeoSet("state", True)])
             with app.test_request_context("/?geo=state:AK"):
-                self.assertEqual(parse_geo_arg(), [GeoPair("state", ["ak"])])
+                self.assertEqual(parse_geo_arg(), [GeoSet("state", ["ak"])])
         with self.subTest("single list"):
             with app.test_request_context("/?geo=state:AK,TK"):
-                self.assertEqual(parse_geo_arg(), [GeoPair("state", ["ak", "tk"])])
+                self.assertEqual(parse_geo_arg(), [GeoSet("state", ["ak", "tk"])])
         with self.subTest("multi"):
             with app.test_request_context("/?geo=state:*;nation:*"):
-                self.assertEqual(parse_geo_arg(), [GeoPair("state", True), GeoPair("nation", True)])
+                self.assertEqual(parse_geo_arg(), [GeoSet("state", True), GeoSet("nation", True)])
             with app.test_request_context("/?geo=state:AK;nation:US"):
                 self.assertEqual(
                     parse_geo_arg(),
-                    [GeoPair("state", ["ak"]), GeoPair("nation", ["us"])],
+                    [GeoSet("state", ["ak"]), GeoSet("nation", ["us"])],
                 )
             with app.test_request_context("/?geo=state:AK;state:KY"):
                 self.assertEqual(
                     parse_geo_arg(),
-                    [GeoPair("state", ["ak"]), GeoPair("state", ["ky"])],
+                    [GeoSet("state", ["ak"]), GeoSet("state", ["ky"])],
                 )
         with self.subTest("multi list"):
             with app.test_request_context("/?geo=state:AK,TK;county:42003,40556"):
                 self.assertEqual(
                     parse_geo_arg(),
                     [
-                        GeoPair("state", ["ak", "tk"]),
-                        GeoPair("county", ["42003", "40556"]),
+                        GeoSet("state", ["ak", "tk"]),
+                        GeoSet("county", ["42003", "40556"]),
                     ],
                 )
         with self.subTest("hybrid"):
@@ -118,9 +118,9 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(
                     parse_geo_arg(),
                     [
-                        GeoPair("nation", True),
-                        GeoPair("state", ["pa"]),
-                        GeoPair("county", ["42003", "42002"]),
+                        GeoSet("nation", True),
+                        GeoSet("state", ["pa"]),
+                        GeoSet("county", ["42003", "42002"]),
                     ],
                 )
 
@@ -136,7 +136,7 @@ class UnitTests(unittest.TestCase):
                 self.assertRaises(ValidationFailedException, parse_single_geo_arg, "geo")
         with self.subTest("single"):
             with app.test_request_context("/?geo=state:AK"):
-                self.assertEqual(parse_single_geo_arg("geo"), GeoPair("state", ["ak"]))
+                self.assertEqual(parse_single_geo_arg("geo"), GeoSet("state", ["ak"]))
         with self.subTest("single list"):
             with app.test_request_context("/?geo=state:AK,TK"):
                 self.assertRaises(ValidationFailedException, parse_single_geo_arg, "geo")
@@ -155,35 +155,35 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(parse_source_signal_arg(), [])
         with self.subTest("single"):
             with app.test_request_context("/?signal=src1:*"):
-                self.assertEqual(parse_source_signal_arg(), [SourceSignalPair("src1", True)])
+                self.assertEqual(parse_source_signal_arg(), [SourceSignalSet("src1", True)])
             with app.test_request_context("/?signal=src1:sig1"):
-                self.assertEqual(parse_source_signal_arg(), [SourceSignalPair("src1", ["sig1"])])
+                self.assertEqual(parse_source_signal_arg(), [SourceSignalSet("src1", ["sig1"])])
         with self.subTest("single list"):
             with app.test_request_context("/?signal=src1:sig1,sig2"):
                 self.assertEqual(
                     parse_source_signal_arg(),
-                    [SourceSignalPair("src1", ["sig1", "sig2"])],
+                    [SourceSignalSet("src1", ["sig1", "sig2"])],
                 )
         with self.subTest("multi"):
             with app.test_request_context("/?signal=src1:*;src2:*"):
                 self.assertEqual(
                     parse_source_signal_arg(),
-                    [SourceSignalPair("src1", True), SourceSignalPair("src2", True)],
+                    [SourceSignalSet("src1", True), SourceSignalSet("src2", True)],
                 )
             with app.test_request_context("/?signal=src1:sig1;src2:sig3"):
                 self.assertEqual(
                     parse_source_signal_arg(),
                     [
-                        SourceSignalPair("src1", ["sig1"]),
-                        SourceSignalPair("src2", ["sig3"]),
+                        SourceSignalSet("src1", ["sig1"]),
+                        SourceSignalSet("src2", ["sig3"]),
                     ],
                 )
             with app.test_request_context("/?signal=src1:sig1;src1:sig4"):
                 self.assertEqual(
                     parse_source_signal_arg(),
                     [
-                        SourceSignalPair("src1", ["sig1"]),
-                        SourceSignalPair("src1", ["sig4"]),
+                        SourceSignalSet("src1", ["sig1"]),
+                        SourceSignalSet("src1", ["sig4"]),
                     ],
                 )
         with self.subTest("multi list"):
@@ -191,8 +191,8 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(
                     parse_source_signal_arg(),
                     [
-                        SourceSignalPair("src1", ["sig1", "sig2"]),
-                        SourceSignalPair("county", ["sig5", "sig6"]),
+                        SourceSignalSet("src1", ["sig1", "sig2"]),
+                        SourceSignalSet("county", ["sig5", "sig6"]),
                     ],
                 )
         with self.subTest("hybrid"):
@@ -200,9 +200,9 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(
                     parse_source_signal_arg(),
                     [
-                        SourceSignalPair("src2", True),
-                        SourceSignalPair("src1", ["sig4"]),
-                        SourceSignalPair("src3", ["sig5", "sig6"]),
+                        SourceSignalSet("src2", True),
+                        SourceSignalSet("src1", ["sig4"]),
+                        SourceSignalSet("src3", ["sig5", "sig6"]),
                     ],
                 )
 
@@ -218,7 +218,7 @@ class UnitTests(unittest.TestCase):
                 self.assertRaises(ValidationFailedException, parse_single_source_signal_arg, "signal")
         with self.subTest("single"):
             with app.test_request_context("/?signal=src1:sig1"):
-                self.assertEqual(parse_single_source_signal_arg("signal"), SourceSignalPair("src1", ["sig1"]))
+                self.assertEqual(parse_single_source_signal_arg("signal"), SourceSignalSet("src1", ["sig1"]))
         with self.subTest("single list"):
             with app.test_request_context("/?signal=src1:sig1,sig2"):
                 self.assertRaises(ValidationFailedException, parse_single_source_signal_arg, "signal")
@@ -270,35 +270,35 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(parse_time_arg(), None)
         with self.subTest("single"):
             with app.test_request_context("/?time=day:*"):
-                self.assertEqual(parse_time_arg(), TimePair("day", True))
+                self.assertEqual(parse_time_arg(), TimeSet("day", True))
             with app.test_request_context("/?time=day:20201201"):
-                self.assertEqual(parse_time_arg(), TimePair("day", [20201201]))
+                self.assertEqual(parse_time_arg(), TimeSet("day", [20201201]))
         with self.subTest("single list"):
             with app.test_request_context("/?time=day:20201201,20201202"):
-                self.assertEqual(parse_time_arg(), TimePair("day", [20201201, 20201202]))
+                self.assertEqual(parse_time_arg(), TimeSet("day", [20201201, 20201202]))
         with self.subTest("single range"):
             with app.test_request_context("/?time=day:20201201-20201204"):
-                self.assertEqual(parse_time_arg(), TimePair("day", [(20201201, 20201204)]))
+                self.assertEqual(parse_time_arg(), TimeSet("day", [(20201201, 20201204)]))
         with self.subTest("multi"):
             with app.test_request_context("/?time=day:*;day:20201201"):
                 self.assertEqual(
                     parse_time_arg(),
-                    TimePair("day", True)
+                    TimeSet("day", True)
                 )
             with app.test_request_context("/?time=week:*;week:202012"):
                 self.assertEqual(
                     parse_time_arg(),
-                    TimePair("week", True)
+                    TimeSet("week", True)
                 )
             with app.test_request_context("/?time=day:20201201;day:20201202-20201205"):
                 self.assertEqual(
                     parse_time_arg(),
-                    TimePair("day", [(20201201, 20201205)])
+                    TimeSet("day", [(20201201, 20201205)])
                 )
             with app.test_request_context("/?time=week:202012;week:202013-202015"):
                 self.assertEqual(
                     parse_time_arg(),
-                    TimePair("week", [(202012, 202015)])
+                    TimeSet("week", [(202012, 202015)])
                 )
 
         with self.subTest("wrong"):

--- a/tests/server/test_query.py
+++ b/tests/server/test_query.py
@@ -17,9 +17,9 @@ from delphi.epidata.server._query import (
     filter_time_pair,
 )
 from delphi.epidata.server._params import (
-    GeoPair,
-    TimePair,
-    SourceSignalPair,
+    GeoSet,
+    TimeSet,
+    SourceSignalSet,
 )
 
 # py3tester coverage target
@@ -138,21 +138,21 @@ class UnitTests(unittest.TestCase):
         with self.subTest("*"):
             params = {}
             self.assertEqual(
-                filter_geo_pairs("t", "v", [GeoPair("state", True)], "p", params),
+                filter_geo_pairs("t", "v", [GeoSet("state", True)], "p", params),
                 "(t = :p_0t)",
             )
             self.assertEqual(params, {"p_0t": "state"})
         with self.subTest("single"):
             params = {}
             self.assertEqual(
-                filter_geo_pairs("t", "v", [GeoPair("state", ["KY"])], "p", params),
+                filter_geo_pairs("t", "v", [GeoSet("state", ["KY"])], "p", params),
                 "((t = :p_0t AND (v = :p_0t_0)))",
             )
             self.assertEqual(params, {"p_0t": "state", "p_0t_0": "KY"})
         with self.subTest("multi"):
             params = {}
             self.assertEqual(
-                filter_geo_pairs("t", "v", [GeoPair("state", ["KY", "AK"])], "p", params),
+                filter_geo_pairs("t", "v", [GeoSet("state", ["KY", "AK"])], "p", params),
                 "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
             )
             self.assertEqual(params, {"p_0t": "state", "p_0t_0": "KY", "p_0t_1": "AK"})
@@ -162,7 +162,7 @@ class UnitTests(unittest.TestCase):
                 filter_geo_pairs(
                     "t",
                     "v",
-                    [GeoPair("state", True), GeoPair("nation", True)],
+                    [GeoSet("state", True), GeoSet("nation", True)],
                     "p",
                     params,
                 ),
@@ -175,7 +175,7 @@ class UnitTests(unittest.TestCase):
                 filter_geo_pairs(
                     "t",
                     "v",
-                    [GeoPair("state", ["AK"]), GeoPair("nation", ["US"])],
+                    [GeoSet("state", ["AK"]), GeoSet("nation", ["US"])],
                     "p",
                     params,
                 ),
@@ -194,21 +194,21 @@ class UnitTests(unittest.TestCase):
         with self.subTest("*"):
             params = {}
             self.assertEqual(
-                filter_source_signal_pairs("t", "v", [SourceSignalPair("src1", True)], "p", params),
+                filter_source_signal_pairs("t", "v", [SourceSignalSet("src1", True)], "p", params),
                 "(t = :p_0t)",
             )
             self.assertEqual(params, {"p_0t": "src1"})
         with self.subTest("single"):
             params = {}
             self.assertEqual(
-                filter_source_signal_pairs("t", "v", [SourceSignalPair("src1", ["sig1"])], "p", params),
+                filter_source_signal_pairs("t", "v", [SourceSignalSet("src1", ["sig1"])], "p", params),
                 "((t = :p_0t AND (v = :p_0t_0)))",
             )
             self.assertEqual(params, {"p_0t": "src1", "p_0t_0": "sig1"})
         with self.subTest("multi"):
             params = {}
             self.assertEqual(
-                filter_source_signal_pairs("t", "v", [SourceSignalPair("src1", ["sig1", "sig2"])], "p", params),
+                filter_source_signal_pairs("t", "v", [SourceSignalSet("src1", ["sig1", "sig2"])], "p", params),
                 "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
             )
             self.assertEqual(params, {"p_0t": "src1", "p_0t_0": "sig1", "p_0t_1": "sig2"})
@@ -218,7 +218,7 @@ class UnitTests(unittest.TestCase):
                 filter_source_signal_pairs(
                     "t",
                     "v",
-                    [SourceSignalPair("src1", True), SourceSignalPair("src2", True)],
+                    [SourceSignalSet("src1", True), SourceSignalSet("src2", True)],
                     "p",
                     params,
                 ),
@@ -232,8 +232,8 @@ class UnitTests(unittest.TestCase):
                     "t",
                     "v",
                     [
-                        SourceSignalPair("src1", ["sig2"]),
-                        SourceSignalPair("src2", ["srcx"]),
+                        SourceSignalSet("src1", ["sig2"]),
+                        SourceSignalSet("src2", ["srcx"]),
                     ],
                     "p",
                     params,
@@ -253,49 +253,49 @@ class UnitTests(unittest.TestCase):
         with self.subTest("*"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimePair("day", True), "p", params),
+                filter_time_pair("t", "v", TimeSet("day", True), "p", params),
                 "(t = :p_0t)",
             )
             self.assertEqual(params, {"p_0t": "day"})
         with self.subTest("single"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimePair("day", [20201201]), "p", params),
+                filter_time_pair("t", "v", TimeSet("day", [20201201]), "p", params),
                 "((t = :p_0t AND (v = :p_0t_0)))",
             )
             self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20201201})
         with self.subTest("multi"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimePair("day", [20201201, 20201203]), "p", params),
+                filter_time_pair("t", "v", TimeSet("day", [20201201, 20201203]), "p", params),
                 "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
             )
             self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20201201, "p_0t_1": 20201203})
         with self.subTest("range"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimePair("day", [(20201201, 20201203)]), "p", params),
+                filter_time_pair("t", "v", TimeSet("day", [(20201201, 20201203)]), "p", params),
                 "((t = :p_0t AND (v BETWEEN :p_0t_0 AND :p_0t_0_2)))",
             )
             self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20201201, "p_0t_0_2": 20201203})
         with self.subTest("dedupe"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimePair("day", [20200101, 20200101, (20200101, 20200101), 20200101]), "p", params),
+                filter_time_pair("t", "v", TimeSet("day", [20200101, 20200101, (20200101, 20200101), 20200101]), "p", params),
                 "((t = :p_0t AND (v = :p_0t_0)))",
             )
             self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20200101})
         with self.subTest("merge single range"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimePair("day", [20200101, 20200102, (20200101, 20200104)]), "p", params),
+                filter_time_pair("t", "v", TimeSet("day", [20200101, 20200102, (20200101, 20200104)]), "p", params),
                 "((t = :p_0t AND (v BETWEEN :p_0t_0 AND :p_0t_0_2)))",
             )
             self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20200101, "p_0t_0_2": 20200104})
         with self.subTest("merge ranges and singles"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimePair("day", [20200101, 20200103, (20200105, 20200107)]), "p", params),
+                filter_time_pair("t", "v", TimeSet("day", [20200101, 20200103, (20200105, 20200107)]), "p", params),
                 "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1 OR v BETWEEN :p_0t_2 AND :p_0t_2_2)))",
             )
             self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20200101, "p_0t_1": 20200103, 'p_0t_2': 20200105, 'p_0t_2_2': 20200107})           

--- a/tests/server/test_query.py
+++ b/tests/server/test_query.py
@@ -12,9 +12,9 @@ from delphi.epidata.server._query import (
     filter_strings,
     filter_integers,
     filter_dates,
-    filter_geo_pairs,
-    filter_source_signal_pairs,
-    filter_time_pair,
+    filter_geo_sets,
+    filter_source_signal_sets,
+    filter_time_set,
 )
 from delphi.epidata.server._params import (
     GeoSet,
@@ -130,36 +130,36 @@ class UnitTests(unittest.TestCase):
             },
         )
 
-    def test_filter_geo_pairs(self):
+    def test_filter_geo_sets(self):
         with self.subTest("empty"):
             params = {}
-            self.assertEqual(filter_geo_pairs("t", "v", [], "p", params), "FALSE")
+            self.assertEqual(filter_geo_sets("t", "v", [], "p", params), "FALSE")
             self.assertEqual(params, {})
         with self.subTest("*"):
             params = {}
             self.assertEqual(
-                filter_geo_pairs("t", "v", [GeoSet("state", True)], "p", params),
+                filter_geo_sets("t", "v", [GeoSet("state", True)], "p", params),
                 "(t = :p_0t)",
             )
             self.assertEqual(params, {"p_0t": "state"})
         with self.subTest("single"):
             params = {}
             self.assertEqual(
-                filter_geo_pairs("t", "v", [GeoSet("state", ["KY"])], "p", params),
+                filter_geo_sets("t", "v", [GeoSet("state", ["KY"])], "p", params),
                 "((t = :p_0t AND (v = :p_0t_0)))",
             )
             self.assertEqual(params, {"p_0t": "state", "p_0t_0": "KY"})
         with self.subTest("multi"):
             params = {}
             self.assertEqual(
-                filter_geo_pairs("t", "v", [GeoSet("state", ["KY", "AK"])], "p", params),
+                filter_geo_sets("t", "v", [GeoSet("state", ["KY", "AK"])], "p", params),
                 "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
             )
             self.assertEqual(params, {"p_0t": "state", "p_0t_0": "KY", "p_0t_1": "AK"})
         with self.subTest("multiple pairs"):
             params = {}
             self.assertEqual(
-                filter_geo_pairs(
+                filter_geo_sets(
                     "t",
                     "v",
                     [GeoSet("state", True), GeoSet("nation", True)],
@@ -172,7 +172,7 @@ class UnitTests(unittest.TestCase):
         with self.subTest("multiple pairs with value"):
             params = {}
             self.assertEqual(
-                filter_geo_pairs(
+                filter_geo_sets(
                     "t",
                     "v",
                     [GeoSet("state", ["AK"]), GeoSet("nation", ["US"])],
@@ -186,36 +186,36 @@ class UnitTests(unittest.TestCase):
                 {"p_0t": "state", "p_0t_0": "AK", "p_1t": "nation", "p_1t_0": "US"},
             )
 
-    def test_filter_source_signal_pairs(self):
+    def test_filter_source_signal_sets(self):
         with self.subTest("empty"):
             params = {}
-            self.assertEqual(filter_source_signal_pairs("t", "v", [], "p", params), "FALSE")
+            self.assertEqual(filter_source_signal_sets("t", "v", [], "p", params), "FALSE")
             self.assertEqual(params, {})
         with self.subTest("*"):
             params = {}
             self.assertEqual(
-                filter_source_signal_pairs("t", "v", [SourceSignalSet("src1", True)], "p", params),
+                filter_source_signal_sets("t", "v", [SourceSignalSet("src1", True)], "p", params),
                 "(t = :p_0t)",
             )
             self.assertEqual(params, {"p_0t": "src1"})
         with self.subTest("single"):
             params = {}
             self.assertEqual(
-                filter_source_signal_pairs("t", "v", [SourceSignalSet("src1", ["sig1"])], "p", params),
+                filter_source_signal_sets("t", "v", [SourceSignalSet("src1", ["sig1"])], "p", params),
                 "((t = :p_0t AND (v = :p_0t_0)))",
             )
             self.assertEqual(params, {"p_0t": "src1", "p_0t_0": "sig1"})
         with self.subTest("multi"):
             params = {}
             self.assertEqual(
-                filter_source_signal_pairs("t", "v", [SourceSignalSet("src1", ["sig1", "sig2"])], "p", params),
+                filter_source_signal_sets("t", "v", [SourceSignalSet("src1", ["sig1", "sig2"])], "p", params),
                 "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
             )
             self.assertEqual(params, {"p_0t": "src1", "p_0t_0": "sig1", "p_0t_1": "sig2"})
         with self.subTest("multiple pairs"):
             params = {}
             self.assertEqual(
-                filter_source_signal_pairs(
+                filter_source_signal_sets(
                     "t",
                     "v",
                     [SourceSignalSet("src1", True), SourceSignalSet("src2", True)],
@@ -228,7 +228,7 @@ class UnitTests(unittest.TestCase):
         with self.subTest("multiple pairs with value"):
             params = {}
             self.assertEqual(
-                filter_source_signal_pairs(
+                filter_source_signal_sets(
                     "t",
                     "v",
                     [
@@ -245,57 +245,57 @@ class UnitTests(unittest.TestCase):
                 {"p_0t": "src1", "p_0t_0": "sig2", "p_1t": "src2", "p_1t_0": "srcx"},
             )
 
-    def test_filter_time_pair(self):
+    def test_filter_time_set(self):
         with self.subTest("empty"):
             params = {}
-            self.assertEqual(filter_time_pair("t", "v", None, "p", params), "FALSE")
+            self.assertEqual(filter_time_set("t", "v", None, "p", params), "FALSE")
             self.assertEqual(params, {})
         with self.subTest("*"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimeSet("day", True), "p", params),
+                filter_time_set("t", "v", TimeSet("day", True), "p", params),
                 "(t = :p_0t)",
             )
             self.assertEqual(params, {"p_0t": "day"})
         with self.subTest("single"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimeSet("day", [20201201]), "p", params),
+                filter_time_set("t", "v", TimeSet("day", [20201201]), "p", params),
                 "((t = :p_0t AND (v = :p_0t_0)))",
             )
             self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20201201})
         with self.subTest("multi"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimeSet("day", [20201201, 20201203]), "p", params),
+                filter_time_set("t", "v", TimeSet("day", [20201201, 20201203]), "p", params),
                 "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1)))",
             )
             self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20201201, "p_0t_1": 20201203})
         with self.subTest("range"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimeSet("day", [(20201201, 20201203)]), "p", params),
+                filter_time_set("t", "v", TimeSet("day", [(20201201, 20201203)]), "p", params),
                 "((t = :p_0t AND (v BETWEEN :p_0t_0 AND :p_0t_0_2)))",
             )
             self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20201201, "p_0t_0_2": 20201203})
         with self.subTest("dedupe"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimeSet("day", [20200101, 20200101, (20200101, 20200101), 20200101]), "p", params),
+                filter_time_set("t", "v", TimeSet("day", [20200101, 20200101, (20200101, 20200101), 20200101]), "p", params),
                 "((t = :p_0t AND (v = :p_0t_0)))",
             )
             self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20200101})
         with self.subTest("merge single range"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimeSet("day", [20200101, 20200102, (20200101, 20200104)]), "p", params),
+                filter_time_set("t", "v", TimeSet("day", [20200101, 20200102, (20200101, 20200104)]), "p", params),
                 "((t = :p_0t AND (v BETWEEN :p_0t_0 AND :p_0t_0_2)))",
             )
             self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20200101, "p_0t_0_2": 20200104})
         with self.subTest("merge ranges and singles"):
             params = {}
             self.assertEqual(
-                filter_time_pair("t", "v", TimeSet("day", [20200101, 20200103, (20200105, 20200107)]), "p", params),
+                filter_time_set("t", "v", TimeSet("day", [20200101, 20200103, (20200105, 20200107)]), "p", params),
                 "((t = :p_0t AND (v = :p_0t_0 OR v = :p_0t_1 OR v BETWEEN :p_0t_2 AND :p_0t_2_2)))",
             )
             self.assertEqual(params, {"p_0t": "day", "p_0t_0": 20200101, "p_0t_1": 20200103, 'p_0t_2': 20200105, 'p_0t_2_2': 20200107})           


### PR DESCRIPTION
Partially addresses #998.

**Prerequisites**:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [X] Build is successful
- [X] Code is cleaned up and formatted

### Summary

Fixes a set of issues in the server code as described [here](https://github.com/cmu-delphi/delphi-epidata/issues/998#issuecomment-1348732544).

- [X] Renames `*Pair` classes (`TimePair`, `GeoPair`, `SourceSignalPair`) into `*Set.`
- [X] Also renames methods where these are parsed and extracted.
- [X] Also renames methods where these are applied to a SQL query as a `WHERE` conditional. In this case they are referred to as filters.