### PR TITLE
ci: make dependabot assign reviewers

### DIFF
--- a/.github/workflows/dependabot-assignments.yml
+++ b/.github/workflows/dependabot-assignments.yml
@@ -1,0 +1,17 @@
+name: Dependabot auto-assign reviewer
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    env: 
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Assign team to PR
+        run: gh pr edit "$PR_URL" --add-reviewer "cmu-delphi/code-reviewers"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Part of #1220 

### Summary:

- Add dependabot workflow (tested [here](https://github.com/dshemetov/test-dependabot-action))

### Prerequisites:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted
