### PR TITLE
deleted itsdangerous from requirements as no needed

### DIFF
--- a/requirements.api.txt
+++ b/requirements.api.txt
@@ -1,7 +1,6 @@
 delphi_utils==0.3.6
 epiweeks==2.1.2
 Flask==2.2.2
-itsdangerous<2.1
 jinja2==3.0.3
 more_itertools==8.4.0
 mysqlclient==2.1.1


### PR DESCRIPTION
closes|addresses https://github.com/cmu-delphi/delphi-epidata/issues/848

### Summary:

Actually, Flask version is 2.2.2, just deleted itsdangerous from requirements as not needed

### Prerequisites:

- [ ] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [ ] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [ ] Code is cleaned up and formatted
