### PR TITLE
Make DataSignal construction more flexible

### DIFF
--- a/src/server/endpoints/covidcast_utils/model.py
+++ b/src/server/endpoints/covidcast_utils/model.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from typing import Callable, Optional, Dict, List, Set, Tuple
 from enum import Enum
 from pathlib import Path
@@ -210,8 +210,8 @@ def _load_data_signals(sources: List[DataSource]):
     data_signals_df: pd.DataFrame = pd.read_csv(_base_dir / "db_signals.csv")
     data_signals_df = data_signals_df.replace({np.nan: None})
     data_signals_df.columns = map(_clean_column, data_signals_df.columns)
-    ignore_columns = {"base_is_other"}
-    data_signals: List[DataSignal] = [DataSignal(**{k: v for k, v in d.items() if k not in ignore_columns}) for d in data_signals_df.to_dict(orient="records")]
+    datasignal_fields = {f.name for f in fields(DataSignal)}
+    data_signals: List[DataSignal] = [DataSignal(**{k: v for k, v in d.items() if k in datasignal_fields}) for d in data_signals_df.to_dict(orient="records")]
     data_signals_df.set_index(["source", "signal"])
 
     by_source_id = {d.key: d for d in data_signals}


### PR DESCRIPTION
Pass only reflexively valid fields to the `DataSignal` constructor when loading from `db_signals.csv`, instead of using a rigid and brittle set of fields (columns) to exclude.  The system will now easily ignore new columns added to the CSV file, but for which it doesn't yet have a use.  This will make it effortlessly handle changes coming in #1259 (and beyond).

I considered logging a list of unused fields/columns, but that will already be noisy because of the existing `base_is_other` column, and i dont think itll be very helpful.