### PR TITLE
feat(R client): read from DELPHI_EPIDATA_KEY

### DIFF
--- a/src/client/delphi_epidata.R
+++ b/src/client/delphi_epidata.R
@@ -18,6 +18,7 @@ Epidata <- (function() {
   client_version <- '4.1.5'
 
   auth <- getOption("epidata.auth", default = NA)
+  auth <- if (is.null(auth)) Sys.getenv("DELPHI_EPIDATA_KEY") else NA
 
   client_user_agent <- user_agent(paste("delphi_epidata/", client_version, " (R)", sep=""))
 

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -11,6 +11,7 @@ Notes:
 # External modules
 import requests
 import asyncio
+import os
 from tenacity import retry, stop_after_attempt
 
 from aiohttp import ClientSession, TCPConnector, BasicAuth
@@ -45,7 +46,7 @@ class Epidata:
 
     # API base url
     BASE_URL = "https://api.delphi.cmu.edu/epidata/api.php"
-    auth = None
+    auth = os.environ.get("DELPHI_EPIDATA_KEY")
 
     client_version = _version
 


### PR DESCRIPTION
This should make CI integrations easier, by allowing us to set the env var to a secret. Also mimics behavior in [epidatr](https://github.com/cmu-delphi/epidatr/blob/dev/R/auth.R).

### Summary:

- read API key from DELPHI_EPIDATA_KEY env var by default, else None
  - don't disturb the existing read from "epidata.auth" R option

### Prerequisites:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted
