### PR TITLE
update delphi_utils version

### DIFF
--- a/requirements.api.txt
+++ b/requirements.api.txt
@@ -1,4 +1,4 @@
-delphi_utils==0.3.6
+delphi_utils==0.3.15
 epiweeks==2.1.2
 Flask==2.2.2
 itsdangerous<2.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,7 +2,7 @@ aiohttp==3.8.3
 black>=20.8b1
 bump2version==1.0.1
 covidcast==0.1.5
-delphi_utils==0.3.6
+delphi_utils==0.3.15
 docker==6.0.1
 dropbox==11.36.0
 freezegun==1.2.2


### PR DESCRIPTION
i assumed this was not version-pinned and would use whatever was most up to date.  i shoulda checked!  fwiw, we were pinned to a version from august 2022.

this should pick up the change from https://github.com/cmu-delphi/covidcast-indicators/pull/1835