### PR TITLE
py client: drop delphi_utils requirement, log to stderr instead

### DIFF
--- a/integrations/client/test_delphi_epidata.py
+++ b/integrations/client/test_delphi_epidata.py
@@ -49,6 +49,12 @@ class DelphiEpidataPythonClientTests(CovidcastBase):
     secrets.db.host = 'delphi_database_epidata'
     secrets.db.epi = ('user', 'pass')
 
+  @pytest.fixture(autouse=True)
+  def capsys(self, capsys):
+    """Hook capsys (stdout and stderr) into this test class."""
+
+    self.capsys = capsys
+
   def test_covidcast(self):
     """Test that the covidcast endpoint returns expected data."""
 
@@ -238,46 +244,46 @@ class DelphiEpidataPythonClientTests(CovidcastBase):
 
     try:
       with self.subTest(name='test multiple GET'):
-        with self.assertLogs('delphi_epidata_client', level='INFO') as logs:
-          get.reset_mock()
-          get.return_value = MockResponse(b'{"key": "value"}', 200)
-          Epidata._request_with_retry("test_endpoint1", params={"key1": "value1"})
-          Epidata._request_with_retry("test_endpoint2", params={"key2": "value2"})
+        get.reset_mock()
+        get.return_value = MockResponse(b'{"key": "value"}', 200)
+        Epidata._request_with_retry("test_endpoint1", params={"key1": "value1"})
+        Epidata._request_with_retry("test_endpoint2", params={"key2": "value2"})
 
-        output = logs.output
+        captured = self.capsys.readouterr()
+        output = captured.err.splitlines()
         self.assertEqual(len(output), 4) # [request, response, request, response]
         self.assertIn("Sending GET request", output[0])
-        self.assertIn("\"url\": \"http://delphi_web_epidata/epidata/test_endpoint1/\"", output[0])
-        self.assertIn("\"params\": {\"key1\": \"value1\"}", output[0])
+        self.assertIn("\'url\': \'http://delphi_web_epidata/epidata/test_endpoint1/\'", output[0])
+        self.assertIn("\'params\': {\'key1\': \'value1\'}", output[0])
         self.assertIn("Received response", output[1])
-        self.assertIn("\"status_code\": 200", output[1])
-        self.assertIn("\"len\": 16", output[1])
+        self.assertIn("\'status_code\': 200", output[1])
+        self.assertIn("\'len\': 16", output[1])
         self.assertIn("Sending GET request", output[2])
-        self.assertIn("\"url\": \"http://delphi_web_epidata/epidata/test_endpoint2/\"", output[2])
-        self.assertIn("\"params\": {\"key2\": \"value2\"}", output[2])
+        self.assertIn("\'url\': \'http://delphi_web_epidata/epidata/test_endpoint2/\'", output[2])
+        self.assertIn("\'params\': {\'key2\': \'value2\'}", output[2])
         self.assertIn("Received response", output[3])
-        self.assertIn("\"status_code\": 200", output[3])
-        self.assertIn("\"len\": 16", output[3])
+        self.assertIn("\'status_code\': 200", output[3])
+        self.assertIn("\'len\': 16", output[3])
 
       with self.subTest(name='test GET and POST'):
-        with self.assertLogs('delphi_epidata_client', level='INFO') as logs:
-          get.reset_mock()
-          get.return_value = MockResponse(b'{"key": "value"}', 414)
-          post.reset_mock()
-          post.return_value = MockResponse(b'{"key": "value"}', 200)
-          Epidata._request_with_retry("test_endpoint3", params={"key3": "value3"})
+        get.reset_mock()
+        get.return_value = MockResponse(b'{"key": "value"}', 414)
+        post.reset_mock()
+        post.return_value = MockResponse(b'{"key": "value"}', 200)
+        Epidata._request_with_retry("test_endpoint3", params={"key3": "value3"})
 
-        output = logs.output
-        self.assertEqual(len(output), 3) # [request, response, request, response]
+        captured = self.capsys.readouterr()
+        output = captured.err.splitlines()
+        self.assertEqual(len(output), 3) # [request, retry, response]
         self.assertIn("Sending GET request", output[0])
-        self.assertIn("\"url\": \"http://delphi_web_epidata/epidata/test_endpoint3/\"", output[0])
-        self.assertIn("\"params\": {\"key3\": \"value3\"}", output[0])
+        self.assertIn("\'url\': \'http://delphi_web_epidata/epidata/test_endpoint3/\'", output[0])
+        self.assertIn("\'params\': {\'key3\': \'value3\'}", output[0])
         self.assertIn("Received 414 response, retrying as POST request", output[1])
-        self.assertIn("\"url\": \"http://delphi_web_epidata/epidata/test_endpoint3/\"", output[1])
-        self.assertIn("\"params\": {\"key3\": \"value3\"}", output[1])
+        self.assertIn("\'url\': \'http://delphi_web_epidata/epidata/test_endpoint3/\'", output[1])
+        self.assertIn("\'params\': {\'key3\': \'value3\'}", output[1])
         self.assertIn("Received response", output[2])
-        self.assertIn("\"status_code\": 200", output[2])
-        self.assertIn("\"len\": 16", output[2])
+        self.assertIn("\'status_code\': 200", output[2])
+        self.assertIn("\'len\': 16", output[2])
     finally: # make sure this global is always reset
       Epidata.debug = False
 
@@ -288,12 +294,12 @@ class DelphiEpidataPythonClientTests(CovidcastBase):
     Epidata.debug = True
     Epidata.sandbox = True
     try:
-      with self.assertLogs('delphi_epidata_client', level='INFO') as logs:
-        Epidata.covidcast('src', 'sig', 'day', 'county', 20200414, '01234')
-      output = logs.output
+      Epidata.covidcast('src', 'sig', 'day', 'county', 20200414, '01234')
+      captured = self.capsys.readouterr()
+      output = captured.err.splitlines()
       self.assertEqual(len(output), 1)
       self.assertIn("Sending GET request", output[0])
-      self.assertIn("\"url\": \"http://delphi_web_epidata/epidata/covidcast/\"", output[0])
+      self.assertIn("\'url\': \'http://delphi_web_epidata/epidata/covidcast/\'", output[0])
       get.assert_not_called()
       post.assert_not_called()
     finally: # make sure these globals are always reset

--- a/src/client/packaging/pypi/pyproject.toml
+++ b/src/client/packaging/pypi/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Natural Language :: English",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
-dependencies = ["aiohttp", "delphi-utils", "requests>=2.7.0", "tenacity"]
+dependencies = ["aiohttp", "requests>=2.7.0", "tenacity"]
 
 [project.urls]
 "Homepage" = "https://github.com/cmu-delphi/delphi-epidata"


### PR DESCRIPTION
This drops the requirement for the bloated `delphi_utils` package in the python client, and replaces the `delphi_utils.logger` with printing to STDERR instead.

Addresses #1467 

I havent tested this yet, and i imagine it is going to fail CI.