### PR TITLE
[Refactor] Further cleans of `csv_importer` 

### DIFF
--- a/src/acquisition/covidcast/csv_importer.py
+++ b/src/acquisition/covidcast/csv_importer.py
@@ -19,7 +19,7 @@ from delphi.epidata.acquisition.covidcast.database import CovidcastRow
 from delphi.epidata.acquisition.covidcast.logger import get_structured_logger
 
 DFRow = NamedTuple('DFRow', [('geo_id', str), ('value', float), ('stderr', float), ('sample_size', float), ('missing_value', int), ('missing_stderr', int), ('missing_sample_size', int)])
-PathDetails = NamedTuple('PathDetails', [('source', str), ("signal", str), ('time_type', str), ('geo_type', str), ('time_value', int), ('issue', int), ('lag', int)])
+PathDetails = NamedTuple('PathDetails', [('source', str), ('signal', str), ('time_type', str), ('geo_type', str), ('time_value', int), ('issue', int), ('lag', int)])
 
 
 @dataclass

--- a/src/acquisition/covidcast/csv_importer.py
+++ b/src/acquisition/covidcast/csv_importer.py
@@ -19,7 +19,7 @@ from delphi.epidata.acquisition.covidcast.database import CovidcastRow
 from delphi.epidata.acquisition.covidcast.logger import get_structured_logger
 
 DFRow = NamedTuple('DFRow', [('geo_id', str), ('value', float), ('stderr', float), ('sample_size', float), ('missing_value', int), ('missing_stderr', int), ('missing_sample_size', int)])
-PathDetails = NamedTuple('PathDetails', [('source', str), ('signal', str), ('time_type', str), ('geo_type', str), ('time_value', int), ('issue', int), ('lag', int)])
+PathDetails = NamedTuple('PathDetails', [('issue', int), ('lag', int), ('source', str), ('signal', str), ('time_type', str), ('time_value', int), ('geo_type', str)])
 
 
 @dataclass
@@ -185,7 +185,7 @@ class CsvImporter:
         yield (path, None)
         continue
 
-      yield (path, PathDetails(source, signal, time_type, geo_type, time_value, issue_value, lag_value))
+      yield (path, PathDetails(issue_value, lag_value, source, signal, time_type, time_value, geo_type))
 
 
   @staticmethod

--- a/src/acquisition/covidcast/csv_to_database.py
+++ b/src/acquisition/covidcast/csv_to_database.py
@@ -4,10 +4,12 @@
 import argparse
 import os
 import time
+from logging import Logger
+from typing import Callable, Iterable, Optional, Tuple
 
 # first party
-from delphi.epidata.acquisition.covidcast.csv_importer import CsvImporter
-from delphi.epidata.acquisition.covidcast.database import Database, CovidcastRow, DBLoadStateException
+from delphi.epidata.acquisition.covidcast.csv_importer import CsvImporter, PathDetails
+from delphi.epidata.acquisition.covidcast.database import Database, DBLoadStateException
 from delphi.epidata.acquisition.covidcast.file_archiver import FileArchiver
 from delphi.epidata.acquisition.covidcast.logger import get_structured_logger
 
@@ -28,17 +30,19 @@ def get_argument_parser():
     help="filename for log output (defaults to stdout)")
   return parser
 
-def collect_files(data_dir, specific_issue_date,csv_importer_impl=CsvImporter):
+
+def collect_files(data_dir: str, specific_issue_date: bool):
   """Fetch path and data profile details for each file to upload."""
   logger= get_structured_logger('collect_files')
   if specific_issue_date:
-    results = list(csv_importer_impl.find_issue_specific_csv_files(data_dir))
+    results = list(CsvImporter.find_issue_specific_csv_files(data_dir))
   else:
-    results = list(csv_importer_impl.find_csv_files(os.path.join(data_dir, 'receiving')))
+    results = list(CsvImporter.find_csv_files(os.path.join(data_dir, 'receiving')))
   logger.info(f'found {len(results)} files')
   return results
 
-def make_handlers(data_dir, specific_issue_date, file_archiver_impl=FileArchiver):
+
+def make_handlers(data_dir: str, specific_issue_date: bool):
   if specific_issue_date:
     # issue-specific uploads are always one-offs, so we can leave all
     # files in place without worrying about cleaning up
@@ -47,7 +51,7 @@ def make_handlers(data_dir, specific_issue_date, file_archiver_impl=FileArchiver
 
     def handle_successful(path_src, filename, source, logger):
       logger.info(event='archiving as successful',file=filename)
-      file_archiver_impl.archive_inplace(path_src, filename)
+      FileArchiver.archive_inplace(path_src, filename)
   else:
     # normal automation runs require some shuffling to remove files
     # from receiving and place them in the archive
@@ -59,22 +63,24 @@ def make_handlers(data_dir, specific_issue_date, file_archiver_impl=FileArchiver
       logger.info(event='archiving as failed - ', detail=source, file=filename)
       path_dst = os.path.join(archive_failed_dir, source)
       compress = False
-      file_archiver_impl.archive_file(path_src, path_dst, filename, compress)
+      FileArchiver.archive_file(path_src, path_dst, filename, compress)
 
     # helper to archive a successful file with compression
     def handle_successful(path_src, filename, source, logger):
       logger.info(event='archiving as successful',file=filename)
       path_dst = os.path.join(archive_successful_dir, source)
       compress = True
-      file_archiver_impl.archive_file(path_src, path_dst, filename, compress)
+      FileArchiver.archive_file(path_src, path_dst, filename, compress)
+
   return handle_successful, handle_failed
 
+
 def upload_archive(
-    path_details,
-    database,
-    handlers,
-    logger,
-    csv_importer_impl=CsvImporter):
+  path_details: Iterable[Tuple[str, Optional[PathDetails]]],
+  database: Database,
+  handlers: Tuple[Callable],
+  logger: Logger
+  ):
   """Upload CSVs to the database and archive them using the specified handlers.
 
   :path_details: output from CsvImporter.find*_csv_files
@@ -89,11 +95,11 @@ def upload_archive(
   total_modified_row_count = 0
   # iterate over each file
   for path, details in path_details:
-    logger.info(event='handling',dest=path)
+    logger.info(event='handling', dest=path)
     path_src, filename = os.path.split(path)
 
+    # file path or name was invalid, source is unknown
     if not details:
-      # file path or name was invalid, source is unknown
       archive_as_failed(path_src, filename, 'unknown',logger)
       continue
 
@@ -138,33 +144,30 @@ def upload_archive(
   return total_modified_row_count
 
 
-def main(
-    args,
-    database_impl=Database,
-    collect_files_impl=collect_files,
-    upload_archive_impl=upload_archive):
+def main(args):
   """Find, parse, and upload covidcast signals."""
 
   logger = get_structured_logger("csv_ingestion", filename=args.log_file)
   start_time = time.time()
 
   # shortcut escape without hitting db if nothing to do
-  path_details = collect_files_impl(args.data_dir, args.specific_issue_date)
+  path_details = collect_files(args.data_dir, args.specific_issue_date)
   if not path_details:
     logger.info('nothing to do; exiting...')
     return
 
   logger.info("Ingesting CSVs", csv_count = len(path_details))
 
-  database = database_impl()
+  database = Database()
   database.connect()
 
   try:
-    modified_row_count = upload_archive_impl(
+    modified_row_count = upload_archive(
       path_details,
       database,
       make_handlers(args.data_dir, args.specific_issue_date),
-      logger)
+      logger
+    )
     logger.info("Finished inserting/updating database rows", row_count = modified_row_count)
   finally:
     database.do_analyze()
@@ -174,6 +177,7 @@ def main(
   logger.info(
       "Ingested CSVs into database",
       total_runtime_in_seconds=round(time.time() - start_time, 2))
+
 
 if __name__ == '__main__':
   main(get_argument_parser().parse_args())

--- a/src/acquisition/covidcast/csv_to_database.py
+++ b/src/acquisition/covidcast/csv_to_database.py
@@ -103,12 +103,8 @@ def upload_archive(
       archive_as_failed(path_src, filename, 'unknown',logger)
       continue
 
-    (source, signal, time_type, geo_type, time_value, issue, lag) = details
-
-    csv_rows = csv_importer_impl.load_csv(path, geo_type)
-
-    cc_rows = CovidcastRow.fromCsvRows(csv_rows, source, signal, time_type, geo_type, time_value, issue, lag)
-    rows_list = list(cc_rows)
+    csv_rows = CsvImporter.load_csv(path, details)
+    rows_list = list(csv_rows)
     all_rows_valid = rows_list and all(r is not None for r in rows_list)
     if all_rows_valid:
       try:
@@ -117,12 +113,13 @@ def upload_archive(
         logger.info(
           "Inserted database rows",
           row_count = modified_row_count,
-          source = source,
-          signal = signal,
-          geo_type = geo_type,
-          time_value = time_value,
-          issue = issue,
-          lag = lag)
+          source = details.source,
+          signal = details.signal,
+          geo_type = details.geo_type,
+          time_value = details.time_value,
+          issue = details.issue,
+          lag = details.lag
+        )
         if modified_row_count is None or modified_row_count: # else would indicate zero rows inserted
           total_modified_row_count += (modified_row_count if modified_row_count else 0)
           database.commit()
@@ -137,9 +134,9 @@ def upload_archive(
 
     # archive the current file based on validation results
     if all_rows_valid:
-      archive_as_successful(path_src, filename, source, logger)
+      archive_as_successful(path_src, filename, details.source, logger)
     else:
-      archive_as_failed(path_src, filename, source,logger)
+      archive_as_failed(path_src, filename, details.source, logger)
 
   return total_modified_row_count
 

--- a/src/acquisition/covidcast_nowcast/load_sensors.py
+++ b/src/acquisition/covidcast_nowcast/load_sensors.py
@@ -6,7 +6,7 @@ import pandas as pd
 import sqlalchemy
 
 import delphi.operations.secrets as secrets
-from delphi.epidata.acquisition.covidcast.csv_importer import CsvImporter
+from delphi.epidata.acquisition.covidcast.csv_importer import CsvImporter, PathDetails
 
 SENSOR_CSV_PATH = "/common/covidcast_nowcast/receiving/"
 SUCCESS_DIR = "archive/successful"
@@ -52,7 +52,7 @@ def main(csv_path: str = SENSOR_CSV_PATH) -> None:
         _move_after_processing(filepath, success=True)
 
 
-def load_and_prepare_file(filepath: str, attributes: tuple) -> pd.DataFrame:
+def load_and_prepare_file(filepath: str, attributes: PathDetails) -> pd.DataFrame:
     """
     Read CSV file into a DataFrame and add relevant attributes as new columns to match DB table.
 
@@ -68,15 +68,14 @@ def load_and_prepare_file(filepath: str, attributes: tuple) -> pd.DataFrame:
     -------
         DataFrame with additional attributes added as columns based on filename and current date.
     """
-    source, signal, time_type, geo_type, time_value, issue_value, lag_value = attributes
     data = pd.read_csv(filepath, dtype=CSV_DTYPES)
-    data["source"] = source
-    data["signal"] = signal
-    data["time_type"] = time_type
-    data["geo_type"] = geo_type
-    data["time_value"] = time_value
-    data["issue"] = issue_value
-    data["lag"] = lag_value
+    data["source"] = attributes.source
+    data["signal"] = attributes.signal
+    data["time_type"] = attributes.time_type
+    data["geo_type"] = attributes.geo_type
+    data["time_value"] = attributes.time_value
+    data["issue"] = attributes.issue
+    data["lag"] = attributes.lag
     data["value_updated_timestamp"] = int(time.time())
     return data
 

--- a/tests/acquisition/covidcast/test_csv_importer.py
+++ b/tests/acquisition/covidcast/test_csv_importer.py
@@ -233,10 +233,10 @@ class UnitTests(unittest.TestCase):
 
     data = {'foo': [1, 2, 3]}
     filepath = 'path/name.csv'
-    geo_type = 'state'
+    details = PathDetails("src", "name", "day", "state", 20200101, 20200101, 0)
 
     mock_read_csv.return_value = pd.DataFrame(data)
-    rows = list(CsvImporter.load_csv(filepath, geo_type))
+    rows = list(CsvImporter.load_csv(filepath, details))
 
     self.assertTrue(mock_read_csv.called)
     self.assertTrue(mock_read_csv.call_args[0][0], filepath)
@@ -255,10 +255,10 @@ class UnitTests(unittest.TestCase):
       'sample_size': ['301', '302', '303', '304'],
     }
     filepath = 'path/name.csv'
-    geo_type = 'state'
+    details = PathDetails("src", "name", "day", "state", 20200101, 20200101, 0)
 
     mock_read_csv.return_value = pd.DataFrame(data=data)
-    rows = list(CsvImporter.load_csv(filepath, geo_type))
+    rows = list(CsvImporter.load_csv(filepath, details))
 
     self.assertTrue(mock_read_csv.called)
     self.assertTrue(mock_read_csv.call_args[0][0], filepath)
@@ -292,10 +292,10 @@ class UnitTests(unittest.TestCase):
       'missing_sample_size': [Nans.NOT_MISSING] * 2 + [Nans.REGION_EXCEPTION] * 2 + [None]
     }
     filepath = 'path/name.csv'
-    geo_type = 'state'
+    details = PathDetails("src", "name", "day", "state", 20200101, 20200101, 0)
 
     mock_read_csv.return_value = pd.DataFrame(data)
-    rows = list(CsvImporter.load_csv(filepath, geo_type))
+    rows = list(CsvImporter.load_csv(filepath, details))
 
     self.assertTrue(mock_read_csv.called)
     self.assertTrue(mock_read_csv.call_args[0][0], filepath)

--- a/tests/acquisition/covidcast/test_csv_importer.py
+++ b/tests/acquisition/covidcast/test_csv_importer.py
@@ -105,10 +105,10 @@ class UnitTests(unittest.TestCase):
     expected_issue_week=int(str(epi.Week.fromdate(date.today())))
     time_value_day = 20200408
     expected = set([
-      (glob_paths[0], ('fb_survey', 'cli', 'week', 'county', 202015, expected_issue_week, delta_epiweeks(202015, expected_issue_week))),
-      (glob_paths[1], ('ght', 'rawsearch', 'day', 'state', time_value_day, expected_issue_day, (date.today() - date(year=time_value_day // 10000, month=(time_value_day // 100) % 100, day=time_value_day % 100)).days)),
-      (glob_paths[2], ('valid', 'sig', 'day', 'nation', time_value_day, expected_issue_day, (date.today() - date(year=time_value_day // 10000, month=(time_value_day // 100) % 100, day=time_value_day % 100)).days)),
-      (glob_paths[3], ('valid', 'sig', 'day', 'hhs', time_value_day, expected_issue_day, (date.today() - date(year=time_value_day // 10000, month=(time_value_day // 100) % 100, day=time_value_day % 100)).days)),
+      (glob_paths[0], PathDetails(expected_issue_week, delta_epiweeks(202015, expected_issue_week), 'fb_survey', 'cli', 'week', 202015, 'county')),
+      (glob_paths[1], PathDetails(expected_issue_day, (date.today() - date(year=time_value_day // 10000, month=(time_value_day // 100) % 100, day=time_value_day % 100)).days, 'ght', 'rawsearch', 'day', time_value_day, 'state')),
+      (glob_paths[2], PathDetails(expected_issue_day, (date.today() - date(year=time_value_day // 10000, month=(time_value_day // 100) % 100, day=time_value_day % 100)).days, 'valid', 'sig', 'day', time_value_day, 'nation')),
+      (glob_paths[3], PathDetails(expected_issue_day, (date.today() - date(year=time_value_day // 10000, month=(time_value_day // 100) % 100, day=time_value_day % 100)).days, 'valid', 'sig', 'day', time_value_day, 'hhs')),
       (glob_paths[4], None),
       (glob_paths[5], None),
       (glob_paths[6], None),
@@ -233,7 +233,7 @@ class UnitTests(unittest.TestCase):
 
     data = {'foo': [1, 2, 3]}
     filepath = 'path/name.csv'
-    details = PathDetails("src", "name", "day", "state", 20200101, 20200101, 0)
+    details = PathDetails(20200101, 0, "src", "name", "day", 20200101, "state")
 
     mock_read_csv.return_value = pd.DataFrame(data)
     rows = list(CsvImporter.load_csv(filepath, details))
@@ -255,7 +255,7 @@ class UnitTests(unittest.TestCase):
       'sample_size': ['301', '302', '303', '304'],
     }
     filepath = 'path/name.csv'
-    details = PathDetails("src", "name", "day", "state", 20200101, 20200101, 0)
+    details = PathDetails(20200101, 0, "src", "name", "day", 20200101, "state")
 
     mock_read_csv.return_value = pd.DataFrame(data=data)
     rows = list(CsvImporter.load_csv(filepath, details))
@@ -292,7 +292,7 @@ class UnitTests(unittest.TestCase):
       'missing_sample_size': [Nans.NOT_MISSING] * 2 + [Nans.REGION_EXCEPTION] * 2 + [None]
     }
     filepath = 'path/name.csv'
-    details = PathDetails("src", "name", "day", "state", 20200101, 20200101, 0)
+    details = PathDetails(20200101, 0, "src", "name", "day", 20200101, "state")
 
     mock_read_csv.return_value = pd.DataFrame(data)
     rows = list(CsvImporter.load_csv(filepath, details))

--- a/tests/acquisition/covidcast/test_csv_importer.py
+++ b/tests/acquisition/covidcast/test_csv_importer.py
@@ -2,8 +2,7 @@
 
 # standard library
 import unittest
-from unittest.mock import MagicMock
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from datetime import date
 import numpy as np
 
@@ -13,7 +12,7 @@ import epiweeks as epi
 
 from delphi_utils import Nans
 from delphi.utils.epiweek import delta_epiweeks
-from delphi.epidata.acquisition.covidcast.csv_importer import CsvImporter, CsvRowValue
+from delphi.epidata.acquisition.covidcast.csv_importer import CsvImporter, CsvRowValue, PathDetails
 
 # py3tester coverage target
 __test_target__ = 'delphi.epidata.acquisition.covidcast.csv_importer'
@@ -32,6 +31,7 @@ class UnitTests(unittest.TestCase):
     self.assertFalse(CsvImporter.is_sane_day(20200199))
     self.assertFalse(CsvImporter.is_sane_day(202015))
 
+
   def test_is_sane_week(self):
     """Sanity check some weeks."""
 
@@ -42,37 +42,38 @@ class UnitTests(unittest.TestCase):
     self.assertFalse(CsvImporter.is_sane_week(202054))
     self.assertFalse(CsvImporter.is_sane_week(20200418))
 
+
+  @patch("delphi.epidata.acquisition.covidcast.csv_importer.glob")
   @patch("os.path.isdir")
-  def test_find_issue_specific_csv_files(self,os_isdir_mock):
+  def test_find_issue_specific_csv_files(self, mock_os_isdir: MagicMock, mock_glob: MagicMock):
       """Recursively explore and find issue specific CSV files."""
       # check valid path
       path_prefix='prefix/to/the/data/issue_20200408'
-      os_isdir_mock.return_value=True
+      mock_os_isdir.return_value=True
       issue_path=path_prefix+'ght/20200408_state_rawsearch.csv'
 
-      mock_glob = MagicMock()
-      mock_glob.glob.side_effect = ([path_prefix], [issue_path])
+      mock_glob.side_effect = ([path_prefix], [issue_path])
 
       #check if the day is a valid day.
       issuedir_match= CsvImporter.PATTERN_ISSUE_DIR.match(path_prefix.lower())
       issue_date_value = int(issuedir_match.group(2))
       self.assertTrue(CsvImporter.is_sane_day(issue_date_value))
 
-      found = set(CsvImporter.find_issue_specific_csv_files(path_prefix, glob=mock_glob))
-      self.assertTrue(len(found)>0)
+      found = set(CsvImporter.find_issue_specific_csv_files(path_prefix))
+      self.assertTrue(len(found) > 0)
 
       # check unvalid path:
       path_prefix_invalid='invalid/prefix/to/the/data/issue_20200408'
-      os_isdir_mock.return_value=False
+      mock_os_isdir.return_value=False
       issue_path_invalid=path_prefix_invalid+'ght/20200408_state_rawsearch.csv'
-      mock_glob_invalid = MagicMock()
-      mock_glob_invalid.glob.side_effect = ([path_prefix_invalid], [issue_path_invalid])
+      mock_glob.side_effect = ([path_prefix_invalid], [issue_path_invalid])
 
-      found = set(CsvImporter.find_issue_specific_csv_files(path_prefix_invalid, glob=mock_glob_invalid))
+      found = set(CsvImporter.find_issue_specific_csv_files(path_prefix_invalid))
       self.assertFalse(len(found)>0)
 
 
-  def test_find_csv_files(self):
+  @patch("delphi.epidata.acquisition.covidcast.csv_importer.glob")
+  def test_find_csv_files(self, mock_glob: MagicMock):
     """Recursively explore and find CSV files."""
 
     path_prefix = 'prefix/to/the/data/'
@@ -96,10 +97,9 @@ class UnitTests(unittest.TestCase):
       # ignored
       path_prefix + 'ignored/README.md',
     ]
-    mock_glob = MagicMock()
-    mock_glob.glob.return_value = glob_paths
+    mock_glob.return_value = glob_paths
 
-    found = set(CsvImporter.find_csv_files(path_prefix, glob=mock_glob))
+    found = set(CsvImporter.find_csv_files(path_prefix))
 
     expected_issue_day=int(date.today().strftime("%Y%m%d"))
     expected_issue_week=int(str(epi.Week.fromdate(date.today())))
@@ -116,6 +116,7 @@ class UnitTests(unittest.TestCase):
     ])
     self.assertEqual(found, expected)
 
+
   def test_is_header_valid_allows_extra_columns(self):
     """Allow and ignore extra columns in the header."""
 
@@ -124,6 +125,7 @@ class UnitTests(unittest.TestCase):
     self.assertTrue(CsvImporter.is_header_valid(columns))
     self.assertTrue(CsvImporter.is_header_valid(columns | {'foo', 'bar'}))
 
+
   def test_is_header_valid_does_not_depend_on_column_order(self):
     """Allow columns to appear in any order."""
 
@@ -131,6 +133,7 @@ class UnitTests(unittest.TestCase):
     columns = sorted(CsvImporter.REQUIRED_COLUMNS)
 
     self.assertTrue(CsvImporter.is_header_valid(columns))
+
 
   def test_floaty_int(self):
     """Parse ints that may look like floats."""
@@ -141,6 +144,7 @@ class UnitTests(unittest.TestCase):
     with self.assertRaises(ValueError):
       CsvImporter.floaty_int('-1.1')
 
+
   def test_maybe_apply(self):
     """Apply a function to a value as long as it's not null-like."""
 
@@ -150,6 +154,7 @@ class UnitTests(unittest.TestCase):
     self.assertIsNone(CsvImporter.maybe_apply(int, 'NaN'))
     self.assertIsNone(CsvImporter.maybe_apply(float, ''))
     self.assertIsNone(CsvImporter.maybe_apply(float, None))
+
 
   def test_extract_and_check_row(self):
     """Apply various sanity checks to a row of data."""
@@ -221,6 +226,7 @@ class UnitTests(unittest.TestCase):
       self.assertEqual(values.stderr, field.stderr)
       self.assertEqual(values.sample_size, field.sample_size)
 
+
   @patch("pandas.read_csv")
   def test_load_csv_with_invalid_header(self, mock_read_csv):
     """Bail loading a CSV when the header is invalid."""
@@ -235,6 +241,7 @@ class UnitTests(unittest.TestCase):
     self.assertTrue(mock_read_csv.called)
     self.assertTrue(mock_read_csv.call_args[0][0], filepath)
     self.assertEqual(rows, [None])
+
 
   @patch("pandas.read_csv")
   def test_load_csv_with_valid_header(self, mock_read_csv):

--- a/tests/acquisition/covidcast/test_csv_to_database.py
+++ b/tests/acquisition/covidcast/test_csv_to_database.py
@@ -17,9 +17,9 @@ class UnitTests(unittest.TestCase):
   """Basic unit tests."""
   _path_details = [
     # a good file
-    ('path/a.csv', PathDetails('src_a', 'sig_a', 'day', 'hrr', 20200419, 20200420, 1)),
+    ('path/a.csv', PathDetails(20200420, 1, 'src_a', 'sig_a', 'day', 20200419, 'hrr')),
     # a file with a data error
-    ('path/b.csv', PathDetails('src_b', 'sig_b', 'week', 'msa', 202016, 202017, 1)),
+    ('path/b.csv', PathDetails(202017, 1, 'src_b', 'sig_b', 'week', 202016, 'msa')),
     # emulate a file that's named incorrectly
     ('path/c.csv', None)
   ]
@@ -194,7 +194,7 @@ class UnitTests(unittest.TestCase):
     data_dir = 'data_dir'
     mock_database.insert_or_update_bulk.side_effect = Exception('testing')
     mock_csv_importer.find_csv_files.return_value = [
-      ('path/file.csv', PathDetails('src', 'sig', 'day', 'hrr', 20200423, 20200424, 1)),
+      ('path/file.csv', PathDetails(20200424, 1, 'src', 'sig', 'day', 20200423, 'hrr')),
     ]
     mock_csv_importer.load_csv.return_value = [
       MagicMock(geo_value='geo', value=1, stderr=1, sample_size=1),

--- a/tests/acquisition/covidcast/test_csv_to_database.py
+++ b/tests/acquisition/covidcast/test_csv_to_database.py
@@ -35,7 +35,7 @@ class UnitTests(unittest.TestCase):
     """Scan the data directory."""
 
     mock_csv_importer.find_csv_files.return_value = self._path_details
-    collect_files("fake_data_dir",False) # no specific issue
+    collect_files("fake_data_dir", False) # no specific issue
     self.assertEqual(mock_csv_importer.find_csv_files.call_count, 1)
 
 

--- a/tests/acquisition/covidcast_nowcast/test_load_sensors.py
+++ b/tests/acquisition/covidcast_nowcast/test_load_sensors.py
@@ -9,6 +9,7 @@ from io import StringIO
 import pandas as pd
 
 # first party
+from delphi.epidata.acquisition.covidcast.csv_importer import PathDetails
 from delphi.epidata.acquisition.covidcast_nowcast.load_sensors import main, load_and_prepare_file
 
 # py3tester coverage target
@@ -20,13 +21,15 @@ class UpdateTests(unittest.TestCase):
   @mock.patch('time.time', mock.MagicMock(return_value=12345))
   def test_load_and_prepare_file(self):
     
-    test_attributes = ("test_source",
-                       "test_signal",
-                       "test_time_type",
-                       "test_geo_type",
-                       20201231,
-                       20210102,
-                       3)
+    test_attributes = PathDetails(
+      20210102,
+      3,
+      "test_source",
+      "test_signal",
+      "test_time_type",
+      20201231,
+      "test_geo_type",
+    )
 
     test_df = load_and_prepare_file(StringIO("sensor_name,geo_value,value\ntestname,01001,1.5"), test_attributes)
     pd.testing.assert_frame_equal(test_df,


### PR DESCRIPTION
**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

A follow up to #949. There were just some pieces of this code that really bothered me cause they were unnecessarily confusing to read every time I went there.

- Remove a bunch of unnecessary function arguments by correctly patching in tests
- Add type hints to many functions
- Simplify the logic that returns a list of CovidcastRows for database import
- Convert the path details tuple to a NamedTuples, so it's less of a mystery