### PR TITLE
Switch Google Health Trends and Google Symptoms inactive/active marking

### DIFF
--- a/docs/api/covidcast-signals/covid-act-now.md
+++ b/docs/api/covidcast-signals/covid-act-now.md
@@ -1,8 +1,8 @@
 ---
 title: <i>inactive</i> COVID Act Now
 parent: Data Sources and Signals
-nav_order: 2
 grand_parent: Main Endpoint (COVIDcast)
+nav_order: 2
 ---
 
 # COVID Act Now (CAN)

--- a/docs/api/covidcast-signals/dsew-cpr.md
+++ b/docs/api/covidcast-signals/dsew-cpr.md
@@ -1,8 +1,8 @@
 ---
 title: <i>inactive</i> Data Strategy and Execution Workgroup Community Profile Report
 parent: Data Sources and Signals
-nav_order: 2
 grand_parent: Main Endpoint (COVIDcast)
+nav_order: 2
 ---
 
 # Data Strategy and Execution Workgroup Community Profile Report (CPR)

--- a/docs/api/covidcast-signals/ght.md
+++ b/docs/api/covidcast-signals/ght.md
@@ -1,8 +1,8 @@
 ---
-title: Google Health Trends
-parent: Inactive Signals
-nav_order: 2
+title: <i>inactive</i> Google Health Trends
+parent: Data Sources and Signals
 grand_parent: Main Endpoint (COVIDcast)
+nav_order: 2
 ---
 
 # Google Health Trends

--- a/docs/api/covidcast-signals/google-symptoms.md
+++ b/docs/api/covidcast-signals/google-symptoms.md
@@ -1,8 +1,8 @@
 ---
-title: Google Search Trends Symptoms
+title: Google Symptom Search Trends
 parent: Data Sources and Signals
-nav_order: 1
 grand_parent: Main Endpoint (COVIDcast)
+nav_order: 1
 ---
 
 # Google Symptoms

--- a/docs/api/covidcast-signals/hhs.md
+++ b/docs/api/covidcast-signals/hhs.md
@@ -1,8 +1,8 @@
 ---
 title: <i>inactive</i> Department of Health & Human Services
 parent: Data Sources and Signals
-nav_order: 2
 grand_parent: Main Endpoint (COVIDcast)
+nav_order: 2
 ---
 
 # Department of Health & Human Services

--- a/docs/api/covidcast-signals/jhu-csse.md
+++ b/docs/api/covidcast-signals/jhu-csse.md
@@ -1,8 +1,8 @@
 ---
 title: <i>inactive</i> JHU Cases and Deaths
 parent: Data Sources and Signals
-nav_order: 2
 grand_parent: Main Endpoint (COVIDcast)
+nav_order: 2
 ---
 
 # JHU Cases and Deaths

--- a/docs/api/covidcast-signals/safegraph.md
+++ b/docs/api/covidcast-signals/safegraph.md
@@ -1,8 +1,8 @@
 ---
 title: <i>inactive</i> SafeGraph
 parent: Data Sources and Signals
-nav_order: 2
 grand_parent: Main Endpoint (COVIDcast)
+nav_order: 2
 ---
 
 # SafeGraph

--- a/docs/api/covidcast-signals/usa-facts.md
+++ b/docs/api/covidcast-signals/usa-facts.md
@@ -1,8 +1,8 @@
 ---
 title: <i>inactive</i> USAFacts Cases and Deaths
 parent: Data Sources and Signals
-nav_order: 2
 grand_parent: Main Endpoint (COVIDcast)
+nav_order: 2
 ---
 
 # USAFacts Cases and Deaths

--- a/docs/api/covidcast-signals/youtube-survey.md
+++ b/docs/api/covidcast-signals/youtube-survey.md
@@ -1,8 +1,8 @@
 ---
 title: <i>inactive</i> Youtube Survey
 parent: Data Sources and Signals
-nav_order: 2
 grand_parent: Main Endpoint (COVIDcast)
+nav_order: 2
 ---
 
 [//]: # (code at https://github.com/cmu-delphi/covid-19/tree/deeb4dc1e9a30622b415361ef6b99198e77d2a94/youtube)


### PR DESCRIPTION
### Summary:

Mark Google Health Trends as inactive. Rename Google symptoms page. Make all headers have the same format (`nav_order` in the same place).

### Prerequisites:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted
