### PR TITLE
Log HTTP referer and origin

### DIFF
--- a/src/server/_common.py
+++ b/src/server/_common.py
@@ -68,7 +68,7 @@ def log_info_with_request(message, **kwargs):
         remote_addr=request.remote_addr,
         real_remote_addr=get_real_ip_addr(request),
         user_agent=request.user_agent.string,
-        req_referrer=request.referrer or request.origin,
+        referrer=request.referrer or request.origin,
         api_key=resolve_auth_token(),
         user_id=(current_user and current_user.id),
         **kwargs
@@ -115,7 +115,6 @@ def before_request_execute():
     user = current_user
     api_key = resolve_auth_token()
 
-    # TODO: replace this next call with: log_info_with_request("Received API request")
     log_info_with_request("Received API request")
 
     if not _is_public_route() and api_key and not user:

--- a/src/server/_common.py
+++ b/src/server/_common.py
@@ -125,7 +125,9 @@ def before_request_execute():
         real_remote_addr=get_real_ip_addr(request),
         user_agent=request.user_agent.string,
         api_key=api_key,
-        user_id=(user and user.id)
+        user_id=(user and user.id),
+        req_referrer=request.referrer,
+        req_origin=request.environ.get('HTTP_ORIGIN', '')
     )
 
     if not _is_public_route() and api_key and not user:
@@ -171,6 +173,8 @@ def after_request_execute(response):
         response_status=response.status,
         content_length=response.calculate_content_length(),
         elapsed_time_ms=total_time,
+        req_referrer=request.referrer,
+        req_origin=request.environ.get('HTTP_ORIGIN', '')
     )
     return response
 

--- a/src/server/_common.py
+++ b/src/server/_common.py
@@ -68,6 +68,7 @@ def log_info_with_request(message, **kwargs):
         remote_addr=request.remote_addr,
         real_remote_addr=get_real_ip_addr(request),
         user_agent=request.user_agent.string,
+        req_referrer=request.referrer or request.origin,
         api_key=resolve_auth_token(),
         user_id=(current_user and current_user.id),
         **kwargs
@@ -115,20 +116,7 @@ def before_request_execute():
     api_key = resolve_auth_token()
 
     # TODO: replace this next call with: log_info_with_request("Received API request")
-    get_structured_logger("server_api").info(
-        "Received API request",
-        method=request.method,
-        url=request.url,
-        form_args=request.form,
-        req_length=request.content_length,
-        remote_addr=request.remote_addr,
-        real_remote_addr=get_real_ip_addr(request),
-        user_agent=request.user_agent.string,
-        api_key=api_key,
-        user_id=(user and user.id),
-        req_referrer=request.referrer,
-        req_origin=request.environ.get('HTTP_ORIGIN', '')
-    )
+    log_info_with_request("Received API request")
 
     if not _is_public_route() and api_key and not user:
         # if this is a privleged endpoint, and an api key was given but it does not look up to a user, raise exception:
@@ -152,30 +140,10 @@ def after_request_execute(response):
     # Convert to milliseconds
     total_time *= 1000
 
-    api_key = resolve_auth_token()
-
     update_key_last_time_used(current_user)
 
-    # TODO: replace this next call with: log_info_with_request_and_response("Served API request", response, elapsed_time_ms=total_time)
-    get_structured_logger("server_api").info(
-        "Served API request",
-        method=request.method,
-        url=request.url,
-        form_args=request.form,
-        req_length=request.content_length,
-        remote_addr=request.remote_addr,
-        real_remote_addr=get_real_ip_addr(request),
-        user_agent=request.user_agent.string,
-        api_key=api_key,
-        values=request.values.to_dict(flat=False),
-        blueprint=request.blueprint,
-        endpoint=request.endpoint,
-        response_status=response.status,
-        content_length=response.calculate_content_length(),
-        elapsed_time_ms=total_time,
-        req_referrer=request.referrer,
-        req_origin=request.environ.get('HTTP_ORIGIN', '')
-    )
+    log_info_with_request_and_response("Served API request", response, elapsed_time_ms=total_time)
+
     return response
 
 

--- a/tests/server/test_validate.py
+++ b/tests/server/test_validate.py
@@ -26,6 +26,7 @@ class UnitTests(unittest.TestCase):
         app.config["TESTING"] = True
         app.config["WTF_CSRF_ENABLED"] = False
         app.config["DEBUG"] = False
+        self.client = app.test_client()
 
     def test_require_all(self):
         with self.subTest("all given"):
@@ -60,3 +61,19 @@ class UnitTests(unittest.TestCase):
         with self.subTest("one options given with is empty but ok"):
             with app.test_request_context("/?abc="):
                 self.assertTrue(require_any(request, "abc", empty=True))
+
+    def test_origin_headers(self):
+        with self.subTest("referer and origin"):
+            with self.assertLogs("server_api", level='INFO') as logs:
+                self.client.get("/signal_dashboard_status", headers={
+                    "Referer": "https://test.com/test",
+                    "Origin": "https://test.com"
+                })
+            output = logs.output
+            self.assertEqual(len(output), 2) # [before_request, after_request]
+            self.assertIn("Received API request", output[0])
+            self.assertIn("\"req_referrer\": \"https://test.com/test\"", output[0])
+            self.assertIn("\"req_origin\": \"https://test.com\"", output[0])
+            self.assertIn("Served API request", output[1])
+            self.assertIn("\"req_referrer\": \"https://test.com/test\"", output[1])
+            self.assertIn("\"req_origin\": \"https://test.com\"", output[1])

--- a/tests/server/test_validate.py
+++ b/tests/server/test_validate.py
@@ -71,9 +71,9 @@ class UnitTests(unittest.TestCase):
             output = logs.output
             self.assertEqual(len(output), 2) # [before_request, after_request]
             self.assertIn("Received API request", output[0])
-            self.assertIn("\"req_referrer\": \"https://test.com/test\"", output[0])
+            self.assertIn("\"referrer\": \"https://test.com/test\"", output[0])
             self.assertIn("Served API request", output[1])
-            self.assertIn("\"req_referrer\": \"https://test.com/test\"", output[1])
+            self.assertIn("\"referrer\": \"https://test.com/test\"", output[1])
         with self.subTest("origin only"):
             with self.assertLogs("server_api", level='INFO') as logs:
                 self.client.get("/signal_dashboard_status", headers={
@@ -82,9 +82,9 @@ class UnitTests(unittest.TestCase):
             output = logs.output
             self.assertEqual(len(output), 2) # [before_request, after_request]
             self.assertIn("Received API request", output[0])
-            self.assertIn("\"req_referrer\": \"https://test.com\"", output[0])
+            self.assertIn("\"referrer\": \"https://test.com\"", output[0])
             self.assertIn("Served API request", output[1])
-            self.assertIn("\"req_referrer\": \"https://test.com\"", output[1])
+            self.assertIn("\"referrer\": \"https://test.com\"", output[1])
         with self.subTest("referer overrides origin"):
             with self.assertLogs("server_api", level='INFO') as logs:
                 self.client.get("/signal_dashboard_status", headers={
@@ -94,6 +94,6 @@ class UnitTests(unittest.TestCase):
             output = logs.output
             self.assertEqual(len(output), 2) # [before_request, after_request]
             self.assertIn("Received API request", output[0])
-            self.assertIn("\"req_referrer\": \"https://test.com/test\"", output[0])
+            self.assertIn("\"referrer\": \"https://test.com/test\"", output[0])
             self.assertIn("Served API request", output[1])
-            self.assertIn("\"req_referrer\": \"https://test.com/test\"", output[1])
+            self.assertIn("\"referrer\": \"https://test.com/test\"", output[1])


### PR DESCRIPTION
Related: #1386.

### Summary:

Logs the HTTP Referer (or referrer) header as `req_referrer` and Origin header as `req_origin`, helping us track where requests come from. The easiest way to test this is via Postman:

<img width="572" alt="Screenshot 2024-05-09 at 14 53 50" src="https://github.com/cmu-delphi/delphi-epidata/assets/13783592/ba87ea43-fa13-4918-a944-ae08cb5443a6">

This generates the following log string:

```
{"method": "GET", "url": "http://localhost:10080/epidata/signal_dashboard_status/", "form_args": {}, "req_length": null, "remote_addr": "172.18.0.1", "real_remote_addr": "172.18.0.1", "user_agent": "PostmanRuntime/7.30.1", "api_key": null, "user_id": "None", "req_referrer": "https://test.com/test", "event": "Received API request", "logger": "server_api", "level": "info", "pid": 8, "timestamp": "2024-05-09T11:28:19.206454Z"}
```
```
{ ... "req_referrer": "https://test.com/test" ... }
```

An automated version of this test has also been included. If no referrer is present, the HTTP `Origin` is used instead.

As mentioned in #1386, we _might_ also need to modify the referrer policy across our webapps in order to properly set the relevant fields. The [default referrer policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) is:
```
Send the origin, path, and querystring when performing a same-origin request. For cross-origin requests send the origin (only) when the protocol security level stays same (HTTPS→HTTPS). Don't send the [Referer](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer) header to less secure destinations (HTTPS→HTTP).
```

Since the API endpoint is HTTPS, for some webapps these headers are likely to be already set out of the box, but further testing will still be necessary.

### Prerequisites:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [x] Code is cleaned up and formatted
