### PR TITLE
use REPLACE INTO instead of INSERT INTO...UPDATE in covid_hosp acquisition

### DIFF
--- a/src/acquisition/covid_hosp/common/database.py
+++ b/src/acquisition/covid_hosp/common/database.py
@@ -159,26 +159,6 @@ class Database:
           (%s, %s, %s, %s, %s, NOW())
       ''', (self.table_name, self.hhs_dataset_id, publication_date, revision, meta_json))
 
-  def remove_issues(self, issue_date):
-    # TODO: this is *VERY* incomplete!  SQL statements are never even evaluated!
-    # delete from metadata table where issue date matches
-    a = f"DELETE FROM `covid_hosp_meta` WHERE dataset_name='{self.table_name}' AND publication_date='{issue_date}'"
-    if self.aggregate_key_cols:
-      # TODO: restrict this to just UNIQUE columns from aggregate keys table?
-      # create (empty) `some_temp_table` like `{self.table_name}_key`
-      b = f"CREATE TABLE some_temp_table AS SELECT {self.aggregate_key_cols} FROM `{self.table_name}_key` WHERE FALSE"
-      # save aggregate keys from what we are about to delete
-      c = f"SELECT {self.aggregate_key_cols} INTO some_temp_table FROM `{self.table_name}` WHERE `{self.publication_col_name}`={issue_date} GROUP BY {self.aggregate_key_cols}"
-      # TODO: combine two SQL queries above into one?
-    # delete from main data table where issue matches
-    d = f"DELETE FROM `{self.table_name}` WHERE `{self.publication_col_name}`={issue_date}"
-    if self.aggregate_key_cols:
-      # delete from saved aggregate keys where the key still exists
-      e = f"DELETE FROM some_temp_table JOIN `{self.table_name}` USING ({self.aggregate_key_cols})"
-      # delete from aggregate key table anything left in saved keys (which should be aggregate keys that only existed in the issue we deleted)
-      f = f"DELETE FROM `{self.table_name}_key` JOIN some_temp_table USING ({self.aggregate_key_cols})"
-      g = "DROP TABLE some_temp_table"
-
   def insert_dataset(self, publication_date, dataframe, logger=False):
     """Add a dataset to the database.
 

--- a/src/acquisition/covid_hosp/common/database.py
+++ b/src/acquisition/covid_hosp/common/database.py
@@ -205,7 +205,7 @@ class Database:
       dataframe.loc[:, csv_name] = dataframe[csv_name].map(self.columns_and_types[csv_name].dtype)
 
     col_names = [f'`{i.sql_name}`' for i in dataframe_columns_and_types + self.additional_fields]
-    value_placeholders = ', '.join(['%s'] * (2 + len(columns))) # extra 2 for `id` and `self.publication_col_name` cols
+    value_placeholders = ', '.join(['%s'] * (2 + len(col_names))) # extra 2 for `id` and `self.publication_col_name` cols
     columnstring = ', '.join(col_names)
     sql = f'REPLACE INTO `{self.table_name}` (`id`, `{self.publication_col_name}`, {columnstring}) VALUES ({value_placeholders})'
     id_and_publication_date = (0, publication_date)

--- a/src/acquisition/covid_hosp/common/database.py
+++ b/src/acquisition/covid_hosp/common/database.py
@@ -244,7 +244,8 @@ class Database:
       if many_values:
         cursor.executemany(sql, many_values)
         rows_affected += cursor.rowcount
-      logger.info('rows affected', count=rows_affected)
+      if logger:
+        logger.info('rows affected', count=rows_affected)
 
     # deal with non/seldomly updated columns used like a fk table (if this database needs it)
     if hasattr(self, 'AGGREGATE_KEY_COLS'):

--- a/src/acquisition/covid_hosp/common/database.py
+++ b/src/acquisition/covid_hosp/common/database.py
@@ -204,19 +204,14 @@ class Database:
     for csv_name in self.key_columns:
       dataframe.loc[:, csv_name] = dataframe[csv_name].map(self.columns_and_types[csv_name].dtype)
 
-    num_columns = 2 + len(dataframe_columns_and_types) + len(self.additional_fields)
-    value_placeholders = ', '.join(['%s'] * num_columns)
     col_names = [f'`{i.sql_name}`' for i in dataframe_columns_and_types + self.additional_fields]
-    columns = ', '.join(col_names)
-    updates = ', '.join(f'{c}=new_values.{c}' for c in col_names)
-    # NOTE: list in `updates` presumes `publication_col_name` is part of the unique key and thus not needed in UPDATE
-    sql = f'INSERT INTO `{self.table_name}` (`id`, `{self.publication_col_name}`, {columns}) ' \
-          f'VALUES ({value_placeholders}) AS new_values ' \
-          f'ON DUPLICATE KEY UPDATE {updates}'
-    sql = f'REPLACE INTO `{self.table_name}` (`id`, `{self.publication_col_name}`, {columns}) VALUES ({value_placeholders})'
+    value_placeholders = ', '.join(['%s'] * (2 + len(columns))) # extra 2 for `id` and `self.publication_col_name` cols
+    columnstring = ', '.join(col_names)
+    sql = f'REPLACE INTO `{self.table_name}` (`id`, `{self.publication_col_name}`, {columnstring}) VALUES ({value_placeholders})'
     id_and_publication_date = (0, publication_date)
+    num_values = len(dataframe.index)
     if logger:
-      logger.info('updating values', count=len(dataframe.index))
+      logger.info('updating values', count=num_values)
     n = 0
     rows_affected = 0
     many_values = []
@@ -245,7 +240,9 @@ class Database:
         cursor.executemany(sql, many_values)
         rows_affected += cursor.rowcount
       if logger:
-        logger.info('rows affected', count=rows_affected)
+        # NOTE: REPLACE INTO marks 2 rows affected for a "replace" (one for a delete and one for a re-insert)
+        # which allows us to count rows which were updated
+        logger.info('rows affected', total=rows_affected, updated=rows_affected-num_values)
 
     # deal with non/seldomly updated columns used like a fk table (if this database needs it)
     if hasattr(self, 'AGGREGATE_KEY_COLS'):

--- a/src/acquisition/covid_hosp/common/database.py
+++ b/src/acquisition/covid_hosp/common/database.py
@@ -159,6 +159,26 @@ class Database:
           (%s, %s, %s, %s, %s, NOW())
       ''', (self.table_name, self.hhs_dataset_id, publication_date, revision, meta_json))
 
+  def remove_issues(self, issue_date):
+    # TODO: this is *VERY* incomplete!  SQL statements are never even evaluated!
+    # delete from metadata table where issue date matches
+    a = f"DELETE FROM `covid_hosp_meta` WHERE dataset_name='{self.table_name}' AND publication_date='{issue_date}'"
+    if self.aggregate_key_cols:
+      # TODO: restrict this to just UNIQUE columns from aggregate keys table?
+      # create (empty) `some_temp_table` like `{self.table_name}_key`
+      b = f"CREATE TABLE some_temp_table AS SELECT {self.aggregate_key_cols} FROM `{self.table_name}_key` WHERE FALSE"
+      # save aggregate keys from what we are about to delete
+      c = f"SELECT {self.aggregate_key_cols} INTO some_temp_table FROM `{self.table_name}` WHERE `{self.publication_col_name}`={issue_date} GROUP BY {self.aggregate_key_cols}"
+      # TODO: combine two SQL queries above into one?
+    # delete from main data table where issue matches
+    d = f"DELETE FROM `{self.table_name}` WHERE `{self.publication_col_name}`={issue_date}"
+    if self.aggregate_key_cols:
+      # delete from saved aggregate keys where the key still exists
+      e = f"DELETE FROM some_temp_table JOIN `{self.table_name}` USING ({self.aggregate_key_cols})"
+      # delete from aggregate key table anything left in saved keys (which should be aggregate keys that only existed in the issue we deleted)
+      f = f"DELETE FROM `{self.table_name}_key` JOIN some_temp_table USING ({self.aggregate_key_cols})"
+      g = "DROP TABLE some_temp_table"
+
   def insert_dataset(self, publication_date, dataframe, logger=False):
     """Add a dataset to the database.
 
@@ -193,10 +213,12 @@ class Database:
     sql = f'INSERT INTO `{self.table_name}` (`id`, `{self.publication_col_name}`, {columns}) ' \
           f'VALUES ({value_placeholders}) AS new_values ' \
           f'ON DUPLICATE KEY UPDATE {updates}'
+    sql = f'REPLACE INTO `{self.table_name}` (`id`, `{self.publication_col_name}`, {columns}) VALUES ({value_placeholders})'
     id_and_publication_date = (0, publication_date)
     if logger:
       logger.info('updating values', count=len(dataframe.index))
     n = 0
+    rows_affected = 0
     many_values = []
     with self.new_cursor() as cursor:
       for index, row in dataframe.iterrows():
@@ -212,6 +234,7 @@ class Database:
         if n % 5_000 == 0:
           try:
             cursor.executemany(sql, many_values)
+            rows_affected += cursor.rowcount
             many_values = []
           except Exception as e:
             if logger:
@@ -220,6 +243,8 @@ class Database:
       # insert final batch
       if many_values:
         cursor.executemany(sql, many_values)
+        rows_affected += cursor.rowcount
+      logger.info('rows affected', count=rows_affected)
 
     # deal with non/seldomly updated columns used like a fk table (if this database needs it)
     if hasattr(self, 'AGGREGATE_KEY_COLS'):

--- a/tests/acquisition/covid_hosp/common/test_database.py
+++ b/tests/acquisition/covid_hosp/common/test_database.py
@@ -148,7 +148,7 @@ class DatabaseTests(unittest.TestCase):
 
     actual_sql = mock_cursor.executemany.call_args[0][0]
     self.assertIn(
-      'INSERT INTO `test_table` (`id`, `publication_date`, `sql_str_col`, `sql_int_col`, `sql_float_col`)',
+      'REPLACE INTO `test_table` (`id`, `publication_date`, `sql_str_col`, `sql_int_col`, `sql_float_col`)',
       actual_sql)
 
     expected_values = [


### PR DESCRIPTION
The change from #1224 does not work on production, presumably because of the new superlong INSERT INTO...UPDATE statement that it introduced.  With it, [this `executemany()` call](https://github.com/cmu-delphi/delphi-epidata/blob/bc7e37590d22c541d87430684e12c747b71c6fd0/src/acquisition/covid_hosp/common/database.py#L214) hangs indefinitely and pegs the CPU (this even happens with a batch size of 2).  The covid_hosp tables have [a large number of lengthy column names](https://github.com/cmu-delphi/delphi-epidata/blob/bc7e37590d22c541d87430684e12c747b71c6fd0/src/ddl/covid_hosp.sql#L380-L500), and each gets repeated thrice in the INSERT INTO...UPDATE syntax, making for a ~20k character long SQL statement (and this doesn't even consider the literal values that get inserted).  It stands to reason that we didn't see this problem in our tests because we don't use an obnoxiously long list of sample columns there (perhaps we should).

I have a hunch that this could be a driver issue, so updates there might've remedied the situation, but i didn't want to crawl down that rabbit hole.  We can potentially explore this with https://github.com/cmu-delphi/delphi-epidata/issues/1355.

The fix uses MySQL's REPLACE INTO statement instead, which doesn't require enumerating column names.  When there is a UNIQUE key collision, INSERT INTO...UPDATE updates the columns as defined in the UPDATE clause, while REPLACE INTO deletes the colliding row and inserts the new one.

Also included in this PR is improved logging which lets us differentiate between new and inserted rows, and it adds a stub for removing covid_hosp datasets from the db (which may be helpful for doing patches in the future).