### PR TITLE
Add deployment config for maintenance dir and files

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -217,6 +217,16 @@
       "add-header-comment": true
     },
 
+    "// maintenance",
+    {
+      "type": "move",
+      "src": "src/maintenance/",
+      "dst": "[[package]]/maintenance/",
+      "match": "^.*\\.(py)$",
+      "recursive": true,
+      "add-header-comment": true
+    },
+
     "// move flask tests out of the way",
     {
       "type": "move",


### PR DESCRIPTION
### Summary:

Tell github-deploy-repo to copy new maintenance dir and files.

### Prerequisites:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [X] Build is successful
- [X] Code is cleaned up and formatted