### PR TITLE
Signal Documentation Coverage Endpoint

### DIFF
--- a/integrations/acquisition/covidcast/test_coverage_crossref_update.py
+++ b/integrations/acquisition/covidcast/test_coverage_crossref_update.py
@@ -14,7 +14,7 @@ from delphi.epidata.client.delphi_epidata import Epidata
 import delphi.operations.secrets as secrets
 import delphi.epidata.acquisition.covidcast.database as live
 from delphi.epidata.maintenance.coverage_crossref_updater import main
-from delphi.epidata.acquisition.covidcast.test_utils import CovidcastBase
+from delphi.epidata.acquisition.covidcast.test_utils import CovidcastBase, CovidcastTestRow
 
 # use the local instance of the Epidata API
 BASE_URL = 'http://delphi_web_epidata/epidata' # NOSONAR
@@ -28,9 +28,7 @@ class CoverageCrossrefTests(CovidcastBase):
     self._db._cursor.execute('TRUNCATE TABLE `coverage_crossref`')
 
   @staticmethod
-  def _make_request(params=None):
-    if params is None:
-        params = {'geo': 'state:*'}
+  def _make_request(params):
     response = requests.get(f"{Epidata.BASE_URL}/covidcast/geo_coverage", params=params, auth=Epidata.auth)
     response.raise_for_status()
     return response.json()
@@ -45,7 +43,7 @@ class CoverageCrossrefTests(CovidcastBase):
         CovidcastTestRow.make_default_row(geo_type="state", geo_value="ny", signal="sig2"),
     ])
 
-    results = self._make_request()
+    results = self._make_request(params = {'geo': 'state:*'})
 
     # make sure the tables are empty
     self.assertEqual(results, {
@@ -57,12 +55,12 @@ class CoverageCrossrefTests(CovidcastBase):
     # update the coverage crossref table
     main()
 
-    results = self._make_request()
+    results = self._make_request(params = {'geo': 'state:*'})
 
     # make sure the data was actually served
     self.assertEqual(results, {
       'result': 1,
-      'epidata': [{'signal': 'sig', 'source': 'src'}],
+      'epidata': [{'signal': 'sig', 'source': 'src'}, {'signal': 'sig2', 'source': 'src'}],
       'message': 'success',
     })
 
@@ -83,3 +81,13 @@ class CoverageCrossrefTests(CovidcastBase):
       'epidata': [{'signal': 'sig', 'source': 'src'}],
       'message': 'success',
     })
+
+    results = self._make_request(params = {'geo': 'state:ny'})
+
+    # make sure the data was actually served
+    self.assertEqual(results, {
+      'result': 1,
+      'epidata': [{'signal': 'sig', 'source': 'src'}, {'signal': 'sig2', 'source': 'src'}],
+      'message': 'success',
+    })
+

--- a/integrations/acquisition/covidcast/test_coverage_crossref_update.py
+++ b/integrations/acquisition/covidcast/test_coverage_crossref_update.py
@@ -1,0 +1,141 @@
+"""Integration tests for covidcast's metadata caching."""
+
+# standard library
+import json
+import unittest
+
+# third party
+import mysql.connector
+import requests
+
+# first party
+from delphi_utils import Nans
+from delphi.epidata.client.delphi_epidata import Epidata
+import delphi.operations.secrets as secrets
+import delphi.epidata.acquisition.covidcast.database as live
+from delphi.epidata.maintenance.coverage_crossref_updater import main
+
+# py3tester coverage target (equivalent to `import *`)
+__test_target__ = (
+  'delphi.epidata.acquisition.covidcast.'
+  'coverage_crossref_updater'
+)
+
+# use the local instance of the Epidata API
+BASE_URL = 'http://delphi_web_epidata/epidata'
+
+
+class CoverageCrossrefTests(unittest.TestCase):
+  """Tests coverage crossref updater."""
+
+  def setUp(self):
+    """Perform per-test setup."""
+
+    # connect to the `epidata` database
+    cnx = mysql.connector.connect(
+        user='user',
+        password='pass',
+        host='delphi_database_epidata',
+        database='covid')
+    cur = cnx.cursor()
+
+    # clear all tables
+    cur.execute("truncate table epimetric_load")
+    cur.execute("truncate table epimetric_full")
+    cur.execute("truncate table epimetric_latest")
+    cur.execute("truncate table geo_dim")
+    cur.execute("truncate table signal_dim")
+    cur.execute("truncate table coverage_crossref")
+    cur.execute("truncate table coverage_crossref_load")
+    cnx.commit()
+    cur.close()
+
+    # make connection and cursor available to test cases
+    self.cnx = cnx
+    self.cur = cnx.cursor()
+
+    # use the local instance of the epidata database
+    secrets.db.host = 'delphi_database_epidata'
+    secrets.db.epi = ('user', 'pass')
+
+    epidata_cnx = mysql.connector.connect(
+        user='user',
+        password='pass',
+        host='delphi_database_epidata',
+        database='epidata')
+    epidata_cur = epidata_cnx.cursor()
+
+    epidata_cur.execute("DELETE FROM `api_user`")
+    epidata_cur.execute('INSERT INTO `api_user`(`api_key`, `email`) VALUES("key", "email")')
+    epidata_cnx.commit()
+    epidata_cur.close()
+    epidata_cnx.close()
+
+    # use the local instance of the Epidata API
+    Epidata.BASE_URL = BASE_URL
+    Epidata.auth = ('epidata', 'key')
+
+  def tearDown(self):
+    """Perform per-test teardown."""
+    self.cur.close()
+    self.cnx.close()
+
+  @staticmethod
+  def _make_request():
+    params = {'geo': 'state:*'}
+    response = requests.get(f"{Epidata.BASE_URL}/covidcast/geo_coverage", params=params, auth=Epidata.auth)
+    response.raise_for_status()
+    return response.json()
+
+  def test_caching(self):
+    """Populate, query, cache, query, and verify the cache."""
+
+    # insert dummy data
+    self.cur.execute(f'''
+      INSERT INTO `signal_dim` (`signal_key_id`, `source`, `signal`)
+      VALUES
+        (42, 'src', 'sig');
+    ''')
+    self.cur.execute(f'''
+      INSERT INTO `geo_dim` (`geo_key_id`, `geo_type`, `geo_value`)
+      VALUES
+        (96, 'state', 'pa'), 
+        (97, 'state', 'wa');
+    ''')
+    self.cur.execute(f'''
+      INSERT INTO
+        `epimetric_latest` (`epimetric_id`, `signal_key_id`, `geo_key_id`, `time_type`,
+	      `time_value`, `value_updated_timestamp`,
+        `value`, `stderr`, `sample_size`,
+        `issue`, `lag`, `missing_value`,
+        `missing_stderr`,`missing_sample_size`)
+      VALUES
+        (15, 42, 96, 'day', 20200422,
+          123, 1, 2, 3, 20200422, 0, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}),
+        (16, 42, 97, 'day', 20200422,
+          789, 1, 2, 3, 20200423, 1, {Nans.NOT_MISSING}, {Nans.NOT_MISSING}, {Nans.NOT_MISSING})
+    ''')
+    self.cnx.commit()
+
+    results = self._make_request()
+    
+    # make sure the tables are empty
+    self.assertEqual(results, {
+      'result': -2,
+      'epidata': [],
+      'message': 'no results',
+    })
+
+    # update the cache
+    args = []
+    main(args)
+
+    results = self._make_request()
+
+    # make sure the cache was actually served
+    self.assertEqual(results, {
+      'result': 1,
+      'epidata': [{'signal': 'sig', 'source': 'src'},
+                  {'signal': 'sig', 'source': 'src'}],
+      'message': 'success',
+    })

--- a/integrations/acquisition/covidcast/test_coverage_crossref_update.py
+++ b/integrations/acquisition/covidcast/test_coverage_crossref_update.py
@@ -91,12 +91,12 @@ class CoverageCrossrefTests(unittest.TestCase):
     """Populate, query, cache, query, and verify the cache."""
 
     # insert dummy data
-    self.cur.execute(f'''
+    self.cur.execute('''
       INSERT INTO `signal_dim` (`signal_key_id`, `source`, `signal`)
       VALUES
         (42, 'src', 'sig');
     ''')
-    self.cur.execute(f'''
+    self.cur.execute('''
       INSERT INTO `geo_dim` (`geo_key_id`, `geo_type`, `geo_value`)
       VALUES
         (96, 'state', 'pa'), 
@@ -126,9 +126,8 @@ class CoverageCrossrefTests(unittest.TestCase):
       'message': 'no results',
     })
 
-    # update the cache
-    args = []
-    main(args)
+    # update the coverage crossref table
+    main()
 
     results = self._make_request()
 

--- a/integrations/acquisition/covidcast/test_coverage_crossref_update.py
+++ b/integrations/acquisition/covidcast/test_coverage_crossref_update.py
@@ -28,8 +28,9 @@ class CoverageCrossrefTests(CovidcastBase):
     self._db._cursor.execute('TRUNCATE TABLE `coverage_crossref`')
 
   @staticmethod
-  def _make_request():
-    params = {'geo': 'state:*'}
+  def _make_request(params=None):
+    if params is None:
+        params = {'geo': 'state:*'}
     response = requests.get(f"{Epidata.BASE_URL}/covidcast/geo_coverage", params=params, auth=Epidata.auth)
     response.raise_for_status()
     return response.json()
@@ -78,7 +79,25 @@ class CoverageCrossrefTests(CovidcastBase):
 
     results = self._make_request()
 
-    # make sure the cache was actually served
+    # make sure the data was actually served
+    self.assertEqual(results, {
+      'result': 1,
+      'epidata': [{'signal': 'sig', 'source': 'src'}],
+      'message': 'success',
+    })
+
+    results = self._make_request(params = {'geo': 'hrr:*'})
+
+    # make sure the tables are empty
+    self.assertEqual(results, {
+      'result': -2,
+      'epidata': [],
+      'message': 'no results',
+    })
+
+    results = self._make_request(params = {'geo': 'state:pa'})
+
+    # make sure the data was actually served
     self.assertEqual(results, {
       'result': 1,
       'epidata': [{'signal': 'sig', 'source': 'src'}],

--- a/integrations/acquisition/covidcast/test_coverage_crossref_update.py
+++ b/integrations/acquisition/covidcast/test_coverage_crossref_update.py
@@ -46,7 +46,6 @@ class CoverageCrossrefTests(unittest.TestCase):
     cur.execute("truncate table geo_dim")
     cur.execute("truncate table signal_dim")
     cur.execute("truncate table coverage_crossref")
-    cur.execute("truncate table coverage_crossref_load")
     cnx.commit()
     cur.close()
 

--- a/src/acquisition/covidcast/database.py
+++ b/src/acquisition/covidcast/database.py
@@ -585,22 +585,6 @@ FROM {self.history_view} h JOIN (
       TRUNCATE coverage_crossref;
     '''
 
-    coverage_crossref_drop_signal_index = '''
-     DROP INDEX coverage_crossref_signal_key_id on coverage_crossref;
-    '''
-    
-    coverage_crossref_drop_geo_index = '''
-     DROP INDEX coverage_crossref_geo_key_id on coverage_crossref;
-    '''
-
-    coverage_crossref_create_signal_index = '''
-      CREATE INDEX coverage_crossref_signal_key_id ON coverage_crossref (signal_key_id);
-    '''
-
-    coverage_crossref_create_geo_index = '''
-      CREATE INDEX coverage_crossref_geo_key_id ON coverage_crossref (geo_key_id);
-    '''
-
     coverage_crossref_update_sql = '''
       INSERT INTO coverage_crossref
       SELECT * FROM coverage_crossref_load;
@@ -615,28 +599,12 @@ FROM {self.history_view} h JOIN (
     self._cursor.execute(coverage_crossref_delete_sql)
     logger.info(f"coverage_crossref_delete_sql:{self._cursor.rowcount}")
 
-    # These will fail if the index does not exist, which is fine
-    try:
-      self._cursor.execute(coverage_crossref_drop_signal_index)
-      logger.info(f"coverage_crossref_drop_signal_index:{self._cursor.rowcount}")
-    except Exception as e:
-      logger.info(f"coverage_crossref_drop_signal_index:{e}")
-
-    try:
-      self._cursor.execute(coverage_crossref_drop_geo_index)
-      logger.info(f"coverage_crossref_drop_geo_index:{self._cursor.rowcount}")
-    except Exception as e:
-      logger.info(f"coverage_crossref_drop_geo_index:{e}")
-
     self._cursor.execute(coverage_crossref_update_sql)
     logger.info(f"coverage_crossref_update_sql:{self._cursor.rowcount}")
     main_rowcount = self._cursor.rowcount
 
-    self._cursor.execute(coverage_crossref_create_signal_index)
-    logger.info(f"coverage_crossref_create_signal_index:{self._cursor.rowcount}")
-
-    self._cursor.execute(coverage_crossref_create_geo_index)
-    logger.info(f"coverage_crossref_create_geo_index:{self._cursor.rowcount}")
+    self._cursor.execute(coverage_crossref_load_delete_sql)
+    logger.info(f"coverage_crossref_load_delete_sql:{self._cursor.rowcount}")
     self.commit()
 
     return main_rowcount

--- a/src/acquisition/covidcast/database.py
+++ b/src/acquisition/covidcast/database.py
@@ -566,11 +566,11 @@ FROM {self.history_view} h JOIN (
     """Compute coverage_crossref table."""
     logger = get_structured_logger("compute_coverage_crossref")
 
-    coverage_crossref_load_delete_sql = f'''
+    coverage_crossref_load_delete_sql = '''
       TRUNCATE coverage_crossref_load;
       '''
 
-    coverage_crossref_compute_sql = f'''
+    coverage_crossref_compute_sql = '''
       INSERT INTO coverage_crossref_load
       SELECT
           el.signal_key_id,
@@ -581,27 +581,27 @@ FROM {self.history_view} h JOIN (
       GROUP BY el.signal_key_id, el.geo_key_id;
       '''
     
-    coverage_crossref_delete_sql = f'''
+    coverage_crossref_delete_sql = '''
       TRUNCATE coverage_crossref;
     '''
 
-    coverage_crossref_drop_signal_index = f'''
+    coverage_crossref_drop_signal_index = '''
      DROP INDEX coverage_crossref_signal_key_id on coverage_crossref;
     '''
     
-    coverage_crossref_drop_geo_index = f'''
+    coverage_crossref_drop_geo_index = '''
      DROP INDEX coverage_crossref_geo_key_id on coverage_crossref;
     '''
 
-    coverage_crossref_create_signal_index = f'''
+    coverage_crossref_create_signal_index = '''
       CREATE INDEX coverage_crossref_signal_key_id ON coverage_crossref (signal_key_id);
     '''
 
-    coverage_crossref_create_geo_index = f'''
+    coverage_crossref_create_geo_index = '''
       CREATE INDEX coverage_crossref_geo_key_id ON coverage_crossref (geo_key_id);
     '''
 
-    coverage_crossref_update_sql = f'''
+    coverage_crossref_update_sql = '''
       INSERT INTO coverage_crossref
       SELECT * FROM coverage_crossref_load;
     '''
@@ -615,11 +615,18 @@ FROM {self.history_view} h JOIN (
     self._cursor.execute(coverage_crossref_delete_sql)
     logger.info(f"coverage_crossref_delete_sql:{self._cursor.rowcount}")
 
-    self._cursor.execute(coverage_crossref_drop_signal_index)
-    logger.info(f"coverage_crossref_drop_signal_index:{self._cursor.rowcount}")
+    # These will fail if the index does not exist, which is fine
+    try:
+      self._cursor.execute(coverage_crossref_drop_signal_index)
+      logger.info(f"coverage_crossref_drop_signal_index:{self._cursor.rowcount}")
+    except Exception as e:
+      logger.info(f"coverage_crossref_drop_signal_index:{e}")
 
-    self._cursor.execute(coverage_crossref_drop_geo_index)
-    logger.info(f"coverage_crossref_drop_geo_index:{self._cursor.rowcount}")
+    try:
+      self._cursor.execute(coverage_crossref_drop_geo_index)
+      logger.info(f"coverage_crossref_drop_geo_index:{self._cursor.rowcount}")
+    except Exception as e:
+      logger.info(f"coverage_crossref_drop_geo_index:{e}")
 
     self._cursor.execute(coverage_crossref_update_sql)
     logger.info(f"coverage_crossref_update_sql:{self._cursor.rowcount}")

--- a/src/ddl/v4_schema.sql
+++ b/src/ddl/v4_schema.sql
@@ -169,9 +169,7 @@ CREATE TABLE `coverage_crossref_load` (
     `signal_key_id` bigint NOT NULL,
     `geo_key_id` bigint NOT NULL,
     `min_time_value` int NOT NULL,
-    `max_time_value` int NOT NULL,
-    UNIQUE INDEX coverage_crossref_signal_key_id ON coverage_crossref (signal_key_id),
-    UNIQUE INDEX coverage_crossref_geo_key_id ON coverage_crossref (geo_key_id)
+    `max_time_value` int NOT NULL
 ) ENGINE=InnoDB;
 
 CREATE TABLE `coverage_crossref` (
@@ -179,8 +177,8 @@ CREATE TABLE `coverage_crossref` (
     `geo_key_id` bigint NOT NULL,
     `min_time_value` int NOT NULL,
     `max_time_value` int NOT NULL,
-    UNIQUE INDEX coverage_crossref_signal_key_id ON coverage_crossref (signal_key_id),
-    UNIQUE INDEX coverage_crossref_geo_key_id ON coverage_crossref (geo_key_id)
+    UNIQUE INDEX coverage_crossref_signal_key_id (`signal_key_id`),
+    UNIQUE INDEX coverage_crossref_geo_key_id (`geo_key_id`)
 ) ENGINE=InnoDB;
 
 CREATE OR REPLACE VIEW `coverage_crossref_v` AS

--- a/src/ddl/v4_schema.sql
+++ b/src/ddl/v4_schema.sql
@@ -165,6 +165,15 @@ CREATE TABLE `covidcast_meta_cache` (
 ) ENGINE=InnoDB;
 INSERT INTO covidcast_meta_cache VALUES (0, '[]');
 
+CREATE TABLE `coverage_crossref_load` (
+    `signal_key_id` bigint NOT NULL,
+    `geo_key_id` bigint NOT NULL,
+    `min_time_value` int NOT NULL,
+    `max_time_value` int NOT NULL,
+    UNIQUE INDEX coverage_crossref_signal_key_id ON coverage_crossref (signal_key_id),
+    UNIQUE INDEX coverage_crossref_geo_key_id ON coverage_crossref (geo_key_id)
+) ENGINE=InnoDB;
+
 CREATE TABLE `coverage_crossref` (
     `signal_key_id` bigint NOT NULL,
     `geo_key_id` bigint NOT NULL,

--- a/src/ddl/v4_schema.sql
+++ b/src/ddl/v4_schema.sql
@@ -164,3 +164,24 @@ CREATE TABLE `covidcast_meta_cache` (
     PRIMARY KEY (`timestamp`)
 ) ENGINE=InnoDB;
 INSERT INTO covidcast_meta_cache VALUES (0, '[]');
+
+CREATE TABLE `coverage_crossref` (
+    `signal_key_id` bigint NOT NULL,
+    `geo_key_id` bigint NOT NULL,
+    `min_time_value` int NOT NULL,
+    `max_time_value` int NOT NULL,
+    UNIQUE INDEX coverage_crossref_signal_key_id ON coverage_crossref (signal_key_id),
+    UNIQUE INDEX coverage_crossref_geo_key_id ON coverage_crossref (geo_key_id)
+) ENGINE=InnoDB;
+
+CREATE OR REPLACE VIEW `coverage_crossref_v` AS
+SELECT
+    `sd`.`source`,
+    `sd`.`signal`,
+    `gd`.`geo_type`,
+    `gd`.`geo_value`,
+    `cc`.`min_time_value`,
+    `cc`.`max_time_value`
+FROM `coverage_crossref` `cc`
+JOIN `signal_dim` `sd` USING (`signal_key_id`)
+JOIN `geo_dim` `gd` USING (`geo_key_id`);

--- a/src/ddl/v4_schema.sql
+++ b/src/ddl/v4_schema.sql
@@ -177,8 +177,8 @@ CREATE TABLE `coverage_crossref` (
     `geo_key_id` bigint NOT NULL,
     `min_time_value` int NOT NULL,
     `max_time_value` int NOT NULL,
-    UNIQUE INDEX coverage_crossref_signal_key_id (`signal_key_id`),
-    UNIQUE INDEX coverage_crossref_geo_key_id (`geo_key_id`)
+    UNIQUE INDEX coverage_crossref_geo_sig (`geo_key_id`, `signal_key_id`),
+    INDEX coverage_crossref_sig_geo (`signal_key_id`, `geo_key_id`)
 ) ENGINE=InnoDB;
 
 CREATE OR REPLACE VIEW `coverage_crossref_v` AS

--- a/src/ddl/v4_schema.sql
+++ b/src/ddl/v4_schema.sql
@@ -165,13 +165,6 @@ CREATE TABLE `covidcast_meta_cache` (
 ) ENGINE=InnoDB;
 INSERT INTO covidcast_meta_cache VALUES (0, '[]');
 
-CREATE TABLE `coverage_crossref_load` (
-    `signal_key_id` bigint NOT NULL,
-    `geo_key_id` bigint NOT NULL,
-    `min_time_value` int NOT NULL,
-    `max_time_value` int NOT NULL
-) ENGINE=InnoDB;
-
 CREATE TABLE `coverage_crossref` (
     `signal_key_id` bigint NOT NULL,
     `geo_key_id` bigint NOT NULL,

--- a/src/ddl/v4_schema_aliases.sql
+++ b/src/ddl/v4_schema_aliases.sql
@@ -8,4 +8,4 @@
 CREATE VIEW `epidata`.`epimetric_full_v`     AS SELECT * FROM `covid`.`epimetric_full_v`;
 CREATE VIEW `epidata`.`epimetric_latest_v`   AS SELECT * FROM `covid`.`epimetric_latest_v`;
 CREATE VIEW `epidata`.`covidcast_meta_cache` AS SELECT * FROM `covid`.`covidcast_meta_cache`;
-CREATE VIEW `epidata`.`coverage_crossref_v` AS SELECT * FROM `covid`.`coverage_crossref_v`;
+CREATE VIEW `epidata`.`coverage_crossref_v`  AS SELECT * FROM `covid`.`coverage_crossref_v`;

--- a/src/ddl/v4_schema_aliases.sql
+++ b/src/ddl/v4_schema_aliases.sql
@@ -8,3 +8,4 @@
 CREATE VIEW `epidata`.`epimetric_full_v`     AS SELECT * FROM `covid`.`epimetric_full_v`;
 CREATE VIEW `epidata`.`epimetric_latest_v`   AS SELECT * FROM `covid`.`epimetric_latest_v`;
 CREATE VIEW `epidata`.`covidcast_meta_cache` AS SELECT * FROM `covid`.`covidcast_meta_cache`;
+CREATE VIEW `epidata`.`coverage_crossref_v`  AS SELECT * FROM `covid`.`coverage_crossref_v`;

--- a/src/ddl/v4_schema_aliases.sql
+++ b/src/ddl/v4_schema_aliases.sql
@@ -8,3 +8,4 @@
 CREATE VIEW `epidata`.`epimetric_full_v`     AS SELECT * FROM `covid`.`epimetric_full_v`;
 CREATE VIEW `epidata`.`epimetric_latest_v`   AS SELECT * FROM `covid`.`epimetric_latest_v`;
 CREATE VIEW `epidata`.`covidcast_meta_cache` AS SELECT * FROM `covid`.`covidcast_meta_cache`;
+CREATE VIEW `epidata`.`coverage_crossref_v` AS SELECT * FROM `covid`.`coverage_crossref_v`;

--- a/src/ddl/v4_schema_aliases.sql
+++ b/src/ddl/v4_schema_aliases.sql
@@ -8,4 +8,3 @@
 CREATE VIEW `epidata`.`epimetric_full_v`     AS SELECT * FROM `covid`.`epimetric_full_v`;
 CREATE VIEW `epidata`.`epimetric_latest_v`   AS SELECT * FROM `covid`.`epimetric_latest_v`;
 CREATE VIEW `epidata`.`covidcast_meta_cache` AS SELECT * FROM `covid`.`covidcast_meta_cache`;
-CREATE VIEW `epidata`.`coverage_crossref_v`  AS SELECT * FROM `covid`.`coverage_crossref_v`;

--- a/src/maintenance/coverage_crossref_updater.py
+++ b/src/maintenance/coverage_crossref_updater.py
@@ -18,7 +18,7 @@ def get_argument_parser():
   return parser
 
 
-def main(args, epidata_impl=Epidata, database_impl=Database):
+def main(args, database_impl=Database):
   """Updates the table for the `coverage_crossref`.
 
   `args`: parsed command-line arguments
@@ -40,11 +40,11 @@ def main(args, epidata_impl=Epidata, database_impl=Database):
     database.disconnect(True)
     raise
 
-  args = ("success",1)
+  result = ("success",1)
   if coverage==0:
-    args = ("no results",-2)
+    result = ("no results",-2)
 
-  logger.info('coverage_crossref result: %s (code %d)' % args)
+  logger.info('coverage_crossref result: %s (code %d)' % result)
 
 
   logger.info(

--- a/src/maintenance/coverage_crossref_updater.py
+++ b/src/maintenance/coverage_crossref_updater.py
@@ -10,24 +10,11 @@ from delphi.epidata.acquisition.covidcast.database import Database
 from delphi_utils import get_structured_logger
 from delphi.epidata.client.delphi_epidata import Epidata
 
-def get_argument_parser():
-  """Define command line arguments."""
 
-  parser = argparse.ArgumentParser()
-  parser.add_argument("--log_file", help="filename for log output")
-  return parser
+def main(database_impl=Database):
+  """Updates the table for the `coverage_crossref`."""
 
-
-def main(args, database_impl=Database):
-  """Updates the table for the `coverage_crossref`.
-
-  `args`: parsed command-line arguments
-  """
-  log_file = None
-
-  logger = get_structured_logger(
-      "coverage_crossref_updater",
-      filename=log_file)
+  logger = get_structured_logger("coverage_crossref_updater")
   start_time = time.time()
   database = database_impl()
   database.connect()
@@ -54,5 +41,4 @@ def main(args, database_impl=Database):
 
 
 if __name__ == '__main__':
-  if not main(get_argument_parser().parse_args()):
-    sys.exit(1)
+  main()

--- a/src/maintenance/coverage_crossref_updater.py
+++ b/src/maintenance/coverage_crossref_updater.py
@@ -1,0 +1,58 @@
+"""Updates the table for the `coverage_crossref` endpoint."""
+
+# standard library
+import argparse
+import sys
+import time
+
+# first party
+from delphi.epidata.acquisition.covidcast.database import Database
+from delphi_utils import get_structured_logger
+from delphi.epidata.client.delphi_epidata import Epidata
+
+def get_argument_parser():
+  """Define command line arguments."""
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--log_file", help="filename for log output")
+  return parser
+
+
+def main(args, epidata_impl=Epidata, database_impl=Database):
+  """Updates the table for the `coverage_crossref`.
+
+  `args`: parsed command-line arguments
+  """
+  log_file = None
+
+  logger = get_structured_logger(
+      "coverage_crossref_updater",
+      filename=log_file)
+  start_time = time.time()
+  database = database_impl()
+  database.connect()
+
+  # compute and update coverage_crossref
+  try:
+    coverage = database.compute_coverage_crossref()
+  except:
+    # clean up before failing
+    database.disconnect(True)
+    raise
+
+  args = ("success",1)
+  if coverage==0:
+    args = ("no results",-2)
+
+  logger.info('coverage_crossref result: %s (code %d)' % args)
+
+
+  logger.info(
+      "Generated and updated covidcast metadata",
+      total_runtime_in_seconds=round(time.time() - start_time, 2))
+  return True
+
+
+if __name__ == '__main__':
+  if not main(get_argument_parser().parse_args()):
+    sys.exit(1)

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -557,7 +557,7 @@ def handle_geo_coverage():
 
     q.apply_geo_filters("geo_type", "geo_value", geo_sets)
     q.set_sort_order("source", "signal")
-    q.group_by = fields_string # this condenses duplicate results, similar to `SELECT DISTINCT`
+    q.group_by = ["c." + field for field in fields_string] # this condenses duplicate results, similar to `SELECT DISTINCT`
 
     return execute_query(q.query, q.params, fields_string, [], [])
 

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -548,14 +548,14 @@ def handle_geo_coverage():
     For a specific geo returns the signal coverage (number of signals for a given geo_type)
     """
 
-    geo_type, geo_value = request.values.get("geo").split(":", 1)
+    geo_sets = parse_geo_sets()
 
-    q = QueryBuilder("covid.coverage_crossref_v", "c")
+    q = QueryBuilder("coverage_crossref_v", "c")
     fields_string = ["source", "signal"]
 
     q.set_fields(fields_string)
 
-    q.where(geo_type=geo_type, geo_value=geo_value)
+    q.apply_geo_filters("geo_type", "geo_value", geo_sets)
     q.set_sort_order("source", "signal")
 
     return execute_query(q.query, q.params, fields_string, [], [])

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -542,6 +542,23 @@ def handle_coverage():
 
     return execute_query(q.query, q.params, fields_string, fields_int, [], transform=transform_row)
 
+@bp.route("/geo_coverage", methods=("GET", "POST"))
+def handle_geo_coverage():
+    """
+    For a specific geo returns the signal coverage (number of signals for a given geo_type)
+    """
+
+    geo_type, geo_value = request.values.get("geo").split(":", 1)
+
+    q = QueryBuilder("covid.coverage_crossref_v", "c")
+    fields_string = ["source", "signal"]
+
+    q.set_fields(fields_string)
+
+    q.where(geo_type=geo_type, geo_value=geo_value)
+    q.set_sort_order("source", "signal")
+
+    return execute_query(q.query, q.params, fields_string, [], [])
 
 @bp.route("/anomalies", methods=("GET", "POST"))
 def handle_anomalies():

--- a/tests/acquisition/covidcast/test_database.py
+++ b/tests/acquisition/covidcast/test_database.py
@@ -78,6 +78,22 @@ class UnitTests(unittest.TestCase):
     self.assertIn('timestamp', sql)
     self.assertIn('epidata', sql)
 
+  def test_compute_coverage_crossref_query(self):
+    """Query to update the compute crossref looks sensible.
+
+    NOTE: Actual behavior is tested by integration test.
+    """
+
+    mock_connector = MagicMock()
+    database = Database()
+    database.connect(connector_impl=mock_connector)
+
+    database.compute_coverage_crossref()
+
+    connection = mock_connector.connect()
+    cursor = connection.cursor()
+    self.assertTrue(cursor.execute.called)
+
   def test_insert_or_update_batch_exception_reraised(self):
     """Test that an exception is reraised"""
     mock_connector = MagicMock()


### PR DESCRIPTION
addresses issue(s) #1583 

### Summary:

Create a new endpoint that returns a list of signals when given a geo. There were other endpoints that did this in the past, but the tables they read from are no longer around in epi v4. Starting from scratch will be much quicker and rely less on legacy code.

Once this is merged, I will also make issues to delete the old coverage code so that we don't have duplicate endpoints.
<!--
  describe what this PR changes

-->

### Prerequisites:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [X] Build is successful
- [X] Code is cleaned up and formatted
