### PR TITLE
get_geo_values() doesnt know about a plain "state" type

### DIFF
--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -218,7 +218,7 @@ class DelphiEpidataPythonClientTests(CovidcastBase):
     # insert placeholder data: three counties, three MSAs
     N = 3
     rows = [
-      CovidcastTestRow.make_default_row(geo_type="fips", geo_value=FIPS[i], value=i)
+      CovidcastTestRow.make_default_row(geo_type="county", geo_value=FIPS[i], value=i)
       for i in range(N)
     ] + [
       CovidcastTestRow.make_default_row(geo_type="msa", geo_value=MSA[i], value=i*10)
@@ -245,7 +245,7 @@ class DelphiEpidataPythonClientTests(CovidcastBase):
     self.assertEqual(request['epidata'], [counties[0]])
     # test fetch a specific yet not existing region
     request = fetch('55555')
-    self.assertEqual(request['message'], 'Invalid geo_value(s) 55555 for the requested geo_type fips')
+    self.assertEqual(request['message'], 'Invalid geo_value(s) 55555 for the requested geo_type county')
     # test fetch a multiple regions
     request = fetch([FIPS[0], FIPS[1]])
     self.assertEqual(request['message'], 'success')
@@ -256,10 +256,10 @@ class DelphiEpidataPythonClientTests(CovidcastBase):
     self.assertEqual(request['epidata'], [counties[0], counties[2]])
     # test fetch a multiple regions but one is not existing
     request = fetch([FIPS[0], '55555'])
-    self.assertEqual(request['message'], 'Invalid geo_value(s) 55555 for the requested geo_type fips')
+    self.assertEqual(request['message'], 'Invalid geo_value(s) 55555 for the requested geo_type county')
     # test fetch a multiple regions but specify no region
     request = fetch([])
-    self.assertEqual(request['message'], 'geo_value is empty for the requested geo_type fips!')
+    self.assertEqual(request['message'], 'geo_value is empty for the requested geo_type county!')
     # test fetch a region with no results
     request = fetch([FIPS[3]])
     self.assertEqual(request['message'], 'no results')
@@ -326,7 +326,7 @@ class DelphiEpidataPythonClientTests(CovidcastBase):
     # insert placeholder data: three counties, three MSAs
     N = 3
     rows = [
-      CovidcastTestRow.make_default_row(geo_type="fips", geo_value=FIPS[i-1], value=i)
+      CovidcastTestRow.make_default_row(geo_type="county", geo_value=FIPS[i-1], value=i)
       for i in range(N)
     ] + [
       CovidcastTestRow.make_default_row(geo_type="msa", geo_value=MSA[i-1], value=i*10)

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -58,6 +58,7 @@ class GeoSet:
         if not isinstance(geo_values, bool):
             if geo_values == ['']:
                 raise ValidationFailedException(f"geo_value is empty for the requested geo_type {geo_type}!")
+            # TODO: keep this translator in sync with CsvImporter.GEOGRAPHIC_RESOLUTIONS in acquisition/covidcast/ and with GeoMapper
             geo_type_translator = {
                 "county": "fips",
                 "state": "state_id",

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -58,11 +58,20 @@ class GeoSet:
         if not isinstance(geo_values, bool):
             if geo_values == ['']:
                 raise ValidationFailedException(f"geo_value is empty for the requested geo_type {geo_type}!")
-            geo_type_translated = "state_id" if geo_type=="state" else geo_type
-            allowed_values = delphi_utils.geomap.GeoMapper().get_geo_values(geo_type_translated)
-            invalid_values = set(geo_values) - set(allowed_values)
-            if invalid_values:
-                raise ValidationFailedException(f"Invalid geo_value(s) {', '.join(invalid_values)} for the requested geo_type {geo_type}")
+            geo_type_translator = {
+                "county": "fips",
+                "state": "state_id",
+                "zip": "zip",
+                "hrr": "hrr",
+                "hhs": "hhs",
+                "msa": "msa",
+                "nation": "nation"
+            }
+            if geo_type in geo_type_translator: # else geo_type is unknown to GeoMapper
+                allowed_values = delphi_utils.geomap.GeoMapper().get_geo_values(geo_type_translator[geo_type])
+                invalid_values = set(geo_values) - set(allowed_values)
+                if invalid_values:
+                    raise ValidationFailedException(f"Invalid geo_value(s) {', '.join(invalid_values)} for the requested geo_type {geo_type}")
         self.geo_type = geo_type
         self.geo_values = geo_values
 

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -58,7 +58,8 @@ class GeoSet:
         if not isinstance(geo_values, bool):
             if geo_values == ['']:
                 raise ValidationFailedException(f"geo_value is empty for the requested geo_type {geo_type}!")
-            allowed_values = delphi_utils.geomap.GeoMapper().get_geo_values(geo_type)
+            geo_type_translated = "state_id" if geo_type=="state" else geo_type
+            allowed_values = delphi_utils.geomap.GeoMapper().get_geo_values(geo_type_translated)
             invalid_values = set(geo_values) - set(allowed_values)
             if invalid_values:
                 raise ValidationFailedException(f"Invalid geo_value(s) {', '.join(invalid_values)} for the requested geo_type {geo_type}")

--- a/tests/server/test_params.py
+++ b/tests/server/test_params.py
@@ -94,6 +94,10 @@ class UnitTests(unittest.TestCase):
                 self.assertEqual(parse_geo_arg(), [GeoSet("fips", True)])
             with app.test_request_context(f"/?geo=fips:{FIPS[0]}"):
                 self.assertEqual(parse_geo_arg(), [GeoSet("fips", [FIPS[0]])])
+        with self.subTest("covidcast"):
+            for geo_type in "county dma hhs hrr msa nation state".split():
+                with app.test_request_context(f"/?geo={geo_type}:*"):
+                    self.assertEqual(parse_geo_arg(), [GeoSet(geo_type, True)])
         with self.subTest("single list"):
             with app.test_request_context(f"/?geo=fips:{FIPS[0]},{FIPS[1]}"):
                 self.assertEqual(parse_geo_arg(), [GeoSet("fips", [FIPS[0], FIPS[1]])])


### PR DESCRIPTION
but it does know about "state_id", "state_code", and "state_name" (see [delphi_utils/geomap.py](https://github.com/cmu-delphi/covidcast-indicators/blob/2f92ca7ecf88c715bf152bd23e256e22347c50ae/_delphi_utils_python/delphi_utils/geomap.py#L545-L546)).  "state_id" appears to be the two-digit state abbreviation, if [delphi_utils/data/2020/state_pop.csv](https://github.com/cmu-delphi/covidcast-indicators/blob/main/_delphi_utils_python/delphi_utils/data/2020/state_pop.csv) is to be believed.

this is untested!  i whipped it up fast to address the issue we saw post-rollout.  its kinda hacky and i dont love the ternary form of it.  ...but it should do the trick, at least in prod for now.

obviously, it should be accompanied by some new additional unit and/or integration tests that involve a "state" geo_type.
