### PR TITLE
Troubleshooting & [hackily] fixing GH action for signals sync (gdoc-->csv)

### DIFF
--- a/.github/workflows/update_gdocs_data.yml
+++ b/.github/workflows/update_gdocs_data.yml
@@ -21,7 +21,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pipd-
       - name: Install Dependencies
-        run: pip install -r requirements.dev.txt
+        run: |
+          pip -V
+          python -m pip install pip==22.0.2
+          pip install -r requirements.dev.txt
       - name: Update Docs
         run: inv update-gdoc
       - name: Create pull request into dev


### PR DESCRIPTION
It looks like an update to the GH actions runner image recently changed the installed `pip` version to "`>=24.1`".  A dependency we have pinned uses a version spec syntax that is not compatible with this...
<details>
  <summary>GH actions output:</summary>

```
...
Collecting dropbox==11.36.0 (from -r requirements.dev.txt (line 6))
  Downloading dropbox-11.36.0-py3-none-any.whl.metadata (4.3 kB)
WARNING: Ignoring version 11.36.0 of dropbox since it has invalid metadata:
Requested dropbox==11.36.0 from https://files.pythonhosted.org/packages/11/7e/e66327f3535cf5b58b3c152144744fc5727355357304facf61e43ab1b895/dropbox-11.36.0-py3-none-any.whl (from -r requirements.dev.txt (line 6)) has invalid metadata: .* suffix can only be used with `==` or `!=` operators
    stone (>=2.*)
           ~~~~^
Please use pip<24.1 if you need to use this version.
ERROR: Ignored the following yanked versions: 10.11.0, 11.3.0, 12.0.0
ERROR: Could not find a version that satisfies the requirement dropbox==11.36.0 (from versions: 1.1, 1.2, 1.3, 1.4, 1.5.1, 1.6, 2.0.0, 2.1.0, 2.2.0, 3.2, 3.12, 3.13, 3.14, 3.21, 3.22, 3.23, 3.24, 3.25, 3.26, 3.27, 3.[28](https://github.com/cmu-delphi/delphi-epidata/actions/runs/10095233705/job/27915622079#step:5:29), 3.29, 3.30, 3.31, 3.32, 3.34, 3.36, 3.37, 3.38, 3.39, 3.40, 3.41, 3.42, 4.0, 5.0, 5.0.1, 5.1, 5.2, 5.2.1, 5.2.2, 6.0, 6.1, 6.2, 6.3.0, 6.4.0, 6.5.0, 6.6.0, 6.6.1, 6.6.2, 6.7.0, 6.8.0, 6.9.0, 7.1.0, 7.1.1, 7.2.0, 7.2.1, 7.3.0, 7.3.1, 8.0.0, 8.1.0, 8.2.0, 8.3.1, 8.4.0, 8.4.1, 8.5.0, 8.5.1, 8.6.0, 8.7.0, 8.7.1, 8.8.0, 8.8.1, 8.9.0, 9.0.0, 9.1.0, 9.2.0, 9.3.0, 9.4.0, 9.5.0, 10.0.0, 10.1.0, 10.1.1, 10.1.2, 10.2.0, 10.3.0, 10.3.1, 10.4.1, 10.5.0, 10.6.0, 10.7.0, 10.8.0, 10.9.0, 10.10.0, 11.0.0, 11.1.0, 11.2.0, 11.4.0, 11.4.1, 11.5.0, 11.6.0, 11.7.0, 11.8.0, 11.9.0, 11.10.0, 11.11.0, 11.12.0, 11.13.0, 11.13.1, 11.13.2, 11.13.3, 11.14.0, 11.15.0, 11.16.0, 11.17.0, 11.18.0, 11.19.0, 11.20.0, 11.21.0, 11.22.0, 11.23.0, 11.24.0, 11.25.0, 11.26.0, 11.27.0, 11.28.0, 11.[29](https://github.com/cmu-delphi/delphi-epidata/actions/runs/10095233705/job/27915622079#step:5:30).0, 11.30.0, 11.31.0, 11.32.0, 11.33.0, 11.34.0, 11.35.0, 11.36.0, 11.36.2, 12.0.1, 12.0.2)
ERROR: No matching distribution found for dropbox==11.36.0
Error: Process completed with exit code 1.
```
</details>

We had a [successful run ~2 months ago](https://github.com/cmu-delphi/delphi-epidata/actions/runs/9290024871/job/25565314861#step:1:9) with version `20240526.1.0`, but [it failed today](https://github.com/cmu-delphi/delphi-epidata/actions/runs/10095233705/job/27915622079#step:1:10) with version `20240721.1.0` (both with image `ubuntu-22.04`).

[The GH Actions output from this PR](https://github.com/cmu-delphi/delphi-epidata/actions/runs/10096915539/job/27920539469#step:5:10) shows the image's installed version to be "`pip 24.1.2`".

This is not a good permanent solution -- it would be better to get Github to roll back to [the version of `pip` that they claim to be using](https://github.com/actions/runner-images/blob/ubuntu22/20240721.1/images/ubuntu/Ubuntu2204-Readme.md?plain=1#L39), or even better update the offending pinned dependency to a compatible version.