### PR TITLE
introduce CHANGELOG.md file for the python delphi_epidata client

### DIFF
--- a/src/client/packaging/pypi/CHANGELOG.md
+++ b/src/client/packaging/pypi/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable future changes to the `delphi_epidata` python client will be documented in this file.
+The format is based on [Keep a Changelog](http://keepachangelog.com/).
+
+## [4.1.10] - 2023-09-28
+
+### Added
+- Established this Changelog


### PR DESCRIPTION
creates `CHANGELOG.md` file (in the PyPI packaging structure for the python client) in anticipation of using it to documenting further changes coming in https://github.com/cmu-delphi/delphi-epidata/pull/1288

date and version number were chosen with the expectation that this can be included in the new release of this repository tomorrow.