### PR TITLE
Fix sorting in compute_covidcast_meta

### DIFF
--- a/src/acquisition/covidcast/database.py
+++ b/src/acquisition/covidcast/database.py
@@ -526,13 +526,7 @@ FROM {self.history_view} h JOIN (
       t.join()
     logger.info("all threads terminated")
 
-    # sort the metadata because threaded workers dgaf
-    sorting_fields = "data_source signal time_type geo_type".split()
-    sortable_fields_fn = lambda x: [(field, x[field]) for field in sorting_fields]
-    prepended_sortables_fn = lambda x: sortable_fields_fn(x) + list(x.items())
-    tuple_representation = list(map(prepended_sortables_fn, meta))
-    tuple_representation.sort()
-    meta = list(map(dict, tuple_representation)) # back to dict form
+    meta = sorted(meta, key=lambda x: (x['data_source'], x['signal'], x['time_type'], x['geo_type']))
 
     return meta
 


### PR DESCRIPTION
### Summary:

Fixex sorting in compute_covidcast_meta
Added missing `api_user` creation in integrations/acquisition/covidcast/

### Prerequisites:

- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted
