### PR TITLE
Properly decode UTF-8 from gsheet csv

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -18,7 +18,7 @@ def update_gdoc(
     base_dir = pathlib.Path("./src/server/endpoints/covidcast_utils/")
 
     def _migrate_file(url: str, filename: str):
-        r = requests.get(url).text.replace("\r\n", "\n")
+        r = requests.get(url).content.decode("utf8").replace("\r\n", "\n")
         rows = r.split("\n")
         rows = [r for r in rows if not r.startswith(",")]
         file_ = base_dir / filename


### PR DESCRIPTION
What i was referring to in https://github.com/cmu-delphi/delphi-epidata/pull/1546#issuecomment-2400786489 is not actually a problem with extended ascii or unicode characters -- unicode seems like it should actually be fine to use as long as it is decoded properly...

* In #1546, i saw the replacement of weird ascii characters (that i thought might have been escaped to comply with some CSV format) with what i thought were proper/plain quotation marks (they were actually unicode's stylized quotes).  

* `db_signals.csv` in the current `main` branch has the weird extended ascii chars (Search for "Children cannot get COVID-19" to see an example: https://github.com/cmu-delphi/delphi-epidata/blob/9e21bfb8c4698d114d3b5cc7b5ad534cddebefdf/src/server/endpoints/covidcast_utils/db_signals.csv#L139 ).  In my exploring today, i realized these funky characters also show up on the website ( see https://delphi.cmu.edu/covidcast/indicator-signal/?sensor=fb-survey-smoothed_wbelief_children_immune , screenshot for posterity: 
![image](https://github.com/user-attachments/assets/c691a127-5e21-4370-8778-ca04d062e38a) ).

* Somehow, that broken encoding was fixed in #1546.  You will have to take my word for it or carefully examine that version of the file for yourself, the diff from that PR is too big for github to display it nicely.

* You can see that the broken decoding came back in https://github.com/cmu-delphi/delphi-epidata/pull/1547/files#diff-5acd8942e330087af27801ddefd15a2ece4fef9aedcd37ea2e5bcbdb42808bf1R22 after i did a find/replace for some of the quotes.  I dont know why we have a mix of low-ascii and higher unicode characters for quotes in the sheet, but maybe google does some "smart" autoformatting for us.

* I still cant explain how they were "fixed" in #1546 but reverted in #1547 ¯\\\_(ツ)_/¯ 

* This code demonstrates that it is a bad decoding:
```py
>>> chr(8220) # unicode quote (left double quote, to be specific)
'“'
>>> chr(8220).encode("utf8") # how its represented in utf8 (3 bytes in the extended ascii range)
b'\xe2\x80\x9c'
>>> chr(8220).encode("utf8").decode("8859") # what it looks like when its improperly decoded (an "a-hat" and two effectively unprintable chars)
'â\x80\x9c'
```

* This S.O. answer essentially explains why it happens with the `.text` accessor in `requests`: https://stackoverflow.com/questions/44203397/python-requests-get-returns-improperly-decoded-text-instead-of-utf-8/52615216#52615216
