### PR TITLE
Update Python client CHANGELOG

### DIFF
--- a/src/client/packaging/pypi/CHANGELOG.md
+++ b/src/client/packaging/pypi/CHANGELOG.md
@@ -3,15 +3,20 @@
 All notable future changes to the `delphi_epidata` python client will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [4.1.17] - 2024-01-30
+## [4.1.21] - TBD
 
 ### Includes
-- https://github.com/cmu-delphi/delphi-epidata/pull/1363
+- https://github.com/cmu-delphi/delphi-epidata/pull/1418
 
 ### Added
 - Adds two debug flags:
   - `debug` logs info about HTTP requests and responses
   - `sandbox` prevents any HTTP requests from actually executing, allowing for tests that do not incur server load.
+
+## [4.1.17] - 2024-01-30
+
+### Includes
+- https://github.com/cmu-delphi/delphi-epidata/pull/1363
 
 ### Changed
 - Replaced use of deprecated setuptools' `pkg_resources` library with the native `importlib.metadata` library.

--- a/src/client/packaging/pypi/CHANGELOG.md
+++ b/src/client/packaging/pypi/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable future changes to the `delphi_epidata` python client will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [4.1.21] - TBD
+
+### Includes
+- https://github.com/cmu-delphi/delphi-epidata/pull/1418
+- https://github.com/cmu-delphi/delphi-epidata/pull/1436
+
+### Added
+- Adds two debug flags: `debug` logs info about HTTP requests and responses; whereas `sandbox` prevents any HTTP requests from actually executing, allowing for tests that do not incur server load.
+
+### Changed
+- Updates internal version detection to use `bumpversion`.
+
+## [4.1.17] - 2024-01-30
+
+### Includes
+- https://github.com/cmu-delphi/delphi-epidata/pull/1363
+
+### Removed
+- Removes uses of setuptools' deprecated pkg_resources library - these are replaced by the native importlib.metadata library.
+
+## [4.1.13] - 2023-11-04
+
+### Includes
+- https://github.com/cmu-delphi/delphi-epidata/pull/1323
+- https://github.com/cmu-delphi/delphi-epidata/pull/1330
+
+### Changed
+- Appends a trailing slash to URLs requested by the Python client, which should prevent an automatic redirect and an extra request to the server.
+
+### Removed
+- Mutes the covidcast_nowcast endpoint & removes unnecessary code that is related to this endpoint.
+
 ## [4.1.11] - 2023-10-12
 
 ### Includes

--- a/src/client/packaging/pypi/CHANGELOG.md
+++ b/src/client/packaging/pypi/CHANGELOG.md
@@ -3,25 +3,13 @@
 All notable future changes to the `delphi_epidata` python client will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [4.1.21] - TBD
-
-### Includes
-- https://github.com/cmu-delphi/delphi-epidata/pull/1418
-- https://github.com/cmu-delphi/delphi-epidata/pull/1436
-
-### Added
-- Adds two debug flags: `debug` logs info about HTTP requests and responses; whereas `sandbox` prevents any HTTP requests from actually executing, allowing for tests that do not incur server load.
-
-### Changed
-- Updates internal version detection to use `bumpversion`.
-
 ## [4.1.17] - 2024-01-30
 
 ### Includes
 - https://github.com/cmu-delphi/delphi-epidata/pull/1363
 
-### Removed
-- Removes uses of setuptools' deprecated pkg_resources library - these are replaced by the native importlib.metadata library.
+### Changed
+- Replaced use of deprecated setuptools' `pkg_resources` library with the native `importlib.metadata` library.
 
 ## [4.1.13] - 2023-11-04
 
@@ -33,7 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Appends a trailing slash to URLs requested by the Python client, which should prevent an automatic redirect and an extra request to the server.
 
 ### Removed
-- Mutes the covidcast_nowcast endpoint & removes unnecessary code that is related to this endpoint.
+- Removed the `covidcast_nowcast()` method, as the associated API endpoint is no longer available.
 
 ## [4.1.11] - 2023-10-12
 

--- a/src/client/packaging/pypi/CHANGELOG.md
+++ b/src/client/packaging/pypi/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Includes
 - https://github.com/cmu-delphi/delphi-epidata/pull/1363
 
+### Added
+- Adds two debug flags:
+  - `debug` logs info about HTTP requests and responses
+  - `sandbox` prevents any HTTP requests from actually executing, allowing for tests that do not incur server load.
+
 ### Changed
 - Replaced use of deprecated setuptools' `pkg_resources` library with the native `importlib.metadata` library.
 

--- a/src/client/packaging/pypi/setup.py
+++ b/src/client/packaging/pypi/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/cmu-delphi/delphi-epidata",
     project_urls={
-        "Changelog": "https://github.com/cmu-delphi/delphi-epidata/blob/dev/src/client/packaging/pypi/CHANGELOG.md",
+        "Changelog": "https://github.com/cmu-delphi/delphi-epidata/blob/main/src/client/packaging/pypi/CHANGELOG.md",
     },
     packages=setuptools.find_packages(),
     install_requires=["aiohttp", "requests>=2.7.0", "tenacity"],


### PR DESCRIPTION
Closes #1432.

### Summary:

Updates the Python client's changelog to include items from previous releases.

Also includes a few currently pending changes. These can be omitted if we want to update the CHANGELOG right away; otherwise the date will need to be updated during the next release.

### Prerequisites:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted
