### PR TITLE
Update old MySQL packages

### DIFF
--- a/requirements.api.txt
+++ b/requirements.api.txt
@@ -4,7 +4,7 @@ Flask==2.2.5
 Flask-Limiter==3.3.0
 jinja2==3.0.3
 more_itertools==8.4.0
-mysqlclient==2.1.1
+mysqlclient==2.2.1
 orjson==3.4.7
 pandas==1.2.3
 python-dotenv==0.15.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -10,10 +10,10 @@ invoke>=1.4.1
 lxml==4.9.1
 matplotlib==3.6.2
 mypy>=0.790
-mysql-connector==2.2.9
+mysql-connector-python==8.2.0
 numpy==1.22.4
 pycountry==22.3.5
-pymysql==1.0.2
+pymysql==1.1.0
 pytest==7.2.0
 pytest-check==1.3.0
 sas7bdat==2.2.3


### PR DESCRIPTION
Closes #1355

### Summary:

Bumps versions for the `mysqlclient`, `mysql-connector-python` (replaces `mysql-connector`) and `pymysql` libraries. 

These do not appear to cause any breaking changes, as a performance test in the previous iteration of this PR #1362 was ran successfully. Still, ideas for further testing are more than welcome!

### Prerequisites:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [X] Code is cleaned up and formatted
