### PR TITLE
Make Epidata.sensors.auth optional

### DIFF
--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -499,16 +499,17 @@ class Epidata:
   def sensors(auth, names, locations, epiweeks):
     """Fetch Delphi's digital surveillance sensors."""
     # Check parameters
-    if auth is None or names is None or locations is None or epiweeks is None:
-      raise Exception('`auth`, `names`, `locations`, and `epiweeks` are all required')
+    if names is None or locations is None or epiweeks is None:
+      raise Exception('`names`, `locations`, and `epiweeks` are all required')
     # Set up request
     params = {
       'endpoint': 'sensors',
-      'auth': auth,
       'names': Epidata._list(names),
       'locations': Epidata._list(locations),
       'epiweeks': Epidata._list(epiweeks),
     }
+    if auth is not None:
+      params['auth'] = auth
     # Make the API call
     return Epidata._request(params)
 


### PR DESCRIPTION

Fixes #49 

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Removes `auth` from argument requirements, and adds it to the request params only if specified. 

