### PR TITLE
followup for #1203: deploy.json fix for src/common/*

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -24,7 +24,7 @@
       "dst": "[[package]]/common/",
       "match": "^.*\\.(py)$",
       "add-header-comment": true,
-	"recursive": true
+      "recursive": true
     },
 
     "// server",

--- a/deploy.json
+++ b/deploy.json
@@ -23,7 +23,8 @@
       "src": "src/common/",
       "dst": "[[package]]/common/",
       "match": "^.*\\.(py)$",
-      "add-header-comment": true
+      "add-header-comment": true,
+	"recursive": true
     },
 
     "// server",

--- a/deploy.json
+++ b/deploy.json
@@ -22,7 +22,7 @@
       "type": "move",
       "src": "src/common/",
       "dst": "[[package]]/common/",
-      "match": "^.*\\.(py)$",
+      "match": "^.*\\.(py|yaml)$",
       "add-header-comment": true,
       "recursive": true
     },


### PR DESCRIPTION
hopefully this works to make `github-deploy-repo` catch all the files from `src/common/` (#1203 added a file to `src/common/covid_hosp/`, and there are a total of 3 in that subdir now)
