### PR TITLE
Fix week parsing for date parameters/arguments

### DIFF
--- a/integrations/server/test_covidcast.py
+++ b/integrations/server/test_covidcast.py
@@ -84,7 +84,7 @@ class CovidcastTests(CovidcastBase):
   def _insert_placeholder_set_with_weeks(self):
     rows = [
       CovidcastTestRow.make_default_row(
-        time_value=2021_05, time_type="week",
+        time_value=2021_05+i, time_type="week",
         source="nchs-mortality", signal="deaths_covid_incidence_num",
         geo_type="state", geo_value="il",
         value=i*i)

--- a/integrations/server/test_covidcast.py
+++ b/integrations/server/test_covidcast.py
@@ -81,6 +81,18 @@ class CovidcastTests(CovidcastBase):
     self._insert_rows(rows)
     return rows 
 
+  def _insert_placeholder_set_with_weeks(self):
+    rows = [
+      CovidcastTestRow.make_default_row(
+        time_value=2021_05, time_type="week",
+        source="nchs-mortality", signal="deaths_covid_incidence_num",
+        geo_type="state", geo_value="il",
+        value=i*i)
+      for i in [0, 1, 2]
+    ]
+    self._insert_rows(rows)
+    return rows
+
   def test_round_trip(self):
     """Make a simple round-trip with some sample data."""
 
@@ -445,3 +457,22 @@ class CovidcastTests(CovidcastBase):
 
     # assert that the right data came back
     self.assertEqual(len(response['epidata']), 2 * 3)
+
+
+  def test_week_formats(self):
+    """Test different ways to specify week ranges are accepted."""
+
+    rows = self._insert_placeholder_set_with_weeks()
+    expected = {
+      'result': 1,
+      'epidata': [r.as_api_row_dict() for r in rows],
+      'message': 'success',
+    }
+
+    colond = self.request_based_on_row(rows[0], time_values="202105:202107")
+    dashed = self.request_based_on_row(rows[0], time_values="202105-202107")
+    enumed = self.request_based_on_row(rows[0], time_values="202105,202106,202107")
+
+    self.assertEqual(expected, colond)
+    self.assertEqual(expected, dashed)
+    self.assertEqual(expected, enumed)

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -439,7 +439,16 @@ def extract_dates(key: Union[str, Sequence[str]]) -> Optional[TimeValues]:
             values.append(r)
             continue
         # parse other date formats
-        r = parse_day_value(part)
+        dashless_part = part.replace("-", "")
+        if len(dashless_part) in (6, 12):
+            # if there are 6 or 12 (hopefully) integers in this, it
+            # should be a week or week range (YYYYWW or YYYYWWYYYYWW)
+            r = parse_week_value(part)
+        else:
+            # else its (presumably) 8 or 16, which should mean day or
+            # day range (YYYYMMDD or YYYYMMDDYYYYMMDD)...
+            # other time types tbd lol
+            r = parse_day_value(part)
         values.append(r)
     return values
 

--- a/src/server/_params.py
+++ b/src/server/_params.py
@@ -441,14 +441,16 @@ def extract_dates(key: Union[str, Sequence[str]]) -> Optional[TimeValues]:
         # parse other date formats
         dashless_part = part.replace("-", "")
         if len(dashless_part) in (6, 12):
-            # if there are 6 or 12 (hopefully) integers in this, it
+            # if there are 6 or 12 (hopefully integer) chars in this, it
             # should be a week or week range (YYYYWW or YYYYWWYYYYWW)
             r = parse_week_value(part)
-        else:
-            # else its (presumably) 8 or 16, which should mean day or
-            # day range (YYYYMMDD or YYYYMMDDYYYYMMDD)...
-            # other time types tbd lol
+        elif len(dashless_part) in (8, 16):
+            # if its 8 or 16, it should be a day or
+            # day range (YYYYMMDD or YYYYMMDDYYYYMMDD)
             r = parse_day_value(part)
+        else:
+            # other time types tbd lol
+            raise ValidationFailedException(f"unrecognized date format: {part}")
         values.append(r)
     return values
 


### PR DESCRIPTION
It looks like #1284 broke some week and week range parsing and was noticed in https://github.com/cmu-delphi/covidcast-indicators/issues/1904.

Heres evidence of the new test failing before i applied the fix:
https://github.com/cmu-delphi/delphi-epidata/actions/runs/6564148018/job/17829935532

This solution is a bit brittle, but ~all of `_params.py` is a mess and needs to be cleaned up, so i think this can fly for now.