### PR TITLE
fix unittest.mock import error

### DIFF
--- a/tests/server/test_pandas.py
+++ b/tests/server/test_pandas.py
@@ -2,7 +2,7 @@
 
 # standard library
 import unittest
-from mock import patch, sentinel, ANY
+from unittest.mock import patch, sentinel, ANY
 
 # first party
 from delphi.epidata.server.main import app


### PR DESCRIPTION
The CI build is currently broken by an import error, but this PR includes a simple fix.

Last successful build:
https://github.com/cmu-delphi/delphi-epidata/actions/runs/12265958980/job/34223121686
Dec 10, 2024
runner image `ubuntu-22.04` version `20241201.1.0`

First failing build:
https://github.com/cmu-delphi/delphi-epidata/actions/runs/12635938712/job/35206910938
Jan 6, 2025
runner image `ubuntu-24.04` version `20241215.1.0`

I'm guessing that these version changes are the cause of the error.  I would have thought that we would be protected from such problems since the tests run inside docker.  (Maybe it does protect us?  Which would then mean that something else is the cause...)

Going from ubuntu 22 to ubuntu 24 is kind of a big step to happen without warning...  Do we want to consider changing to running on a specific image version instead of "latest"?
https://github.com/cmu-delphi/delphi-epidata/blob/827be440de000c4caeea0fd0b70f9db2bb4fdb44/.github/workflows/ci.yaml#L6