### PR TITLE
Fix problem with covid_hosp skipping state revisions.

### DIFF
--- a/src/acquisition/covid_hosp/common/database.py
+++ b/src/acquisition/covid_hosp/common/database.py
@@ -19,6 +19,7 @@ class Database:
   def __init__(self,
                connection,
                table_name=None,
+               dataset_name=None,
                columns_and_types=None,
                key_columns=None,
                additional_fields=None):
@@ -40,6 +41,7 @@ class Database:
 
     self.connection = connection
     self.table_name = table_name
+    self.dataset_name = dataset_name
     self.publication_col_name = "issue" if table_name == 'covid_hosp_state_timeseries' else \
       'publication_date'
     self.columns_and_types = {
@@ -116,7 +118,7 @@ class Database:
           `covid_hosp_meta`
         WHERE
           `dataset_name` = %s AND `revision_timestamp` = %s
-      ''', (self.table_name, revision))
+      ''', (self.dataset_name, revision))
       for (result,) in cursor:
         return bool(result)
 
@@ -145,7 +147,7 @@ class Database:
           )
         VALUES
           (%s, %s, %s, %s, NOW())
-      ''', (self.table_name, publication_date, revision, meta_json))
+      ''', (self.dataset_name, publication_date, revision, meta_json))
 
   def insert_dataset(self, publication_date, dataframe):
     """Add a dataset to the database.
@@ -232,7 +234,7 @@ class Database:
         from
           `covid_hosp_meta`
         WHERE
-          dataset_name = "{self.table_name}"
+          dataset_name = "{self.dataset_name}"
       ''')
       for (result,) in cursor:
         if result is not None:

--- a/src/acquisition/covid_hosp/facility/database.py
+++ b/src/acquisition/covid_hosp/facility/database.py
@@ -214,6 +214,6 @@ class Database(BaseDatabase):
         *args,
         **kwargs,
         table_name=Database.TABLE_NAME,
-        dataset_name=Network.DATASET_ID,
+        hhs_dataset_id=Network.DATASET_ID,
         key_columns=Database.KEY_COLS,
         columns_and_types=Database.ORDERED_CSV_COLUMNS)

--- a/src/acquisition/covid_hosp/facility/database.py
+++ b/src/acquisition/covid_hosp/facility/database.py
@@ -2,6 +2,7 @@
 from delphi.epidata.acquisition.covid_hosp.common.database import Database as BaseDatabase
 from delphi.epidata.acquisition.covid_hosp.common.database import Columndef
 from delphi.epidata.acquisition.covid_hosp.common.utils import Utils
+from delphi.epidata.acquisition.covid_hosp.facility.network import Network
 
 
 class Database(BaseDatabase):
@@ -213,5 +214,6 @@ class Database(BaseDatabase):
         *args,
         **kwargs,
         table_name=Database.TABLE_NAME,
+        dataset_name=Network.DATASET_ID,
         key_columns=Database.KEY_COLS,
         columns_and_types=Database.ORDERED_CSV_COLUMNS)

--- a/src/acquisition/covid_hosp/state_daily/database.py
+++ b/src/acquisition/covid_hosp/state_daily/database.py
@@ -224,7 +224,7 @@ class Database(BaseDatabase):
         *args,
         **kwargs,
         table_name=Database.TABLE_NAME,
-        dataset_name=Network.DATASET_ID,
+        hhs_dataset_id=Network.DATASET_ID,
         columns_and_types=Database.ORDERED_CSV_COLUMNS,
         key_columns=Database.KEY_COLS,
         additional_fields=[Columndef('D', 'record_type', None)])

--- a/src/acquisition/covid_hosp/state_daily/database.py
+++ b/src/acquisition/covid_hosp/state_daily/database.py
@@ -2,6 +2,7 @@
 from delphi.epidata.acquisition.covid_hosp.common.database import Database as BaseDatabase
 from delphi.epidata.acquisition.covid_hosp.common.database import Columndef
 from delphi.epidata.acquisition.covid_hosp.common.utils import Utils
+from delphi.epidata.acquisition.covid_hosp.state_daily.network import Network
 
 
 class Database(BaseDatabase):
@@ -223,6 +224,7 @@ class Database(BaseDatabase):
         *args,
         **kwargs,
         table_name=Database.TABLE_NAME,
+        dataset_name=Network.DATASET_ID,
         columns_and_types=Database.ORDERED_CSV_COLUMNS,
         key_columns=Database.KEY_COLS,
         additional_fields=[Columndef('D', 'record_type', None)])

--- a/src/acquisition/covid_hosp/state_timeseries/database.py
+++ b/src/acquisition/covid_hosp/state_timeseries/database.py
@@ -2,6 +2,7 @@
 from delphi.epidata.acquisition.covid_hosp.common.database import Database as BaseDatabase
 from delphi.epidata.acquisition.covid_hosp.common.database import Columndef
 from delphi.epidata.acquisition.covid_hosp.common.utils import Utils
+from delphi.epidata.acquisition.covid_hosp.state_timeseries.network import Network
 
 
 class Database(BaseDatabase):
@@ -222,6 +223,7 @@ class Database(BaseDatabase):
         *args,
         **kwargs,
         table_name=Database.TABLE_NAME,
+        dataset_name=Network.DATASET_ID,
         columns_and_types=Database.ORDERED_CSV_COLUMNS,
         key_columns=Database.KEY_COLS,
         additional_fields=[Columndef('T', 'record_type', None)])

--- a/src/acquisition/covid_hosp/state_timeseries/database.py
+++ b/src/acquisition/covid_hosp/state_timeseries/database.py
@@ -223,7 +223,7 @@ class Database(BaseDatabase):
         *args,
         **kwargs,
         table_name=Database.TABLE_NAME,
-        dataset_name=Network.DATASET_ID,
+        hhs_dataset_id=Network.DATASET_ID,
         columns_and_types=Database.ORDERED_CSV_COLUMNS,
         key_columns=Database.KEY_COLS,
         additional_fields=[Columndef('T', 'record_type', None)])

--- a/src/ddl/covid_hosp.sql
+++ b/src/ddl/covid_hosp.sql
@@ -48,6 +48,7 @@ surfaced through the Epidata API.
 CREATE TABLE `covid_hosp_meta` (
   `id` INT NOT NULL AUTO_INCREMENT,
   `dataset_name` VARCHAR(64) NOT NULL,
+  `hhs_dataset_id` CHAR(9) NOT NULL DEFAULT "????-????",
   `publication_date` INT NOT NULL,
   `revision_timestamp` VARCHAR(512) NOT NULL,
   `metadata_json` JSON NOT NULL,

--- a/src/ddl/migrations/covid_hosp_meta_v0.4.4-v0.4.5.sql
+++ b/src/ddl/migrations/covid_hosp_meta_v0.4.4-v0.4.5.sql
@@ -1,0 +1,3 @@
+UPDATE covid_hosp_meta SET dataset_name="g62h-syeh" WHERE revision_timestamp like "%g62h-syeh%";
+UPDATE covid_hosp_meta SET dataset_name="6xf2-c3ie" where revision_timestamp like "%6xf2-c3ie%";
+UPDATE covid_hosp_meta SET dataset_name="anag-cw7u" WHERE revision_timestamp LIKE "%anag-cw7u%";

--- a/src/ddl/migrations/covid_hosp_meta_v0.4.4-v0.4.5.sql
+++ b/src/ddl/migrations/covid_hosp_meta_v0.4.4-v0.4.5.sql
@@ -1,3 +1,4 @@
-UPDATE covid_hosp_meta SET dataset_name="g62h-syeh" WHERE revision_timestamp like "%g62h-syeh%";
-UPDATE covid_hosp_meta SET dataset_name="6xf2-c3ie" where revision_timestamp like "%6xf2-c3ie%";
-UPDATE covid_hosp_meta SET dataset_name="anag-cw7u" WHERE revision_timestamp LIKE "%anag-cw7u%";
+ALTER TABLE covid_hosp_meta ADD COLUMN hhs_dataset_id CHAR(9) NOT NULL DEFAULT "????-????";
+UPDATE covid_hosp_meta SET hhs_dataset_id="g62h-syeh" WHERE revision_timestamp LIKE "%g62h-syeh%";
+UPDATE covid_hosp_meta SET hhs_dataset_id="6xf2-c3ie" WHERE revision_timestamp LIKE "%6xf2-c3ie%";
+UPDATE covid_hosp_meta SET hhs_dataset_id="anag-cw7u" WHERE revision_timestamp LIKE "%anag-cw7u%";

--- a/tests/acquisition/covid_hosp/common/test_database.py
+++ b/tests/acquisition/covid_hosp/common/test_database.py
@@ -68,7 +68,7 @@ class DatabaseTests(unittest.TestCase):
 
     mock_connection = MagicMock()
     mock_cursor = mock_connection.cursor()
-    database = Database(mock_connection, table_name=sentinel.table_name, dataset_name=sentinel.dataset_name)
+    database = Database(mock_connection, table_name=sentinel.table_name, hhs_dataset_id=sentinel.hhs_dataset_id)
 
     with self.subTest(name='new revision'):
       mock_cursor.__iter__.return_value = [(0,)]
@@ -78,7 +78,7 @@ class DatabaseTests(unittest.TestCase):
       # compare with boolean literal to test the type cast
       self.assertIs(result, False)
       query_values = mock_cursor.execute.call_args[0][-1]
-      self.assertEqual(query_values, (sentinel.dataset_name, sentinel.revision))
+      self.assertEqual(query_values, (sentinel.hhs_dataset_id, sentinel.revision))
 
     with self.subTest(name='old revision'):
       mock_cursor.__iter__.return_value = [(1,)]
@@ -88,7 +88,7 @@ class DatabaseTests(unittest.TestCase):
       # compare with boolean literal to test the type cast
       self.assertIs(result, True)
       query_values = mock_cursor.execute.call_args[0][-1]
-      self.assertEqual(query_values, (sentinel.dataset_name, sentinel.revision))
+      self.assertEqual(query_values, (sentinel.hhs_dataset_id, sentinel.revision))
 
   def test_insert_metadata(self):
     """Add new metadata to the database."""
@@ -98,7 +98,7 @@ class DatabaseTests(unittest.TestCase):
 
     mock_connection = MagicMock()
     mock_cursor = mock_connection.cursor()
-    database = Database(mock_connection, table_name=sentinel.table_name, dataset_name=sentinel.dataset_name)
+    database = Database(mock_connection, table_name=sentinel.table_name, hhs_dataset_id=sentinel.hhs_dataset_id)
 
     result = database.insert_metadata(
         sentinel.publication_date,
@@ -108,7 +108,8 @@ class DatabaseTests(unittest.TestCase):
     self.assertIsNone(result)
     actual_values = mock_cursor.execute.call_args[0][-1]
     expected_values = (
-      sentinel.dataset_name,
+      sentinel.table_name,
+      sentinel.hhs_dataset_id,
       sentinel.publication_date,
       sentinel.revision,
       sentinel.meta_json,

--- a/tests/acquisition/covid_hosp/common/test_database.py
+++ b/tests/acquisition/covid_hosp/common/test_database.py
@@ -68,7 +68,7 @@ class DatabaseTests(unittest.TestCase):
 
     mock_connection = MagicMock()
     mock_cursor = mock_connection.cursor()
-    database = Database(mock_connection, table_name=sentinel.table_name)
+    database = Database(mock_connection, table_name=sentinel.table_name, dataset_name=sentinel.dataset_name)
 
     with self.subTest(name='new revision'):
       mock_cursor.__iter__.return_value = [(0,)]
@@ -78,7 +78,7 @@ class DatabaseTests(unittest.TestCase):
       # compare with boolean literal to test the type cast
       self.assertIs(result, False)
       query_values = mock_cursor.execute.call_args[0][-1]
-      self.assertEqual(query_values, (sentinel.table_name, sentinel.revision))
+      self.assertEqual(query_values, (sentinel.dataset_name, sentinel.revision))
 
     with self.subTest(name='old revision'):
       mock_cursor.__iter__.return_value = [(1,)]
@@ -88,7 +88,7 @@ class DatabaseTests(unittest.TestCase):
       # compare with boolean literal to test the type cast
       self.assertIs(result, True)
       query_values = mock_cursor.execute.call_args[0][-1]
-      self.assertEqual(query_values, (sentinel.table_name, sentinel.revision))
+      self.assertEqual(query_values, (sentinel.dataset_name, sentinel.revision))
 
   def test_insert_metadata(self):
     """Add new metadata to the database."""
@@ -98,7 +98,7 @@ class DatabaseTests(unittest.TestCase):
 
     mock_connection = MagicMock()
     mock_cursor = mock_connection.cursor()
-    database = Database(mock_connection, table_name=sentinel.dataset_name)
+    database = Database(mock_connection, table_name=sentinel.table_name, dataset_name=sentinel.dataset_name)
 
     result = database.insert_metadata(
         sentinel.publication_date,

--- a/tests/acquisition/covid_hosp/common/test_utils.py
+++ b/tests/acquisition/covid_hosp/common/test_utils.py
@@ -129,7 +129,10 @@ class UtilsTests(unittest.TestCase):
 
     self.assertTrue(result)
 
-    mock_connection.insert_metadata.assert_called_once()
+    # should have been called twice
+    mock_connection.insert_metadata.assert_called()
+    assert mock_connection.insert_metadata.call_count == 2
+    # most recent call should be for the final revision at url2
     args = mock_connection.insert_metadata.call_args[0]
     self.assertEqual(args[:2], (20210315, "url2"))
     pd.testing.assert_frame_equal(


### PR DESCRIPTION
Prevents future recurrence of the HHS state hospital admissions outage active 2023-01-12.

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

In January 2023, we noticed that the HHS hospital admissions data had unusually high lag. On investigation, it turned out that timeseries datasets had not been fetched in over a week, even though new timeseries revisions were available from healthdata.gov. It turned out that successful import of daily revisions (which in Jan 2023 have 7 days of lag, while timeseries revisions have only 1-2) were masking the new timeseries revisions from the acquisition system.

This PR changes the usage of the `dataset_name` column in the `covid_hosp_meta` table from containing the data table name (for which `covid_hosp_state_timeseries` is shared by both the timeseries and daily revisions pipelines) to containing the healthdata.gov dataset ID (which is unique). This lets the acquisition system check for the last known timeseries file when pulling timeseries revisions, and the last known daily file when pulling daily revisions.

This PR also changes how we track metadata. Previously, each run of the pipeline collected together all revisions posted to healthdata.gov on a particular day, and recorded only one line in metadata for the whole batch -- preventing us humans from having any idea whether any particular file from healthdata.gov was actually ingested by the acquisition system. The proposed change records a line in metadata for each file from healthdata.gov which is included in the batch.

This PR includes a migration to run after deploy and before next acquisition, which will update the `covid_hosp_meta` table to tag state rows with their healthdata.gov ID based on the name of the revision file stored in the `revision_timestamp` column.

**Things this PR _DOES NOT_ include**:
* changing the `older_than` inequality to permit pulling revisions from the current day: we exclude current-day revisions on purpose to avoid a scenario where the initial data reported for an issue turns out to be incomplete and must be updated later, i.e., needing to version our versions in addition to versioning the reference dates. essentially, we wait until we're sure the issue from healthdata.gov is complete before ingesting it.
* checking the metadata table and skipping acquisition of revisions that are already listed: this is potentially desirable as a mechanism for minimally backfilling the last two years of potentially-skipped revisions, or as a mechanism for relaxing our insistence on excluding current-day revisions if we think 12-24 hours of reduced lag is worth the consequences. we'd need to include a way to turn it off though, since our current method of pulling in new columns on past data is just to re-acquire the files.