### PR TITLE
API Keys: Clients

### DIFF
--- a/dev/docker/python/Dockerfile
+++ b/dev/docker/python/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.8-buster
 
+RUN apt-get update && apt-get install -y r-base && Rscript -e "install.packages(c('httr','xml2'))"
+
 WORKDIR /usr/src/app
 
 COPY repos repos

--- a/dev/local/Makefile
+++ b/dev/local/Makefile
@@ -172,6 +172,17 @@ test:
 		--env "FLASK_SECRET=abc" \
 		delphi_web_python python -m pytest --import-mode importlib $(pdb) $(test) | tee test_output_$(NOW).log
 
+.PHONY=r-test
+r-test:
+	@docker run -i --rm --network delphi-net \
+		$(M1) \
+		--mount type=bind,source=$(CWD)repos/delphi/delphi-epidata,target=/usr/src/app/repos/delphi/delphi-epidata,readonly \
+		--mount type=bind,source=$(CWD)repos/delphi/delphi-epidata/src,target=/usr/src/app/delphi/epidata,readonly \
+		--env "SQLALCHEMY_DATABASE_URI=$(sqlalchemy_uri)" \
+		--env "FLASK_SECRET=abc" \
+		delphi_web_python Rscript repos/delphi/delphi-epidata/integrations/client/test_delphi_epidata.R | tee r-test_output_$(NOW).log
+
+
 .PHONY=bash
 bash:
 	@docker run -it --rm --network delphi-net \

--- a/integrations/client/test_delphi_epidata.R
+++ b/integrations/client/test_delphi_epidata.R
@@ -44,19 +44,25 @@ res <- call_region_epiweeks("kcdc_ili")
 check(res, -2, "no results", 0)
 res <- call_region_epiweeks("gft")
 check(res, -2, "no results", 0)
+## pre-pandemic auth endpoint; no test credentials plumbing for that yet
 #res <- Epidata$ght("abc", list("nat"), list(201440), "cough")
 #check(res, -2, "no results", 0)
+## pre-pandemic auth endpoint; no test credentials plumbing for that yet
 #res <- Epidata$twitter("abc", list("nat"), epiweeks=list(201440))
 #check(res, -2, "no results", 0)
 cat("wiki\n")
 res <- Epidata$wiki(list("abc"), list(20141201))
 check(res, -2, "no results", 0)
+## pre-pandemic auth endpoint; no test credentials plumbing for that yet
 #res <- Epidata$cdc("abc", list(201440), list("nat"))
 #check(res, -2, "no results", 0
+## pre-pandemic auth endpoint; no test credentials plumbing for that yet
 #res <- Epidata$quidel("abc", list(201440), list("nat"))
 #check(res, -2, "no results", 0)
+## pre-pandemic auth endpoint; no test credentials plumbing for that yet
 #res <- Epidata$norostat("abc", "nat", list(201440))
 #check(res, -2, "no results", 0)
+## pre-pandemic auth endpoint; no test credentials plumbing for that yet
 #res <- Epidata$meta_norostat("abc")
 #out(res)
 res <- call_region_epiweeks("nidss.flu")
@@ -66,18 +72,18 @@ check(res, -2, "no results", 0)
 cat("delphi\n")
 res <- Epidata$delphi("xyz", 201440)
 check(res, -2, "no results", 0)
+## pre-pandemic auth endpoint; no test credentials plumbing for that yet
 #res <- Epidata$sensors("abc", list("def"), list("nat"), list(201440))
 #check(res, -2, "no results", 0)
+## pre-pandemic auth endpoint; no test credentials plumbing for that yet
 #res <- Epidata$dengue_sensors("abc", list("def"), list("nat"), list(201440))
 #check(res, -2, "no results", 0)
 res <- call_region_epiweeks("nowcast")
 check(res, -2, "no results", 0)
-
-# Fails with database error:
+## Fails with database error:
 #res <- call_region_epiweeks("dengue_nowcast")
 #out(res)
 #check(res, -2, "no results", 0)
-
 cat("meta\n")
 res <- Epidata$meta()
 check(res, 1, "success", 1)

--- a/integrations/client/test_delphi_epidata.R
+++ b/integrations/client/test_delphi_epidata.R
@@ -1,0 +1,100 @@
+#!/usr/bin/env Rscript
+
+# disgusting hack to set up cwd
+initial_options <- commandArgs(trailingOnly = FALSE)
+file_arg_name <- "--file="
+basename <- dirname(sub(file_arg_name, "", initial_options[grep(file_arg_name, initial_options)]))
+setwd(basename)
+
+options(epidata.url="http://delphi_web_epidata/epidata/")
+source("../../src/client/delphi_epidata.R")
+
+out <- function(res) {
+  cat(paste(res$result, res$message, length(res$epidata), "\n"))
+}
+
+check <- function(res, exp_result, exp_message, exp_length) {
+  stopifnot(res$result == exp_result)
+  stopifnot(res$message == exp_message)
+  stopifnot(length(res$epidata) == exp_length)
+}
+
+call_region_epiweeks <- function(fn_name) {
+  fn <- Epidata[[fn_name]]
+  cat(paste(fn_name,"\n"))
+  fn(list('nat'), list(201440))
+}
+
+cat("server_version\n")
+res <- Epidata$server_version()
+stopifnot("version" %in% names(res))
+cat("fluview\n")
+res <- Epidata$fluview(list('nat'), list(201440, Epidata$range(201501, 201510)), auth="test")
+check(res, -2, "no results", 0)
+cat("fluview_meta\n")
+res <- Epidata$fluview_meta()
+check(res, 1, "success", 1)
+res <- call_region_epiweeks("fluview_clinical")
+check(res, -2, "no results", 0)
+res <- call_region_epiweeks("flusurv")
+check(res, -2, "no results", 0)
+res <- call_region_epiweeks("ecdc_ili")
+check(res, -2, "no results", 0)
+res <- call_region_epiweeks("kcdc_ili")
+check(res, -2, "no results", 0)
+res <- call_region_epiweeks("gft")
+check(res, -2, "no results", 0)
+#res <- Epidata$ght("abc", list("nat"), list(201440), "cough")
+#check(res, -2, "no results", 0)
+#res <- Epidata$twitter("abc", list("nat"), epiweeks=list(201440))
+#check(res, -2, "no results", 0)
+cat("wiki\n")
+res <- Epidata$wiki(list("abc"), list(20141201))
+check(res, -2, "no results", 0)
+#res <- Epidata$cdc("abc", list(201440), list("nat"))
+#check(res, -2, "no results", 0
+#res <- Epidata$quidel("abc", list(201440), list("nat"))
+#check(res, -2, "no results", 0)
+#res <- Epidata$norostat("abc", "nat", list(201440))
+#check(res, -2, "no results", 0)
+#res <- Epidata$meta_norostat("abc")
+#out(res)
+res <- call_region_epiweeks("nidss.flu")
+check(res, -2, "no results", 0)
+res <- call_region_epiweeks("nidss.dengue")
+check(res, -2, "no results", 0)
+cat("delphi\n")
+res <- Epidata$delphi("xyz", 201440)
+check(res, -2, "no results", 0)
+#res <- Epidata$sensors("abc", list("def"), list("nat"), list(201440))
+#check(res, -2, "no results", 0)
+#res <- Epidata$dengue_sensors("abc", list("def"), list("nat"), list(201440))
+#check(res, -2, "no results", 0)
+res <- call_region_epiweeks("nowcast")
+check(res, -2, "no results", 0)
+
+# Fails with database error:
+#res <- call_region_epiweeks("dengue_nowcast")
+#out(res)
+#check(res, -2, "no results", 0)
+
+cat("meta\n")
+res <- Epidata$meta()
+check(res, 1, "success", 1)
+cat("covidcast\n")
+res <- Epidata$covidcast("abc", "def", "day", "nation", list(20200401), "us")
+check(res, -2, "no results", 0)
+cat("covidcast_meta\n")
+res <- Epidata$covidcast_meta()
+check(res, 1, "success", 16)
+cat("covid_hosp\n")
+res <- Epidata$covid_hosp("pa", 20201201)
+check(res, -2, "no results", 0)
+cat("covid_hosp_facility\n")
+res <- Epidata$covid_hosp_facility(list("abc"), list(202050))
+check(res, -2, "no results", 0)
+cat("covid_hosp_facility_lookup\n")
+res <- Epidata$covid_hosp_facility_lookup("pa")
+check(res, 1, "success", 1)
+
+

--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -13,9 +13,13 @@ library(httr)
 Epidata <- (function() {
 
   # API base url
-  BASE_URL <- 'https://delphi.cmu.edu/epidata/api.php'
+  BASE_URL <- getOption('epidata.url', default = 'https://delphi.cmu.edu/epidata/')
 
   client_version <- '0.4.7'
+
+  auth <- getOption("epidata.auth", default = NA)
+
+  client_user_agent <- user_agent(paste("delphi_epidata", client_version, "R", sep="/"))
 
   # Helper function to cast values and/or ranges to strings
   .listitem <- function(value) {
@@ -36,10 +40,31 @@ Epidata <- (function() {
 
   # Helper function to request and parse epidata
   .request <- function(params) {
+    headers <- add_headers(Authorization = ifelse(is.na(auth), "", paste("Bearer", auth)))
+    url <- paste(BASE_URL, params$endpoint, sep="")
+    params <- within(params, rm(endpoint))
     # API call
-    res <- GET(BASE_URL, query=params)
+    res <- GET(url,
+               client_user_agent,
+               headers,
+               query=params)
     if (res$status_code == 414) {
-      res <- POST(BASE_URL, body=params, encode='form')
+      res <- POST(url,
+                  client_user_agent,
+                  headers,
+                  body=params, encode='form')
+    }
+    if (res$status_code != 200) {
+      # 500, 429, 401 are possible
+      msg <- "fetch data from API"
+      if (http_type(res) == "text/html") {
+        # grab the error information out of the returned HTML document
+        msg <- paste(msg, ":", xml2::xml_text(xml2::xml_find_all(
+          xml2::read_html(content(res, 'text')),
+          "//p"
+        )))
+      }
+      stop_for_status(res, task = msg)
     }
     return(content(res, 'parsed'))
   }
@@ -563,7 +588,7 @@ Epidata <- (function() {
     }
     # Set up request
     params <- list(
-      endpoint = 'covid_hosp',
+      endpoint = 'covid_hosp_state_timeseries',
       states = .list(states),
       dates = .list(dates)
     )
@@ -582,7 +607,7 @@ Epidata <- (function() {
     }
     # Set up request
     params <- list(
-      source = 'covid_hosp_facility',
+      endpoint = 'covid_hosp_facility',
       hospital_pks = .list(hospital_pks),
       collection_weeks = .list(collection_weeks)
     )
@@ -596,7 +621,7 @@ Epidata <- (function() {
   # Lookup COVID hospitalization facility identifiers
   covid_hosp_facility_lookup <- function(state, ccn, city, zip, fips_code) {
     # Set up request
-    params <- list(source = 'covid_hosp_facility_lookup')
+    params <- list(endpoint = 'covid_hosp_facility_lookup')
     if(!missing(state)) {
       params$state <- state
     } else if(!missing(ccn)) {
@@ -614,14 +639,21 @@ Epidata <- (function() {
     return(.request(params))
   }
 
+  server_version <- function() {
+    return(.request(list(endpoint = 'version')))
+  }
+
   # Export the public methods
   return(list(
     range = range,
     client_version = client_version,
+    server_version = server_version,
     fluview = fluview,
     fluview_meta = fluview_meta,
     fluview_clinical = fluview_clinical,
     flusurv = flusurv,
+    ecdc_ili = ecdc_ili,
+    kcdc_ili = kcdc_ili,
     gft = gft,
     ght = ght,
     twitter = twitter,

--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -19,7 +19,7 @@ Epidata <- (function() {
 
   auth <- getOption("epidata.auth", default = NA)
 
-  client_user_agent <- user_agent(paste("delphi_epidata", client_version, "R", sep="/"))
+  client_user_agent <- user_agent(paste("delphi_epidata/", client_version, " (R)", sep=""))
 
   # Helper function to cast values and/or ranges to strings
   .listitem <- function(value) {

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -25,7 +25,7 @@ except DistributionNotFound:
   _version = "0.script"
 
 _HEADERS = {
-  "user-agent": "delphi_epidata/" + _version
+  "user-agent": "delphi_epidata/" + _version + "/Python"
 }
 
 # Because the API is stateless, the Epidata class only contains static methods
@@ -62,6 +62,8 @@ class Epidata:
     req = requests.get(Epidata.BASE_URL, params, auth=Epidata.auth, headers=_HEADERS)
     if req.status_code == 414:
       req = requests.post(Epidata.BASE_URL, params, auth=Epidata.auth, headers=_HEADERS)
+    # handle 401 and 429
+    req.raise_for_status()
     return req
 
   @staticmethod
@@ -74,12 +76,15 @@ class Epidata:
     """
     try:
       result = Epidata._request_with_retry(params)
-      if params is not None and "format" in params and params["format"]=="csv":
-        return result.text
-      else:
-        return result.json()
     except Exception as e:
       return {'result': 0, 'message': 'error: ' + str(e)}
+    if params is not None and "format" in params and params["format"]=="csv":
+      return result.text
+    else:
+      try:
+        return result.json()
+      except requests.exceptions.JSONDecodeError:
+        return {'result': 0, 'message': 'error: ' + result.text}
 
   # Raise an Exception on error, otherwise return epidata
   @staticmethod

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -25,7 +25,7 @@ except DistributionNotFound:
   _version = "0.script"
 
 _HEADERS = {
-  "user-agent": "delphi_epidata/" + _version + "/Python"
+  "user-agent": "delphi_epidata/" + _version + " (Python)"
 }
 
 # Because the API is stateless, the Epidata class only contains static methods

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -84,7 +84,7 @@ class Epidata:
       try:
         return result.json()
       except requests.exceptions.JSONDecodeError:
-        return {'result': 0, 'message': 'error: ' + result.text}
+        return {'result': 0, 'message': 'error decoding json: ' + result.text}
 
   # Raise an Exception on error, otherwise return epidata
   @staticmethod


### PR DESCRIPTION

**Prerequisites**:

- [x] ~Unless it is a documentation hotfix it should be merged against the `dev` branch~ will revert to `api-keys` once [small fixes](https://github.com/cmu-delphi/delphi-epidata/pull/1151) is merged
- [x] Branch is up-to-date with the branch to be merged with
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

* bring py client in line with current api key behavior (permit anonymous requests, handle 401 and 429)
* support api keys in r client
  - add integration test for r client
  - add R to python image (double checked this image only used for local dev and github ci)
  - add `r-test` local development target (i didn't add it to ci but i could if folks think it's needed)
* minor improvement to error handling in py client that's been bugging me for months if not years - if json was expected but can't be parsed, show the user the actual error message from the server instead of the json parsing exception


