### PR TITLE
upload-artifact@v2 -> v4

### DIFF
--- a/.github/workflows/missing_signals.yaml
+++ b/.github/workflows/missing_signals.yaml
@@ -21,7 +21,7 @@ jobs:
         run: python scripts/report_missing_covidcast_meta.py
       - name: Upload Missing Artifact
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: missing_db_signals.csv
           path:  missing_db_signals.csv

--- a/.github/workflows/performance-tests-one-time.yml
+++ b/.github/workflows/performance-tests-one-time.yml
@@ -101,7 +101,7 @@ jobs:
               write_float('requests_per_sec', final_line[9])
 
       - name: Archive results as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: locust-output
           path: |

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -109,7 +109,7 @@ jobs:
               write_float('requests_per_sec', final_line[9])
 
       - name: Archive results as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: locust-output
           path: |

--- a/.github/workflows/release-helper.yml
+++ b/.github/workflows/release-helper.yml
@@ -89,7 +89,7 @@ jobs:
         working-directory: src/client/packaging/pypi
         run: |
           python -m build --sdist --wheel
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: delphi_epidata_py
           path: src/client/packaging/pypi/dist/*.tar.gz
@@ -132,7 +132,7 @@ jobs:
       - run: npm pack
       - name: Rename to a different name
         run: for f in *.tgz; do mv "$f" "$(echo "$f" | sed s/delphi_epidata-/delphi_epidata_js-/)"; done
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: delphi_epidata_js
           path: src/client/packaging/npm/*.tgz


### PR DESCRIPTION
addresses #1540

### Summary:

Changes all `actions/upload-artifact@v2` to `actions/upload-artifact@v4`. There's no use of download-artifact in the repo. 

### Prerequisites:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [ ] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [x] Code is cleaned up and formatted
