### PR TITLE
revert and deprecate async_epidata (+ Remove usage of PHP alias in the Python client)

### DIFF
--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -342,12 +342,12 @@ class DelphiEpidataPythonClientTests(CovidcastBase):
     responses = [i[0]["epidata"] for i in test_output]
     # check response is same as standard covidcast call (minus fields omitted by the api.php endpoint),
     # using 24 calls to test batch sizing
-    ignore_fields = ["source", "time_type", "geo_type"]
+    ignore_fields = CovidcastTestRow._api_row_compatibility_ignore_fields
     self.assertEqual(
       responses,
       [
-        [{k: v for k, v in row.items() if k not in ignore_fields} for row in Epidata.covidcast(**self.params_from_row(rows[0]))["epidata"]],
-        [{k: v for k, v in row.items() if k not in ignore_fields} for row in Epidata.covidcast(**self.params_from_row(rows[1]))["epidata"]],
+        [{k: row[k] for k in row.keys() - ignore_fields} for row in Epidata.covidcast(**self.params_from_row(rows[0]))["epidata"]],
+        [{k: row[k] for k in row.keys() - ignore_fields} for row in Epidata.covidcast(**self.params_from_row(rows[1]))["epidata"]],
       ]*12
     )
 

--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -335,9 +335,9 @@ class DelphiEpidataPythonClientTests(CovidcastBase):
     ]
     self._insert_rows(rows)
 
-    test_output = Epidata.async_epidata('covidcast', [
-      self.params_from_row(rows[0]),
-      self.params_from_row(rows[1])
+    test_output = Epidata.async_epidata([
+      self.params_from_row(rows[0], source='covidcast'),
+      self.params_from_row(rows[1], source='covidcast')
     ]*12, batch_size=10)
     responses = [i[0] for i in test_output]
     # check response is same as standard covidcast call, using 24 calls to test batch sizing
@@ -352,8 +352,9 @@ class DelphiEpidataPythonClientTests(CovidcastBase):
   @fake_epidata_endpoint
   def test_async_epidata_fail(self):
     with pytest.raises(ClientResponseError, match="404, message='NOT FOUND'"):
-      Epidata.async_epidata('covidcast', [
+      Epidata.async_epidata([
         {
+          'source': 'covidcast',
           'data_source': 'src',
           'signals': 'sig',
           'time_type': 'day',

--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -339,13 +339,15 @@ class DelphiEpidataPythonClientTests(CovidcastBase):
       self.params_from_row(rows[0], source='covidcast'),
       self.params_from_row(rows[1], source='covidcast')
     ]*12, batch_size=10)
-    responses = [i[0] for i in test_output]
-    # check response is same as standard covidcast call, using 24 calls to test batch sizing
+    responses = [i[0]["epidata"] for i in test_output]
+    # check response is same as standard covidcast call (minus fields omitted by the api.php endpoint),
+    # using 24 calls to test batch sizing
+    ignore_fields = ["source", "time_type", "geo_type"]
     self.assertEqual(
       responses,
       [
-        Epidata.covidcast(**self.params_from_row(rows[0])),
-        Epidata.covidcast(**self.params_from_row(rows[1])),
+        [{k: v for k, v in row.items() if k not in ignore_fields} for row in Epidata.covidcast(**self.params_from_row(rows[0]))["epidata"]],
+        [{k: v for k, v in row.items() if k not in ignore_fields} for row in Epidata.covidcast(**self.params_from_row(rows[1]))["epidata"]],
       ]*12
     )
 

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -691,14 +691,17 @@ class Epidata:
         return Epidata._request("covidcast_nowcast", params)
 
     @staticmethod
-    def async_epidata(endpoint, param_list, batch_size=50):
-        """Make asynchronous Epidata calls for a list of parameters."""
+    def async_epidata(param_list, batch_size=50):
+        """[DEPRECATED] Make asynchronous Epidata calls for a list of parameters."""
 
-        request_url = f"{Epidata.BASE_URL}/{endpoint}"
+        import warnings
+        warnings.filterwarnings("once", category=DeprecationWarning, module="delphi_epidata")
+        warnings.warn("Method `Epidata.async_epidata()` is deprecated and will be removed in a future version.",
+                      category=DeprecationWarning)
 
         async def async_get(params, session):
             """Helper function to make Epidata GET requests."""
-            async with session.get(request_url, params=params) as response:
+            async with session.get(f"{Epidata.BASE_URL}/api.php", params=params) as response:
                 response.raise_for_status()
                 return await response.json(), params
 


### PR DESCRIPTION
whoops, i wasnt paying attention on the command line and my commit message got slightly mangled, it should read:
"revert `async_epidata()` to previous behavior, and mark deprecated (`filterwarnings()` not fully tested)"

to be added to #1288 

i did not do much testing around the `warnings.filterwarnings()` call, but it is intended to print the deprecation warning for the method only once (on its first use), no matter how `async_epidata()` is called.