### PR TITLE
fix: Python client logger import

### DIFF
--- a/requirements.api.txt
+++ b/requirements.api.txt
@@ -1,4 +1,4 @@
-delphi_utils==0.3.15
+delphi_utils
 epiweeks==2.1.2
 Flask==2.2.5
 Flask-Limiter==3.3.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,7 +2,7 @@ aiohttp==3.9.4
 black>=20.8b1
 bump2version==1.0.1
 covidcast==0.1.5
-delphi_utils==0.3.15
+delphi_utils
 docker==6.0.1
 dropbox==11.36.0
 freezegun==1.2.2

--- a/src/client/delphi_epidata.py
+++ b/src/client/delphi_epidata.py
@@ -16,7 +16,7 @@ from tenacity import retry, stop_after_attempt
 
 from aiohttp import ClientSession, TCPConnector, BasicAuth
 
-from delphi.epidata.common.logger import get_structured_logger
+from delphi_utils.logger import get_structured_logger
 
 __version__ = "4.1.22"
 

--- a/src/client/packaging/pypi/CHANGELOG.md
+++ b/src/client/packaging/pypi/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable future changes to the `delphi_epidata` python client will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [4.2.22] - 2024-05-31
+
+### Includes
+- https://github.com/cmu-delphi/delphi-epidata/pull/1460
+
+### Fixed
+- Replaced bad internal logger package import with one from `delphi_utils` package instead.
+
 ## [4.1.21] - 2024-05-20
 
 ### Includes

--- a/src/client/packaging/pypi/CHANGELOG.md
+++ b/src/client/packaging/pypi/CHANGELOG.md
@@ -3,13 +3,14 @@
 All notable future changes to the `delphi_epidata` python client will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [4.2.22] - 2024-05-31
+## [4.2.23] - 2024-05-31
 
 ### Includes
 - https://github.com/cmu-delphi/delphi-epidata/pull/1460
 
 ### Fixed
 - Replaced bad internal logger package import with one from `delphi_utils` package instead.
+  - This bug affected releases 4.1.21 and 4.1.22
 
 ## [4.1.21] - 2024-05-20
 

--- a/src/client/packaging/pypi/setup.py
+++ b/src/client/packaging/pypi/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
         "Changelog": "https://github.com/cmu-delphi/delphi-epidata/blob/main/src/client/packaging/pypi/CHANGELOG.md",
     },
     packages=setuptools.find_packages(),
-    install_requires=["aiohttp", "requests>=2.7.0", "tenacity"],
+    install_requires=["aiohttp", "delphi-utils", "requests>=2.7.0", "tenacity"],
     classifiers=[
         "Programming Language :: Python",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
### Summary:

* add delphi-utils as dependency to Python client
* import logger from delphi-utils instead of locally
* unpin delphi-utils in both requirements files

### Prerequisites:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted
