### PR TITLE
Add option to modify rate limiting for perftests

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Build & run epidata
         run: |
           cd ../driver
-          sudo make web sql="${{ secrets.DB_CONN_STRING }}"
+          sudo make web sql="${{ secrets.DB_CONN_STRING }}" rate_limit="999999/second"
           sudo make redis
       - name: Check out delphi-admin
         uses: actions/checkout@v3

--- a/dev/local/Makefile
+++ b/dev/local/Makefile
@@ -37,6 +37,7 @@
 #   test=         Only runs tests in the directories provided here, e.g.
 #                 repos/delphi/delphi-epidata/tests/acquisition/covidcast
 #   sql=          Overrides the default SQL connection string.
+#   rate_limit=   Overrides the default rate limit for API requests.
 
 
 # Set optional argument defaults
@@ -54,6 +55,14 @@ ifdef sql
 	sqlalchemy_uri:=$(sql)
 else
 	sqlalchemy_uri:=mysql+mysqldb://user:pass@delphi_database_epidata:3306/epidata
+endif
+
+ifdef rate_limit
+# Notation found here: https://flask-limiter.readthedocs.io/en/stable/#rate-limit-string-notation
+	rate_limit_settings:=--env "RATE_LIMIT=$(rate_limit)"
+else
+# Default behavior is to set the rate limit to "5/hour" for API key tests via this environment variable
+	rate_limit_settings:=--env "TESTING_MODE=True"
 endif
 
 SHELL:=/bin/sh
@@ -104,7 +113,7 @@ web:
 		--env "REDIS_PASSWORD=1234" \
 		--env "API_KEY_ADMIN_PASSWORD=test_admin_password" \
 		--env "API_KEY_REGISTER_WEBHOOK_TOKEN=abc" \
-		--env "TESTING_MODE=True" \
+		$(rate_limit_settings) \
 		--network delphi-net --name delphi_web_epidata \
 		delphi_web_epidata >$(LOG_WEB) 2>&1 &
 


### PR DESCRIPTION
### Summary:

Adds an option to the makefile to override the default rate limit. Also applies this option to the perftest rig.

### Prerequisites:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [X] Code is cleaned up and formatted
