### PR TITLE
allow state-level FIPS codes for geo_type "county"

### DIFF
--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -60,7 +60,7 @@ class GeoSet:
                 raise ValidationFailedException(f"geo_value is empty for the requested geo_type {geo_type}!")
             # TODO: keep this translator in sync with CsvImporter.GEOGRAPHIC_RESOLUTIONS in acquisition/covidcast/ and with GeoMapper
             geo_type_translator = {
-                "county": "fips",
+                "county": "chng-fips",
                 "state": "state_id",
                 "zip": "zip",
                 "hrr": "hrr",


### PR DESCRIPTION
this change is intended to remedy the empty state visualization on the covidcast dashboard (ie, as seen on https://delphi.cmu.edu/covidcast/?date=20221115&region=PA) that was noticed today.  

it should make it so state-level FIPS codes are also allowed as valid values for `geo_type` of "`county`" (ie, all of Pennsylvania is captured in FIPS code 42000 where individual counties can be found in the range of 42001-42999).  it looks like "`hhs`" would work identically in place of "`chng-fips`" too, which kind of implies "hhs" and "county" may be redundant geo_types as stored in the epimetric tables.

this is also largely untested