### PR TITLE
change github perftest workflow to use as_of query set

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           cd delphi-admin/load-testing/locust
           docker build -t locust .
-          export CSV=v4-requests-small.csv
+          export CSV=v4-requests-as_of.csv
           touch output_stats.csv && chmod 666 output_stats.csv
           touch output_stats_history.csv && chmod 666 output_stats_history.csv
           touch output_failures.csv && chmod 666 output_failures.csv


### PR DESCRIPTION
this changes the github action/workflow for performance testing to use the ["as_of" set of sample queries](https://github.com/cmu-delphi/delphi-admin/blob/main/load-testing/locust/v4-requests-as_of.csv).

question: will this need to be merged into the `main` branch before the action/workflow uses the new query set, or will it work after being merged into `dev`?