### PR TITLE
Put hhs docs under inactive signals

### DIFF
--- a/docs/api/covidcast-signals/hhs.md
+++ b/docs/api/covidcast-signals/hhs.md
@@ -1,6 +1,6 @@
 ---
 title: Department of Health & Human Services
-parent: Data Sources and Signals
+parent: Inactive Signals
 grand_parent: COVIDcast Main Endpoint
 ---
 


### PR DESCRIPTION
### Summary:

Move hhs docs under inactive signals


### Prerequisites:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted
