### PR TITLE
Link to client instructions from API Keys Usage section

### DIFF
--- a/docs/api/api_keys.md
+++ b/docs/api/api_keys.md
@@ -40,6 +40,14 @@ If you choose to
 [register for an API key](https://api.delphi.cmu.edu/epidata/admin/registration_form),
 there are several ways to use your key to authenticate your requests:
 
+### Using a client
+
+* covidcast
+  * [R client](https://cmu-delphi.github.io/covidcast/covidcastR/reference/covidcast_signal.html#api-keys-1)
+  * [Python client](https://cmu-delphi.github.io/covidcast/covidcast-py/html/signals.html#covidcast.use_api_key)
+* [epidatr](https://github.com/cmu-delphi/epidatr#api-keys)
+* [delphi-epidata](https://cmu-delphi.github.io/delphi-epidata/api/client_libraries.html)
+
 ### Via request parameter
 
 The request parameter “api_key” can be used to pass the API key to the server.

--- a/docs/api/client_libraries.md
+++ b/docs/api/client_libraries.md
@@ -4,9 +4,17 @@ parent: Other Endpoints (COVID-19 and Other Diseases)
 nav_order: 1
 ---
 
-# Epidata API Client Libraries.
+# Epidata API Client Libraries
 
-Epidata clients are available for
+For anyone looking for COVIDCast data, please visit our [COVIDCast Libraries](covidcast_clients.md).
+
+We are currently working on fully-featured Epidata clients for R and Python. They are not ready
+for release yet, but you can track our development progress and help us test them out at:
+
+* [epidatr](https://github.com/cmu-delphi/epidatr)
+* [epidatpy](https://github.com/cmu-delphi/epidatpy)
+
+In the meantime, minimalist Epidata clients remain available for
 [JavaScript](https://github.com/cmu-delphi/delphi-epidata/blob/master/src/client/delphi_epidata.js),
 [Python](https://github.com/cmu-delphi/delphi-epidata/blob/master/src/client/delphi_epidata.py),
 and
@@ -15,9 +23,9 @@ The following samples show how to import the library and fetch Delphi's COVID-19
 Surveillance Streams from Facebook Survey CLI for county 06001 and days
 `20200401` and `20200405-20200414` (11 days total).
 
-For anyone looking for COVIDCast data, please visit our [COVIDCast Libraries](covidcast_clients.md).
-
 ### JavaScript (in a web browser)
+
+The minimalist JavaScript client does not currently support API keys. If you need API key support in JavaScript, contact delphi-support+privacy@andrew.cmu.edu.
 
 ````html
 <!-- Imports -->
@@ -45,6 +53,8 @@ in the same directory as your Python script.
 ````python
 # Import
 from delphi_epidata import Epidata
+# [Optional] configure your API key, if desired
+Epidata.auth = ('epidata', <your API key>)
 # Fetch data
 res = Epidata.covidcast('fb-survey', 'smoothed_cli', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001')
 print(res['result'], res['message'], len(res['epidata']))
@@ -54,6 +64,8 @@ print(res['result'], res['message'], len(res['epidata']))
 
 
 ````R
+# [Optional] configure your API key, if desired
+option('epidata.auth', <your API key>)
 # Import
 source('delphi_epidata.R')
 # Fetch data

--- a/docs/api/client_libraries.md
+++ b/docs/api/client_libraries.md
@@ -54,7 +54,7 @@ in the same directory as your Python script.
 # Import
 from delphi_epidata import Epidata
 # [Optional] configure your API key, if desired
-Epidata.auth = ('epidata', <your API key>)
+#Epidata.auth = ('epidata', <your API key>)
 # Fetch data
 res = Epidata.covidcast('fb-survey', 'smoothed_cli', 'day', 'county', [20200401, Epidata.range(20200405, 20200414)], '06001')
 print(res['result'], res['message'], len(res['epidata']))
@@ -65,7 +65,7 @@ print(res['result'], res['message'], len(res['epidata']))
 
 ````R
 # [Optional] configure your API key, if desired
-option('epidata.auth', <your API key>)
+#option('epidata.auth', <your API key>)
 # Import
 source('delphi_epidata.R')
 # Fetch data


### PR DESCRIPTION
### Summary:

[Karla's question](https://github.com/cmu-delphi/delphi-epidata/issues/1183#issuecomment-1584723472) revealed that we don't have API key usage instructions for clients linked from the API Keys usage page. This PR fixes that. 

Changelog:

* api_keys.md: Link to client documentation for API key usage
* client_libraries.md: Describe API key usage for one-file clients; add links to new epidat* clients

### Prerequisites:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted
