### PR TITLE
changes to signals in rate-limit exempt list

### DIFF
--- a/integrations/server/test_api_keys.py
+++ b/integrations/server/test_api_keys.py
@@ -69,7 +69,7 @@ class APIKeysTets(DelphiTestBase):
     def test_multiples_non_allowed_signal(self):
         """Test requests with 2 multiples and non-allowed dashboard signal"""
         params = {
-            "signal": "hospital-admissions:smoothed_adj_covid19_from_claims",
+            "signal": "hospital-admissions:smoothed_covid19",
             "time_type": "day",
             "geo_type": "state",
             "geo_value": "pa,ny",
@@ -83,7 +83,7 @@ class APIKeysTets(DelphiTestBase):
     def test_multiples_mixed_allowed_signal_two_multiples(self):
         """Test requests with 2 multiples and mixed-allowed dashboard signal"""
         params = {
-            "signal": "fb-survey:smoothed_wcli,hospital-admissions:smoothed_adj_covid19_from_claims",
+            "signal": "fb-survey:smoothed_wcli,hospital-admissions:smoothed_covid19",
             "time_type": "day",
             "geo_type": "state",
             "geo_value": "pa",

--- a/src/server/endpoints/covidcast_utils/dashboard_signals.py
+++ b/src/server/endpoints/covidcast_utils/dashboard_signals.py
@@ -30,6 +30,10 @@ class DashboardSignals:
       with open(module_dir / 'descriptions.raw.txt', 'r') as f:
         for desc in yaml.safe_load_all(f):
           srcsigs.append( (desc['Id'], desc['Signal']) )
+          if 'Overrides' in desc:
+            for sub_geo in desc['Overrides']:
+              sub_signal = desc['Overrides'][sub_geo]
+              srcsigs.append( (sub_signal['Id'], sub_signal['Signal']) )
 
       source_id = None
       with open(module_dir / 'questions.raw.txt', 'r') as f:

--- a/src/server/endpoints/covidcast_utils/descriptions.raw.txt
+++ b/src/server/endpoints/covidcast_utils/descriptions.raw.txt
@@ -63,8 +63,8 @@ ExtendedColorScale: true
 Levels: [nation, state, county]
 Overrides:
   County:
-    Id: dsew-cpr
-    Signal: confirmed_admissions_covid_1d_prop_7dav
+    Id: hospital-admissions
+    Signal: smoothed_adj_covid19_from_claims
 
 
 
@@ -97,3 +97,13 @@ SignalTooltip: Newly reported COVID-19 deaths per 100,000 people, based on data 
 
 
 Description: This data shows the number of COVID-19 deaths newly reported each day. The signal is based on COVID-19 death counts compiled and made public by [a team at Johns Hopkins University](https://systems.jhu.edu/research/public-health/ncov/).
+---
+Name: COVID Deaths (NCHS)
+Id: nchs-mortality
+Signal: deaths_covid_incidence_prop
+
+
+SignalTooltip: Newly reported COVID-19 deaths per 100,000 people, based on NCHS mortality data.
+
+
+Description: This data shows the number of COVID-19 deaths newly reported each week. The signal is based on COVID-19 death counts compiled and made public by [the National Center for Health Statistics](https://www.cdc.gov/nchs/nvss/vsrr/COVID19/index.htm).


### PR DESCRIPTION
* preemptively adds `nchs-mortality:deaths_covid_incidence_prop` into the ratelimit-exempt signal set
* changes hospital admissions override signal for county-level visualizations to an active/current signal (from a `dsew-cpr` to `hospital-admissions:smoothed_adj_covid19_from_claims`)
* adds a fix to include override signals in the ratelimit-exempt set
* fixes tests to work around changes to exemption status of above signals