### PR TITLE
Add server.utils to deployment config

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -27,6 +27,13 @@
     },
     {
       "type": "move",
+      "src": "src/server/utils",
+      "dst": "[[package]]/server/utils/",
+      "match": "^.*\\.(py)$",
+      "add-header-comment": true
+    },
+    {
+      "type": "move",
       "src": "src/server/endpoints",
       "dst": "[[package]]/server/endpoints/",
       "match": "^.*\\.(py)$",


### PR DESCRIPTION
Fixes failing Deploy Repo job in Automation

**Prerequisites**:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

Our home-brewed deployment system requires handling directories and subdirectories one at a time (there's no recursive traversal afaict). Looks like we added a dependency at some point recently where the tests reach into epidata.server.utils, but the utils directory was never added to deploy.json so the tests couldn't find the utils code at deployment time. This caused deployments to fail:

```
Traceback (most recent call last):
  File "/home/automation/.pyenv/versions/3.8.2/lib/python3.8/runpy.py", line 193, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/automation/.pyenv/versions/3.8.2/lib/python3.8/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/automation/driver/delphi/github_deploy_repo/github_deploy_repo.py", line 323, in <module>
    main(get_argument_parser().parse_args())
  File "/home/automation/driver/delphi/github_deploy_repo/github_deploy_repo.py", line 314, in main
    deploy_all(cnx, repo_list)
  File "/home/automation/driver/delphi/github_deploy_repo/github_deploy_repo.py", line 267, in deploy_all
    raise exceptions[0]
  File "/home/automation/driver/delphi/github_deploy_repo/github_deploy_repo.py", line 259, in deploy_all
    deploy_repo(cnx, owner, name, branch)
  File "/home/automation/driver/delphi/github_deploy_repo/github_deploy_repo.py", line 251, in deploy_repo
    raise exception
  File "/home/automation/driver/delphi/github_deploy_repo/github_deploy_repo.py", line 230, in deploy_repo
    execute(url, commit, tmpdir, config_name)
  File "/home/automation/driver/delphi/github_deploy_repo/github_deploy_repo.py", line 140, in execute
    executors[action](repo_link, commit, path, row, paths)
  File "/home/automation/driver/delphi/github_deploy_repo/actions/py3test.py", line 43, in py3test
    results = [p3t.analyze_results(p3t.run_tests(f)) for f in test_files]
  File "/home/automation/driver/delphi/github_deploy_repo/actions/py3test.py", line 43, in <listcomp>
    results = [p3t.analyze_results(p3t.run_tests(f)) for f in test_files]
  File "/home/automation/driver/undefx/py3tester/py3tester.py", line 240, in run_tests
    module = importlib.import_module(module_name)
  File "/home/automation/.pyenv/versions/3.8.2/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/automation/driver/github_deploy_repo__tmp/tests/acquisition/covidcast/test_covidcast_row.py", line 8, in <module>
  File "/home/automation/driver/delphi/epidata/acquisition/covidcast/test_utils.py", line 25, in <module>
    from delphi.epidata.server.utils.dates import day_to_time_value, time_value_to_day
ModuleNotFoundError: No module named 'delphi.epidata.server.utils'
```

This PR configures Deploy Repo to put the server/utils directory in the right place.
