### PR TITLE
updated min year

### DIFF
--- a/src/acquisition/covidcast/csv_importer.py
+++ b/src/acquisition/covidcast/csv_importer.py
@@ -68,7 +68,7 @@ class CsvImporter:
   REQUIRED_COLUMNS = {'geo_id', 'val', 'se', 'sample_size'}
 
   # reasonable time bounds for sanity checking time values
-  MIN_YEAR = 2019
+  MIN_YEAR = 2017 # google-symptoms released earlier data
   MAX_YEAR = 2030
 
   # The datatypes expected by pandas.read_csv. Int64 is like float in that it can handle both numbers and nans.


### PR DESCRIPTION
addresses issue(s) #1582 and is preq for [patch google symptom early 2017-08-15 - 2020-02-19 #2107](https://github.com/cmu-delphi/covidcast-indicators/issues/2107)

### Summary:

some point in time google symptom released data for earlier (2017-08-15) than the previous oldest date of (2020-02-20)
While attempting to patch data, acquisition failed due to MIN_YEAR constant being later than the newly available data.

### Prerequisites:

- [ x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [ x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [ ] Code is cleaned up and formatted
