### PR TITLE
Cleanup more files from previous runs of performance test rig 

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Set up repository # mimics install.sh in the README except that delphi is cloned from the PR rather than main
         run: |
           cd ..
+          rm -rf driver
           mkdir -p driver/repos/delphi
           cd driver/repos/delphi
           git clone https://github.com/cmu-delphi/operations


### PR DESCRIPTION
### Summary:

Adds an extra step to the performance test runner which cleans up further files from previous (now self-hosted) runs.