### PR TITLE
covid_hosp update running time improvements -- part 2

### DIFF
--- a/src/acquisition/covid_hosp/common/utils.py
+++ b/src/acquisition/covid_hosp/common/utils.py
@@ -160,7 +160,8 @@ class Utils:
       ## repeated concatenation in pandas is expensive, but (1) we don't expect
       ## batch sizes to be terribly large (7 files max) and (2) this way we can
       ## more easily capture the next iteration's updates to any new keys
-      new_rows = df.loc[[i for i in df.index.to_list() if i not in result.index.to_list()]]
+      result_index_set = set(result.index.to_list())
+      new_rows = df.loc[[i for i in df.index.to_list() if i not in result_index_set]]
       result = pd.concat([result, new_rows])
 
     # convert the index rows back to columns


### PR DESCRIPTION
aka "fixin' 2: electric boogaloo"

a follow-up to #1083, as we are still seeing very long running time for `covid_hosp_facility` acquisition in production.