### PR TITLE
Make HTTP status 4xx responses uniform

### DIFF
--- a/src/server/_config.py
+++ b/src/server/_config.py
@@ -57,7 +57,7 @@ REGION_TO_STATE = {
 }
 NATION_REGION = "nat"
 
-API_KEY_REQUIRED_STARTING_AT = date.fromisoformat(os.environ.get("API_REQUIRED_STARTING_AT", "2023-06-21"))
+API_KEY_REQUIRED_STARTING_AT = date.fromisoformat(os.environ.get("API_KEY_REQUIRED_STARTING_AT", "2023-06-21"))
 TEMPORARY_API_KEY = os.environ.get("TEMPORARY_API_KEY", "TEMP-API-KEY-EXPIRES-2023-06-28")
 # password needed for the admin application if not set the admin routes won't be available
 ADMIN_PASSWORD = os.environ.get("API_KEY_ADMIN_PASSWORD", "abc")

--- a/src/server/_limiter.py
+++ b/src/server/_limiter.py
@@ -2,7 +2,7 @@ from delphi.epidata.server.endpoints.covidcast_utils.dashboard_signals import Da
 from flask import Response, request, make_response, jsonify
 from flask_limiter import Limiter, HEADERS
 from redis import Redis
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Unauthorized, TooManyRequests
 
 from ._common import app, get_real_ip_addr
 from ._config import RATE_LIMIT, RATELIMIT_STORAGE_URL, REDIS_HOST, REDIS_PASSWORD
@@ -105,7 +105,7 @@ apply_limit = limiter.limit(RATE_LIMIT, deduct_when=deduct_on_success)
 
 @app.errorhandler(429)
 def ratelimit_handler(e):
-    return make_response(jsonify(error=ERROR_MSG_RATE_LIMIT), 429)
+    return TooManyRequests(ERROR_MSG_RATE_LIMIT)
 
 
 def requests_left():


### PR DESCRIPTION

### Summary:

We were returning JSON for 429s, and HTML for 401s -- this PR has us return HTML for both.

I could've gone either way, but HTML is what delphi-epidata.R expects, and what I've been telling Dmitry, Logan, and Alex, so it won out

### Prerequisites:

- [x] It should be merged against the `api-keys` branch
- [x] Branch is up-to-date with the branch to be merged with
- [x] Build is successful
- [x] Code is cleaned up and formatted
