### PR TITLE
Prevent "308 PERMANENT REDIRECT" via client change

### DIFF
--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -70,7 +70,7 @@ class Epidata:
     @retry(reraise=True, stop=stop_after_attempt(2))
     def _request_with_retry(endpoint, params={}):
         """Make request with a retry if an exception is thrown."""
-        request_url = f"{Epidata.BASE_URL}/{endpoint}"
+        request_url = f"{Epidata.BASE_URL}/{endpoint}/"
         req = requests.get(request_url, params, auth=Epidata.auth, headers=_HEADERS)
         if req.status_code == 414:
             req = requests.post(request_url, params, auth=Epidata.auth, headers=_HEADERS)


### PR DESCRIPTION
Closes #1320.

### Summary:

Appends a trailing slash to URLs requested by the Python client, which should prevent an automatic redirect and an extra request to the server.

### Prerequisites:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [X] Code is cleaned up and formatted
