### PR TITLE
Remove WireGuard step

### DIFF
--- a/.github/workflows/performance-tests-one-time.yml
+++ b/.github/workflows/performance-tests-one-time.yml
@@ -23,14 +23,6 @@ jobs:
       max_time: ${{ steps.output.outputs.max_time }}
       requests_per_sec: ${{ steps.output.outputs.requests_per_sec }}
     steps:
-      - name: Set up WireGuard
-        uses: egor-tensin/setup-wireguard@v1.2.0
-        with:
-          endpoint: '${{ secrets.WG_PERF_ENDPOINT }}'
-          endpoint_public_key: '${{ secrets.WG_PERF_ENDPOINT_PUBLIC_KEY }}'
-          ips: '${{ secrets.WG_PERF_IPS }}'
-          allowed_ips: '${{ secrets.WG_PERF_ALLOWED_IPS }}'
-          private_key: '${{ secrets.WG_PERF_PRIVATE_KEY }}'
       - name: Clean files from previous runs
         uses: AutoModality/action-clean@v1
       - name: Check out repository

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -25,14 +25,6 @@ jobs:
       max_time: ${{ steps.output.outputs.max_time }}
       requests_per_sec: ${{ steps.output.outputs.requests_per_sec }}
     steps:
-      - name: Set up WireGuard
-        uses: egor-tensin/setup-wireguard@v1.2.0
-        with:
-          endpoint: '${{ secrets.WG_PERF_ENDPOINT }}'
-          endpoint_public_key: '${{ secrets.WG_PERF_ENDPOINT_PUBLIC_KEY }}'
-          ips: '${{ secrets.WG_PERF_IPS }}'
-          allowed_ips: '${{ secrets.WG_PERF_ALLOWED_IPS }}'
-          private_key: '${{ secrets.WG_PERF_PRIVATE_KEY }}'
       - name: Clean files from previous runs
         uses: AutoModality/action-clean@v1
       - name: Check out repository


### PR DESCRIPTION
addresses issue(s) #1556 <!--list issue(s) associated with this PR -->

### Summary:

<!--
  describe what this PR changes
-->

Removes the step to install/set up WireGuard from the performance testing Actions workflows.

Reason:

- The WireGuard setup, though pretty stable overall, recently failed in our test environment and resulted in a lot of spurious monitoring alerts. We don't need it anymore because we now run these workflows via local runner that has more direct access to the test environment.

NOTE: There is also an Actions secret used in these workflows of `DB_CONN_STRING` that has already been updated and tested.

### Prerequisites:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted