### PR TITLE
replace references to `delphi.cmu.edu/epidata` with `api.delphi.cmu.edu/epidata`

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -70,7 +70,7 @@ Please note that our `endpoint` parameters were previously referenced as `source
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/
+The base URL is: https://api.covidcast.cmu.edu/epidata/
 
 ## Specifying Epiweeks, Dates, and Lists
 
@@ -154,7 +154,7 @@ The parameters available for each source are documented in each linked source-sp
 # Example URLs
 
 ### FluView on 2015w01 (national)
-https://delphi.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201501
+https://api.covidcast.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201501
 
 ```json
 {
@@ -184,7 +184,7 @@ https://delphi.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201501
 ```
 
 ### Wikipedia Access article "influenza" on 2020w01
-https://delphi.cmu.edu/epidata/wiki/?language=en&articles=influenza&epiweeks=202001
+https://api.covidcast.cmu.edu/epidata/wiki/?language=en&articles=influenza&epiweeks=202001
 
 ```json
 {

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -70,7 +70,7 @@ Please note that our `endpoint` parameters were previously referenced as `source
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/
+The base URL is: https://api.delphi.cmu.edu/epidata/
 
 ## Specifying Epiweeks, Dates, and Lists
 
@@ -154,7 +154,7 @@ The parameters available for each source are documented in each linked source-sp
 # Example URLs
 
 ### FluView on 2015w01 (national)
-https://api.covidcast.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201501
+https://api.delphi.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201501
 
 ```json
 {
@@ -184,7 +184,7 @@ https://api.covidcast.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201501
 ```
 
 ### Wikipedia Access article "influenza" on 2020w01
-https://api.covidcast.cmu.edu/epidata/wiki/?language=en&articles=influenza&epiweeks=202001
+https://api.delphi.cmu.edu/epidata/wiki/?language=en&articles=influenza&epiweeks=202001
 
 ```json
 {

--- a/docs/api/afhsb.md
+++ b/docs/api/afhsb.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/afhsb/
+The base URL is: https://api.covidcast.cmu.edu/epidata/afhsb/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/afhsb.md
+++ b/docs/api/afhsb.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/afhsb/
+The base URL is: https://api.delphi.cmu.edu/epidata/afhsb/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/api_keys.md
+++ b/docs/api/api_keys.md
@@ -44,7 +44,7 @@ there are several ways to use your key to authenticate your requests:
 The request parameter “api_key” can be used to pass the API key to the server.
 Example:
 
-    http://delphi.cmu.edu/epidata/covidcast/meta?api_key=your_api_key_here
+    https://api.delphi.cmu.edu/epidata/covidcast/meta?api_key=your_api_key_here
 
 ### Via Basic Authentication
 
@@ -52,7 +52,7 @@ Another method is using the HTTP basic authorization header with the username
 "epidata" and the API key as the password. Example:
 
 ```
-curl -u 'epidata:your_api_key_here' https://delphi.cmu.edu/epidata/covidcast/meta
+curl -u 'epidata:your_api_key_here' https://api.delphi.cmu.edu/epidata/covidcast/meta
 ```
 
 ### Via Bearer Token
@@ -60,5 +60,5 @@ curl -u 'epidata:your_api_key_here' https://delphi.cmu.edu/epidata/covidcast/met
 Another method is providing the key in a bearer token header. Example:
 
 ```
-curl -H 'Authorization: Bearer your_api_key_here' https://delphi.cmu.edu/epidata/covidcast/meta
+curl -H 'Authorization: Bearer your_api_key_here' https://api.delphi.cmu.edu/epidata/covidcast/meta
 ```

--- a/docs/api/cdc.md
+++ b/docs/api/cdc.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/cdc/
+The base URL is: https://api.delphi.cmu.edu/epidata/cdc/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/cdc.md
+++ b/docs/api/cdc.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/cdc/
+The base URL is: https://api.covidcast.cmu.edu/epidata/cdc/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/covid_hosp.md
+++ b/docs/api/covid_hosp.md
@@ -46,7 +46,7 @@ dataset was published by HHS.
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/covid_hosp_state_timeseries/
+The base URL is: https://api.covidcast.cmu.edu/epidata/covid_hosp_state_timeseries/
 
 See [this documentation](README.md) for details on specifying locations and dates.
 
@@ -82,7 +82,7 @@ If `issues` is not specified, then the most recent issue is used by default.
 # Example URLs
 
 ### MA on 2020-05-10 (per most recent issue)
-https://delphi.cmu.edu/epidata/covid_hosp_state_timeseries/?states=MA&dates=20200510
+https://api.covidcast.cmu.edu/epidata/covid_hosp_state_timeseries/?states=MA&dates=20200510
 
 ```json
 {

--- a/docs/api/covid_hosp.md
+++ b/docs/api/covid_hosp.md
@@ -46,7 +46,7 @@ dataset was published by HHS.
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/covid_hosp_state_timeseries/
+The base URL is: https://api.delphi.cmu.edu/epidata/covid_hosp_state_timeseries/
 
 See [this documentation](README.md) for details on specifying locations and dates.
 
@@ -82,7 +82,7 @@ If `issues` is not specified, then the most recent issue is used by default.
 # Example URLs
 
 ### MA on 2020-05-10 (per most recent issue)
-https://api.covidcast.cmu.edu/epidata/covid_hosp_state_timeseries/?states=MA&dates=20200510
+https://api.delphi.cmu.edu/epidata/covid_hosp_state_timeseries/?states=MA&dates=20200510
 
 ```json
 {

--- a/docs/api/covid_hosp_facility.md
+++ b/docs/api/covid_hosp_facility.md
@@ -37,7 +37,7 @@ HHS. New versions are expected to be published roughly weekly.
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/covid_hosp_facility/
+The base URL is: https://api.covidcast.cmu.edu/epidata/covid_hosp_facility/
 
 See [this documentation](README.md) for details on specifying locations and dates.
 
@@ -87,7 +87,7 @@ has been renamed here for clarity.
 # Example URLs
 
 ### Moses Taylor Hospital (Scranton, PA) on the first collection week of December 2020 (per most recent issue)
-https://delphi.cmu.edu/epidata/covid_hosp_facility/?hospital_pks=390119&collection_weeks=20201201-20201207
+https://api.covidcast.cmu.edu/epidata/covid_hosp_facility/?hospital_pks=390119&collection_weeks=20201201-20201207
 
 ```json
 {

--- a/docs/api/covid_hosp_facility.md
+++ b/docs/api/covid_hosp_facility.md
@@ -37,7 +37,7 @@ HHS. New versions are expected to be published roughly weekly.
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/covid_hosp_facility/
+The base URL is: https://api.delphi.cmu.edu/epidata/covid_hosp_facility/
 
 See [this documentation](README.md) for details on specifying locations and dates.
 
@@ -87,7 +87,7 @@ has been renamed here for clarity.
 # Example URLs
 
 ### Moses Taylor Hospital (Scranton, PA) on the first collection week of December 2020 (per most recent issue)
-https://api.covidcast.cmu.edu/epidata/covid_hosp_facility/?hospital_pks=390119&collection_weeks=20201201-20201207
+https://api.delphi.cmu.edu/epidata/covid_hosp_facility/?hospital_pks=390119&collection_weeks=20201201-20201207
 
 ```json
 {

--- a/docs/api/covid_hosp_facility_lookup.md
+++ b/docs/api/covid_hosp_facility_lookup.md
@@ -30,7 +30,7 @@ This data source provides metadata about healthcare facilities in the US.
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/covid_hosp_facility_lookup/
+The base URL is: https://api.delphi.cmu.edu/epidata/covid_hosp_facility_lookup/
 
 See [this documentation](README.md) for details on specifying locations and dates.
 
@@ -72,7 +72,7 @@ Use the `hospital_pk` value when querying
 # Example URLs
 
 ### Lookup facilities in the city of Southlake (TX)
-https://api.covidcast.cmu.edu/epidata/covid_hosp_facility_lookup/?city=southlake
+https://api.delphi.cmu.edu/epidata/covid_hosp_facility_lookup/?city=southlake
 
 ```json
 {

--- a/docs/api/covid_hosp_facility_lookup.md
+++ b/docs/api/covid_hosp_facility_lookup.md
@@ -30,7 +30,7 @@ This data source provides metadata about healthcare facilities in the US.
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/covid_hosp_facility_lookup/
+The base URL is: https://api.covidcast.cmu.edu/epidata/covid_hosp_facility_lookup/
 
 See [this documentation](README.md) for details on specifying locations and dates.
 
@@ -72,7 +72,7 @@ Use the `hospital_pk` value when querying
 # Example URLs
 
 ### Lookup facilities in the city of Southlake (TX)
-https://delphi.cmu.edu/epidata/covid_hosp_facility_lookup/?city=southlake
+https://api.covidcast.cmu.edu/epidata/covid_hosp_facility_lookup/?city=southlake
 
 ```json
 {

--- a/docs/api/covidcast.md
+++ b/docs/api/covidcast.md
@@ -92,7 +92,7 @@ sources and signals.
 ## Constructing API Queries
 
 The COVIDcast API is based on HTTP GET queries and returns data in JSON form.
-The base URL is `https://api.covidcast.cmu.edu/epidata/covidcast/`.
+The base URL is `https://api.delphi.cmu.edu/epidata/covidcast/`.
 
 See [this documentation](README.md) for details on specifying epiweeks, dates,
 and lists.
@@ -207,7 +207,7 @@ The `fields` parameter can be used to limit which fields are included in each re
 
 ### Facebook Survey CLI on 2020-04-06 to 2010-04-10 (county 06001)
 
-https://api.covidcast.cmu.edu/epidata/covidcast/?data_source=fb-survey&signal=smoothed_cli&time_type=day&geo_type=county&time_values=20200406-20200410&geo_value=06001
+https://api.delphi.cmu.edu/epidata/covidcast/?data_source=fb-survey&signal=smoothed_cli&time_type=day&geo_type=county&time_values=20200406-20200410&geo_value=06001
 
 ```json
 {
@@ -229,7 +229,7 @@ https://api.covidcast.cmu.edu/epidata/covidcast/?data_source=fb-survey&signal=sm
 
 ### Facebook Survey CLI on 2020-04-06 (all counties)
 
-https://api.covidcast.cmu.edu/epidata/covidcast/?data_source=fb-survey&signal=smoothed_cli&time_type=day&geo_type=county&time_values=20200406&geo_value=*
+https://api.delphi.cmu.edu/epidata/covidcast/?data_source=fb-survey&signal=smoothed_cli&time_type=day&geo_type=county&time_values=20200406&geo_value=*
 
 ```json
 {

--- a/docs/api/covidcast_meta.md
+++ b/docs/api/covidcast_meta.md
@@ -13,7 +13,7 @@ geographic levels at which they are reported.
 
 ## The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/covidcast_meta/
+The base URL is: https://api.delphi.cmu.edu/epidata/covidcast_meta/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -45,7 +45,7 @@ None required.
 
 ## Example URLs
 
-https://api.covidcast.cmu.edu/epidata/covidcast_meta/
+https://api.delphi.cmu.edu/epidata/covidcast_meta/
 
 ```json
 {

--- a/docs/api/delphi.md
+++ b/docs/api/delphi.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/delphi/
+The base URL is: https://api.covidcast.cmu.edu/epidata/delphi/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -58,7 +58,7 @@ See [this documentation](README.md) for details on specifying epiweeks, dates, a
 # Example URLs
 
 ### Delphi on 2020w01 (EC)
-https://delphi.cmu.edu/epidata/delphi/?system=ec&epiweek=202001
+https://api.covidcast.cmu.edu/epidata/delphi/?system=ec&epiweek=202001
 
 ```json
 {

--- a/docs/api/delphi.md
+++ b/docs/api/delphi.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/delphi/
+The base URL is: https://api.delphi.cmu.edu/epidata/delphi/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -58,7 +58,7 @@ See [this documentation](README.md) for details on specifying epiweeks, dates, a
 # Example URLs
 
 ### Delphi on 2020w01 (EC)
-https://api.covidcast.cmu.edu/epidata/delphi/?system=ec&epiweek=202001
+https://api.delphi.cmu.edu/epidata/delphi/?system=ec&epiweek=202001
 
 ```json
 {

--- a/docs/api/dengue_nowcast.md
+++ b/docs/api/dengue_nowcast.md
@@ -20,7 +20,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/dengue_nowcast/
+The base URL is: https://api.delphi.cmu.edu/epidata/dengue_nowcast/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/dengue_nowcast.md
+++ b/docs/api/dengue_nowcast.md
@@ -20,7 +20,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/dengue_nowcast/
+The base URL is: https://api.covidcast.cmu.edu/epidata/dengue_nowcast/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/dengue_sensors.md
+++ b/docs/api/dengue_sensors.md
@@ -20,7 +20,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/dengue_sensors/
+The base URL is: https://api.delphi.cmu.edu/epidata/dengue_sensors/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/dengue_sensors.md
+++ b/docs/api/dengue_sensors.md
@@ -20,7 +20,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/dengue_sensors/
+The base URL is: https://api.covidcast.cmu.edu/epidata/dengue_sensors/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/ecdc_ili.md
+++ b/docs/api/ecdc_ili.md
@@ -19,7 +19,7 @@ ECDC ILI data from ECDC website. ... <!-- TODO -->
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/ecdc_ili/
+The base URL is: https://api.delphi.cmu.edu/epidata/ecdc_ili/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/ecdc_ili.md
+++ b/docs/api/ecdc_ili.md
@@ -19,7 +19,7 @@ ECDC ILI data from ECDC website. ... <!-- TODO -->
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/ecdc_ili/
+The base URL is: https://api.covidcast.cmu.edu/epidata/ecdc_ili/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/flusurv.md
+++ b/docs/api/flusurv.md
@@ -26,7 +26,7 @@ See also:
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/flusurv/
+The base URL is: https://api.covidcast.cmu.edu/epidata/flusurv/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -79,7 +79,7 @@ Notes:
 # Example URLs
 
 ### FluSurv on 2020w01 (CA)
-https://delphi.cmu.edu/epidata/flusurv/?locations=ca&epiweeks=202001
+https://api.covidcast.cmu.edu/epidata/flusurv/?locations=ca&epiweeks=202001
 
 ```json
 {

--- a/docs/api/flusurv.md
+++ b/docs/api/flusurv.md
@@ -26,7 +26,7 @@ See also:
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/flusurv/
+The base URL is: https://api.delphi.cmu.edu/epidata/flusurv/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -79,7 +79,7 @@ Notes:
 # Example URLs
 
 ### FluSurv on 2020w01 (CA)
-https://api.covidcast.cmu.edu/epidata/flusurv/?locations=ca&epiweeks=202001
+https://api.delphi.cmu.edu/epidata/flusurv/?locations=ca&epiweeks=202001
 
 ```json
 {

--- a/docs/api/fluview.md
+++ b/docs/api/fluview.md
@@ -25,7 +25,7 @@ Influenza-like illness (ILI) from U.S. Outpatient Influenza-like Illness Surveil
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/fluview/
+The base URL is: https://api.covidcast.cmu.edu/epidata/fluview/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -80,7 +80,7 @@ Notes:
 # Example URLs
 
 ### FluView on 2015w01 (national)
-https://delphi.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201501
+https://api.covidcast.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201501
 
 ```json
 {
@@ -111,11 +111,11 @@ https://delphi.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201501
 
 ### FluView in HHS Regions 4 and 6 for the 2014/2015 flu season
 
-https://delphi.cmu.edu/epidata/fluview/?regions=hhs4,hhs6&epiweeks=201440-201520
+https://api.covidcast.cmu.edu/epidata/fluview/?regions=hhs4,hhs6&epiweeks=201440-201520
 
 ### Updates to FluView on 2014w53, reported from 2015w01 through 2015w10 (national)
 
-https://delphi.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201453&issues=201501-201510
+https://api.covidcast.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201453&issues=201501-201510
 
 
 # Code Samples

--- a/docs/api/fluview.md
+++ b/docs/api/fluview.md
@@ -25,7 +25,7 @@ Influenza-like illness (ILI) from U.S. Outpatient Influenza-like Illness Surveil
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/fluview/
+The base URL is: https://api.delphi.cmu.edu/epidata/fluview/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -80,7 +80,7 @@ Notes:
 # Example URLs
 
 ### FluView on 2015w01 (national)
-https://api.covidcast.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201501
+https://api.delphi.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201501
 
 ```json
 {
@@ -111,11 +111,11 @@ https://api.covidcast.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201501
 
 ### FluView in HHS Regions 4 and 6 for the 2014/2015 flu season
 
-https://api.covidcast.cmu.edu/epidata/fluview/?regions=hhs4,hhs6&epiweeks=201440-201520
+https://api.delphi.cmu.edu/epidata/fluview/?regions=hhs4,hhs6&epiweeks=201440-201520
 
 ### Updates to FluView on 2014w53, reported from 2015w01 through 2015w10 (national)
 
-https://api.covidcast.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201453&issues=201501-201510
+https://api.delphi.cmu.edu/epidata/fluview/?regions=nat&epiweeks=201453&issues=201501-201510
 
 
 # Code Samples

--- a/docs/api/fluview_clinical.md
+++ b/docs/api/fluview_clinical.md
@@ -20,7 +20,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/fluview_clinical/
+The base URL is: https://api.delphi.cmu.edu/epidata/fluview_clinical/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -66,7 +66,7 @@ If neither is specified, the current issues are used.
 # Example URLs
 
 ### FluView Clinical on 2020w01 (national)
-https://api.covidcast.cmu.edu/epidata/fluview_clinical/?regions=nat&epiweeks=202001
+https://api.delphi.cmu.edu/epidata/fluview_clinical/?regions=nat&epiweeks=202001
 
 ```json
 {

--- a/docs/api/fluview_clinical.md
+++ b/docs/api/fluview_clinical.md
@@ -20,7 +20,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/fluview_clinical/
+The base URL is: https://api.covidcast.cmu.edu/epidata/fluview_clinical/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -66,7 +66,7 @@ If neither is specified, the current issues are used.
 # Example URLs
 
 ### FluView Clinical on 2020w01 (national)
-https://delphi.cmu.edu/epidata/fluview_clinical/?regions=nat&epiweeks=202001
+https://api.covidcast.cmu.edu/epidata/fluview_clinical/?regions=nat&epiweeks=202001
 
 ```json
 {

--- a/docs/api/fluview_meta.md
+++ b/docs/api/fluview_meta.md
@@ -20,7 +20,7 @@ Returns information about the [`fluview` endpoint](fluview.md).
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/fluview_meta/
+The base URL is: https://api.delphi.cmu.edu/epidata/fluview_meta/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -42,7 +42,7 @@ There are no parameters for this endpoint.
 # Example URLs
 
 ### FluView Metadata
-https://api.covidcast.cmu.edu/epidata/fluview_meta/
+https://api.delphi.cmu.edu/epidata/fluview_meta/
 
 ```json
 {

--- a/docs/api/fluview_meta.md
+++ b/docs/api/fluview_meta.md
@@ -20,7 +20,7 @@ Returns information about the [`fluview` endpoint](fluview.md).
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/fluview_meta/
+The base URL is: https://api.covidcast.cmu.edu/epidata/fluview_meta/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -42,7 +42,7 @@ There are no parameters for this endpoint.
 # Example URLs
 
 ### FluView Metadata
-https://delphi.cmu.edu/epidata/fluview_meta/
+https://api.covidcast.cmu.edu/epidata/fluview_meta/
 
 ```json
 {

--- a/docs/api/gft.md
+++ b/docs/api/gft.md
@@ -23,7 +23,7 @@ Estimate of influenza activity based on volume of certain search queries. Google
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/gft/
+The base URL is: https://api.covidcast.cmu.edu/epidata/gft/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -50,7 +50,7 @@ See [this documentation](README.md) for details on specifying epiweeks, dates, a
 # Example URLs
 
 ### Google Flu Trends on 2015w01 (national)
-https://delphi.cmu.edu/epidata/gft/?locations=nat&epiweeks=201501
+https://api.covidcast.cmu.edu/epidata/gft/?locations=nat&epiweeks=201501
 
 ```json
 {

--- a/docs/api/gft.md
+++ b/docs/api/gft.md
@@ -23,7 +23,7 @@ Estimate of influenza activity based on volume of certain search queries. Google
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/gft/
+The base URL is: https://api.delphi.cmu.edu/epidata/gft/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -50,7 +50,7 @@ See [this documentation](README.md) for details on specifying epiweeks, dates, a
 # Example URLs
 
 ### Google Flu Trends on 2015w01 (national)
-https://api.covidcast.cmu.edu/epidata/gft/?locations=nat&epiweeks=201501
+https://api.delphi.cmu.edu/epidata/gft/?locations=nat&epiweeks=201501
 
 ```json
 {

--- a/docs/api/ght.md
+++ b/docs/api/ght.md
@@ -19,7 +19,7 @@ Estimate of influenza activity based on volume of certain search queries. ... <!
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/ght/
+The base URL is: https://api.delphi.cmu.edu/epidata/ght/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/ght.md
+++ b/docs/api/ght.md
@@ -19,7 +19,7 @@ Estimate of influenza activity based on volume of certain search queries. ... <!
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/ght/
+The base URL is: https://api.covidcast.cmu.edu/epidata/ght/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/kcdc_ili.md
+++ b/docs/api/kcdc_ili.md
@@ -18,7 +18,7 @@ KCDC ILI data from KCDC website. ... <!-- TODO -->
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/kcdc_ili/
+The base URL is: https://api.covidcast.cmu.edu/epidata/kcdc_ili/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/kcdc_ili.md
+++ b/docs/api/kcdc_ili.md
@@ -18,7 +18,7 @@ KCDC ILI data from KCDC website. ... <!-- TODO -->
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/kcdc_ili/
+The base URL is: https://api.delphi.cmu.edu/epidata/kcdc_ili/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/meta.md
+++ b/docs/api/meta.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/meta/
+The base URL is: https://api.covidcast.cmu.edu/epidata/meta/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -38,7 +38,7 @@ None.
 
 # Example URLs
 
-https://delphi.cmu.edu/epidata/meta/
+https://api.covidcast.cmu.edu/epidata/meta/
 
 ```json
 {

--- a/docs/api/meta.md
+++ b/docs/api/meta.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/meta/
+The base URL is: https://api.delphi.cmu.edu/epidata/meta/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -38,7 +38,7 @@ None.
 
 # Example URLs
 
-https://api.covidcast.cmu.edu/epidata/meta/
+https://api.delphi.cmu.edu/epidata/meta/
 
 ```json
 {

--- a/docs/api/meta_afhsb.md
+++ b/docs/api/meta_afhsb.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/meta_afhsb/
+The base URL is: https://api.delphi.cmu.edu/epidata/meta_afhsb/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/meta_afhsb.md
+++ b/docs/api/meta_afhsb.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/meta_afhsb/
+The base URL is: https://api.covidcast.cmu.edu/epidata/meta_afhsb/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/meta_norostat.md
+++ b/docs/api/meta_norostat.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/meta_norostat/
+The base URL is: https://api.covidcast.cmu.edu/epidata/meta_norostat/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/meta_norostat.md
+++ b/docs/api/meta_norostat.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/meta_norostat/
+The base URL is: https://api.delphi.cmu.edu/epidata/meta_norostat/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/nidss_dengue.md
+++ b/docs/api/nidss_dengue.md
@@ -23,7 +23,7 @@ Counts of confirmed dengue cases from Taiwan's NIDSS.
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/nidss_dengue/
+The base URL is: https://api.delphi.cmu.edu/epidata/nidss_dengue/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -50,7 +50,7 @@ See [this documentation](README.md) for details on specifying epiweeks, dates, a
 # Example URLs
 
 ### NIDSS Dengue on 2015w01 (nationwide)
-https://api.covidcast.cmu.edu/epidata/nidss_dengue/?locations=nationwide&epiweeks=201501
+https://api.delphi.cmu.edu/epidata/nidss_dengue/?locations=nationwide&epiweeks=201501
 
 ```json
 {

--- a/docs/api/nidss_dengue.md
+++ b/docs/api/nidss_dengue.md
@@ -23,7 +23,7 @@ Counts of confirmed dengue cases from Taiwan's NIDSS.
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/nidss_dengue/
+The base URL is: https://api.covidcast.cmu.edu/epidata/nidss_dengue/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -50,7 +50,7 @@ See [this documentation](README.md) for details on specifying epiweeks, dates, a
 # Example URLs
 
 ### NIDSS Dengue on 2015w01 (nationwide)
-https://delphi.cmu.edu/epidata/nidss_dengue/?locations=nationwide&epiweeks=201501
+https://api.covidcast.cmu.edu/epidata/nidss_dengue/?locations=nationwide&epiweeks=201501
 
 ```json
 {

--- a/docs/api/nidss_flu.md
+++ b/docs/api/nidss_flu.md
@@ -25,7 +25,7 @@ Outpatient ILI from Taiwan's National Infectious Disease Statistics System (NIDS
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/nidss_flu/
+The base URL is: https://api.delphi.cmu.edu/epidata/nidss_flu/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -67,7 +67,7 @@ If neither is specified, the current issues are used.
 # Example URLs
 
 ### NIDSS Flu on 2015w01 (nationwide)
-https://api.covidcast.cmu.edu/epidata/nidss_flu/?regions=nationwide&epiweeks=201501
+https://api.delphi.cmu.edu/epidata/nidss_flu/?regions=nationwide&epiweeks=201501
 
 ```json
 {

--- a/docs/api/nidss_flu.md
+++ b/docs/api/nidss_flu.md
@@ -25,7 +25,7 @@ Outpatient ILI from Taiwan's National Infectious Disease Statistics System (NIDS
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/nidss_flu/
+The base URL is: https://api.covidcast.cmu.edu/epidata/nidss_flu/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -67,7 +67,7 @@ If neither is specified, the current issues are used.
 # Example URLs
 
 ### NIDSS Flu on 2015w01 (nationwide)
-https://delphi.cmu.edu/epidata/nidss_flu/?regions=nationwide&epiweeks=201501
+https://api.covidcast.cmu.edu/epidata/nidss_flu/?regions=nationwide&epiweeks=201501
 
 ```json
 {

--- a/docs/api/norostat.md
+++ b/docs/api/norostat.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/norostat/
+The base URL is: https://api.covidcast.cmu.edu/epidata/norostat/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/norostat.md
+++ b/docs/api/norostat.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/norostat/
+The base URL is: https://api.delphi.cmu.edu/epidata/norostat/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/nowcast.md
+++ b/docs/api/nowcast.md
@@ -25,7 +25,7 @@ A nowcast of U.S. national, regional, and state-level (weighted) %ILI, available
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/nowcast/
+The base URL is: https://api.covidcast.cmu.edu/epidata/nowcast/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -53,7 +53,7 @@ See [this documentation](README.md) for details on specifying epiweeks, dates, a
 # Example URLs
 
 ### ILI Nearby on 2020w01 (national)
-https://delphi.cmu.edu/epidata/nowcast/?locations=nat&epiweeks=202001
+https://api.covidcast.cmu.edu/epidata/nowcast/?locations=nat&epiweeks=202001
 
 ```json
 {

--- a/docs/api/nowcast.md
+++ b/docs/api/nowcast.md
@@ -25,7 +25,7 @@ A nowcast of U.S. national, regional, and state-level (weighted) %ILI, available
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/nowcast/
+The base URL is: https://api.delphi.cmu.edu/epidata/nowcast/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -53,7 +53,7 @@ See [this documentation](README.md) for details on specifying epiweeks, dates, a
 # Example URLs
 
 ### ILI Nearby on 2020w01 (national)
-https://api.covidcast.cmu.edu/epidata/nowcast/?locations=nat&epiweeks=202001
+https://api.delphi.cmu.edu/epidata/nowcast/?locations=nat&epiweeks=202001
 
 ```json
 {

--- a/docs/api/paho_dengue.md
+++ b/docs/api/paho_dengue.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/paho_dengue/
+The base URL is: https://api.covidcast.cmu.edu/epidata/paho_dengue/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/paho_dengue.md
+++ b/docs/api/paho_dengue.md
@@ -19,7 +19,7 @@ General topics not specific to any particular endpoint are discussed in the
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/paho_dengue/
+The base URL is: https://api.delphi.cmu.edu/epidata/paho_dengue/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/quidel.md
+++ b/docs/api/quidel.md
@@ -21,7 +21,7 @@ Data provided by Quidel Corp., which contains flu lab test results.
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/quidel/
+The base URL is: https://api.delphi.cmu.edu/epidata/quidel/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/quidel.md
+++ b/docs/api/quidel.md
@@ -21,7 +21,7 @@ Data provided by Quidel Corp., which contains flu lab test results.
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/quidel/
+The base URL is: https://api.covidcast.cmu.edu/epidata/quidel/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 

--- a/docs/api/sensors.md
+++ b/docs/api/sensors.md
@@ -29,7 +29,7 @@ the COVID-19 pandemic.
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/sensors/
+The base URL is: https://api.delphi.cmu.edu/epidata/sensors/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -70,7 +70,7 @@ Notes:
 # Example URLs
 
 ### Delphi's Digital Surveillance SAR3 Sensor on 2020w01 (national)
-https://api.covidcast.cmu.edu/epidata/sensors/?names=sar3&locations=nat&epiweeks=202001
+https://api.delphi.cmu.edu/epidata/sensors/?names=sar3&locations=nat&epiweeks=202001
 
 ```json
 {

--- a/docs/api/sensors.md
+++ b/docs/api/sensors.md
@@ -29,7 +29,7 @@ the COVID-19 pandemic.
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/sensors/
+The base URL is: https://api.covidcast.cmu.edu/epidata/sensors/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -70,7 +70,7 @@ Notes:
 # Example URLs
 
 ### Delphi's Digital Surveillance SAR3 Sensor on 2020w01 (national)
-https://delphi.cmu.edu/epidata/sensors/?names=sar3&locations=nat&epiweeks=202001
+https://api.covidcast.cmu.edu/epidata/sensors/?names=sar3&locations=nat&epiweeks=202001
 
 ```json
 {

--- a/docs/api/twitter.md
+++ b/docs/api/twitter.md
@@ -23,7 +23,7 @@ Estimate of influenza activity based on analysis of language used in tweets.
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/twitter/
+The base URL is: https://api.covidcast.cmu.edu/epidata/twitter/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -53,7 +53,7 @@ Note:
 # Example URLs
 
 ### Twitter on 2015w01 (national)
-https://delphi.cmu.edu/epidata/twitter/?auth=...&locations=nat&epiweeks=201501
+https://api.covidcast.cmu.edu/epidata/twitter/?auth=...&locations=nat&epiweeks=201501
 
 ```json
 {

--- a/docs/api/twitter.md
+++ b/docs/api/twitter.md
@@ -23,7 +23,7 @@ Estimate of influenza activity based on analysis of language used in tweets.
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/twitter/
+The base URL is: https://api.delphi.cmu.edu/epidata/twitter/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -53,7 +53,7 @@ Note:
 # Example URLs
 
 ### Twitter on 2015w01 (national)
-https://api.covidcast.cmu.edu/epidata/twitter/?auth=...&locations=nat&epiweeks=201501
+https://api.delphi.cmu.edu/epidata/twitter/?auth=...&locations=nat&epiweeks=201501
 
 ```json
 {

--- a/docs/api/wiki.md
+++ b/docs/api/wiki.md
@@ -24,7 +24,7 @@ Number of page visits for selected English, Influenza-related wikipedia articles
 
 # The API
 
-The base URL is: https://api.covidcast.cmu.edu/epidata/wiki/
+The base URL is: https://api.delphi.cmu.edu/epidata/wiki/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -66,7 +66,7 @@ Note:
 # Example URLs
 
 ### Wikipedia Access article "influenza" on 2020w01
-https://api.covidcast.cmu.edu/epidata/wiki/?language=en&articles=influenza&epiweeks=202001
+https://api.delphi.cmu.edu/epidata/wiki/?language=en&articles=influenza&epiweeks=202001
 
 ```json
 {
@@ -86,7 +86,7 @@ https://api.covidcast.cmu.edu/epidata/wiki/?language=en&articles=influenza&epiwe
 ```
 
 ### Wikipedia Access article "influenza" on date 2020-01-01
-https://api.covidcast.cmu.edu/epidata/wiki/?language=en&articles=influenza&dates=20200101
+https://api.delphi.cmu.edu/epidata/wiki/?language=en&articles=influenza&dates=20200101
 
 ```json
 {

--- a/docs/api/wiki.md
+++ b/docs/api/wiki.md
@@ -24,7 +24,7 @@ Number of page visits for selected English, Influenza-related wikipedia articles
 
 # The API
 
-The base URL is: https://delphi.cmu.edu/epidata/wiki/
+The base URL is: https://api.covidcast.cmu.edu/epidata/wiki/
 
 See [this documentation](README.md) for details on specifying epiweeks, dates, and lists.
 
@@ -66,7 +66,7 @@ Note:
 # Example URLs
 
 ### Wikipedia Access article "influenza" on 2020w01
-https://delphi.cmu.edu/epidata/wiki/?language=en&articles=influenza&epiweeks=202001
+https://api.covidcast.cmu.edu/epidata/wiki/?language=en&articles=influenza&epiweeks=202001
 
 ```json
 {
@@ -86,7 +86,7 @@ https://delphi.cmu.edu/epidata/wiki/?language=en&articles=influenza&epiweeks=202
 ```
 
 ### Wikipedia Access article "influenza" on date 2020-01-01
-https://delphi.cmu.edu/epidata/wiki/?language=en&articles=influenza&dates=20200101
+https://api.covidcast.cmu.edu/epidata/wiki/?language=en&articles=influenza&dates=20200101
 
 ```json
 {

--- a/docs/new_endpoint_tutorial.md
+++ b/docs/new_endpoint_tutorial.md
@@ -325,7 +325,7 @@ actual
 created in this tutorial.
 
 Once it's approved, merge the PR, and contact an admin to schedule a release. Once released, the API will begin serving your new endpoint. Go ahead and give it a
-try: https://api.covidcast.cmu.edu/epidata/fluview_meta/
+try: https://api.delphi.cmu.edu/epidata/fluview_meta/
 
 ```
 {

--- a/docs/new_endpoint_tutorial.md
+++ b/docs/new_endpoint_tutorial.md
@@ -325,7 +325,7 @@ actual
 created in this tutorial.
 
 Once it's approved, merge the PR, and contact an admin to schedule a release. Once released, the API will begin serving your new endpoint. Go ahead and give it a
-try: https://delphi.cmu.edu/epidata/fluview_meta/
+try: https://api.covidcast.cmu.edu/epidata/fluview_meta/
 
 ```
 {

--- a/scripts/report_missing_covidcast_meta.py
+++ b/scripts/report_missing_covidcast_meta.py
@@ -5,7 +5,7 @@ import pandas as pd
 from pathlib import Path
 
 base_dir = Path(__file__).parent.parent
-base_url = 'https://delphi.cmu.edu/epidata'
+base_url = 'https://api.covidcast.cmu.edu/epidata'
 
 def is_known_missing(source: str, signal: str) -> bool:
     if '7dav_cumulative' in signal:

--- a/scripts/report_missing_covidcast_meta.py
+++ b/scripts/report_missing_covidcast_meta.py
@@ -5,7 +5,7 @@ import pandas as pd
 from pathlib import Path
 
 base_dir = Path(__file__).parent.parent
-base_url = 'https://api.covidcast.cmu.edu/epidata'
+base_url = 'https://api.delphi.cmu.edu/epidata'
 
 def is_known_missing(source: str, signal: str) -> bool:
     if '7dav_cumulative' in signal:

--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -13,7 +13,7 @@ library(httr)
 Epidata <- (function() {
 
   # API base url
-  BASE_URL <- 'https://api.covidcast.cmu.edu/epidata/api.php'
+  BASE_URL <- 'https://api.delphi.cmu.edu/epidata/api.php'
 
   client_version <- '0.4.11'
 

--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -13,7 +13,7 @@ library(httr)
 Epidata <- (function() {
 
   # API base url
-  BASE_URL <- 'https://delphi.cmu.edu/epidata/api.php'
+  BASE_URL <- 'https://api.covidcast.cmu.edu/epidata/api.php'
 
   client_version <- '0.4.11'
 

--- a/src/client/delphi_epidata.js
+++ b/src/client/delphi_epidata.js
@@ -21,7 +21,7 @@
     factory(root, root.fetch, root.jQuery || root.$);
   }
 })(this, function (exports, fetchImpl, jQuery) {
-  const BASE_URL = "https://api.covidcast.cmu.edu/epidata/";
+  const BASE_URL = "https://api.delphi.cmu.edu/epidata/";
   const client_version = "0.4.11";
 
   // Helper function to cast values and/or ranges to strings

--- a/src/client/delphi_epidata.js
+++ b/src/client/delphi_epidata.js
@@ -21,7 +21,7 @@
     factory(root, root.fetch, root.jQuery || root.$);
   }
 })(this, function (exports, fetchImpl, jQuery) {
-  const BASE_URL = "https://delphi.cmu.edu/epidata/";
+  const BASE_URL = "https://api.covidcast.cmu.edu/epidata/";
   const client_version = "0.4.11";
 
   // Helper function to cast values and/or ranges to strings

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -33,7 +33,7 @@ class Epidata:
   """An interface to DELPHI's Epidata API."""
 
   # API base url
-  BASE_URL = 'https://delphi.cmu.edu/epidata/api.php'
+  BASE_URL = 'https://api.covidcast.cmu.edu/epidata/api.php'
 
   client_version = _version
 

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -33,7 +33,7 @@ class Epidata:
   """An interface to DELPHI's Epidata API."""
 
   # API base url
-  BASE_URL = 'https://api.covidcast.cmu.edu/epidata/api.php'
+  BASE_URL = 'https://api.delphi.cmu.edu/epidata/api.php'
 
   client_version = _version
 

--- a/src/client/packaging/npm/tests/__snapshots__/delphi_epidata.spec.js.snap
+++ b/src/client/packaging/npm/tests/__snapshots__/delphi_epidata.spec.js.snap
@@ -36,7 +36,7 @@ exports[`fluview basic async 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
-      "https://api.covidcast.cmu.edu/epidata/fluview/?regions=a&epiweeks=4",
+      "https://api.delphi.cmu.edu/epidata/fluview/?regions=a&epiweeks=4",
     ],
   ],
   "results": Array [
@@ -52,7 +52,7 @@ exports[`fluview basic sync 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
-      "https://api.covidcast.cmu.edu/epidata/fluview/?regions=a&epiweeks=4",
+      "https://api.delphi.cmu.edu/epidata/fluview/?regions=a&epiweeks=4",
     ],
   ],
   "results": Array [

--- a/src/client/packaging/npm/tests/__snapshots__/delphi_epidata.spec.js.snap
+++ b/src/client/packaging/npm/tests/__snapshots__/delphi_epidata.spec.js.snap
@@ -36,7 +36,7 @@ exports[`fluview basic async 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
-      "https://delphi.cmu.edu/epidata/fluview/?regions=a&epiweeks=4",
+      "https://api.covidcast.cmu.edu/epidata/fluview/?regions=a&epiweeks=4",
     ],
   ],
   "results": Array [
@@ -52,7 +52,7 @@ exports[`fluview basic sync 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
-      "https://delphi.cmu.edu/epidata/fluview/?regions=a&epiweeks=4",
+      "https://api.covidcast.cmu.edu/epidata/fluview/?regions=a&epiweeks=4",
     ],
   ],
   "results": Array [


### PR DESCRIPTION
  - `delphi.cmu.edu/epidata` proxies to `api.covidcast.cmu.edu/epidata` but this includes an "extra hop" which presents a number of problems:
    - it adds a single point of failure.
    - the resource is not load-balanced but proxies to our load-balanced servers, thus defeating some of the other purposes of load-balancing.
    - complicates logging as the webapp logs will need to be cross referenced with proxy logs to get the full spectrum of information on usage.
    - aggregates any number of users' activity behind one IP address (the address of the proxy) for the purposes of rate limiting.

  - this change should happen in our code (especially client libs) and documentation.  outside of this repository, this includes but is not limited to:
    - https://github.com/cmu-delphi/epidatr/blob/02a688219c0deba8a451de2aa1877ee33a8d5672/R/constants.R#L3
    - https://github.com/cmu-delphi/epidatpy/blob/8659609c960cf1863f7c200ee6da9aa876a33b18/epidatpy/_constants.py#L9
    - likely more in: https://github.com/search?q=org%3Acmu-delphi+%22delphi.cmu.edu%22+language%3AR+OR+language%3Apython+OR+language%3AJavaScript+&type=code
    - ( https://github.com/cmu-delphi/covidcast seems to be ok )
    - ( documentation in https://cmu-delphi.github.io/delphi-epidata/api/README.html#the-api should be changed with this PR )

  - usage of this proxied url is not very high at the moment.  however, we are about to announce our "API Keys" release, which involves changes that will require many users to alter their interactions with our service.  they may choose to use our client libraries or reference our documentation, and it is advantageous for us if they do not increase activity to this proxied URI -- hence the desire to update our references to point to the non-proxied URI before such an announcement.  additionally, a significant portion of our current users still make use of very old versions of client libraries, so it is also important that we update our references sooner rather than later, to prevent users from becoming "cemented" to a newer library that still references the proxied URI.

  - we may want to consider using a hostname other than `api.covidcast.cmu.edu`, perhaps one that is not covid-specific
    - this change can happen in the future, and can be done with DNS aliases (CNAMES or similar)

  - ultimately, once activity to `delphi.cmu.edu/epidata` stops (or drops to a negligible amount), the proxying rule can be disabled or removed.
    - it looks like the config for this may be located here: https://github.com/cmu-delphi/delphi-admin/blob/5b7067c5343072bf4fdebc11d1ffdc00fdfc2644/ansible/templates/web-frontend-prod/web-frontend-main-p.conf.j2#L188-L190
