### PR TITLE
Fix `as_of` for date range

### DIFF
--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -130,6 +130,14 @@ class DelphiEpidataPythonClientTests(CovidcastBase):
         'message': 'success',
       })
 
+    with self.subTest(name='bad as-of date'):
+      # fetch data, specifying as_of
+      as_of_response = Epidata.covidcast(
+        **self.params_from_row(rows[0], as_of="20230101-20230102")
+      )
+      self.assertEqual(as_of_response, {"epidata": [], "message": "not a valid date: 20230101-20230102", "result": -1})
+
+
     with self.subTest(name='request a range of issues'):
       # fetch data, specifying issue range, not lag
       response_2 = Epidata.covidcast(

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -2,7 +2,7 @@ from math import inf
 import re
 from dataclasses import dataclass
 from typing import List, Optional, Sequence, Tuple, Union
-import delphi_utils    
+import delphi_utils
 
 from flask import request
 
@@ -407,6 +407,8 @@ def parse_date(s: str) -> int:
         if s == "*":
             return s
         else:
+            if len(s) > 10:  # max len of date is 10 (YYYY-MM-DD format)
+                raise ValueError
             return int(s.replace("-", ""))
     except ValueError:
         raise ValidationFailedException(f"not a valid date: {s}")


### PR DESCRIPTION
### Summary:

Made as_of query to fail with a helpful error message if len(as_of) > 10

### Prerequisites:

- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted
