### PR TITLE
Update deprecated epidata packages

### DIFF
--- a/requirements.api.txt
+++ b/requirements.api.txt
@@ -4,7 +4,7 @@ Flask==2.2.5
 Flask-Limiter==3.3.0
 jinja2==3.0.3
 more_itertools==8.4.0
-mysqlclient==2.1.1
+mysqlclient==2.2.1
 orjson==3.4.7
 pandas==1.2.3
 python-dotenv==0.15.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -10,10 +10,10 @@ invoke>=1.4.1
 lxml==4.9.1
 matplotlib==3.6.2
 mypy>=0.790
-mysql-connector==2.2.9
+mysql-connector-python==8.2.0
 numpy==1.22.4
 pycountry==22.3.5
-pymysql==1.0.2
+pymysql==1.1.0
 pytest==7.2.0
 pytest-check==1.3.0
 sas7bdat==2.2.3

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -14,14 +14,14 @@ import asyncio
 from tenacity import retry, stop_after_attempt
 
 from aiohttp import ClientSession, TCPConnector, BasicAuth
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version, PackageNotFoundError
 
 # Obtain package version for the user-agent. Uses the installed version by
 # preference, even if you've installed it and then use this script independently
 # by accident.
 try:
-    _version = get_distribution("delphi-epidata").version
-except DistributionNotFound:
+    _version = version("delphi-epidata")
+except PackageNotFoundError:
     _version = "0.script"
 
 _HEADERS = {"user-agent": "delphi_epidata/" + _version + " (Python)"}


### PR DESCRIPTION
Closes #1355 & #1301.

### Summary:

Updates the packages used for MySQL connectors & replaces Setuptools `pkg_resources` with the native `importlib.metadata`.

### Prerequisites:

- [ ] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [ ] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [ ] Code is cleaned up and formatted
