### PR TITLE
NHSN documentation fixes for page title and heading

### DIFF
--- a/docs/api/covidcast-signals/nhsn.md
+++ b/docs/api/covidcast-signals/nhsn.md
@@ -4,7 +4,7 @@ parent: Data Sources and Signals
 grand_parent: Main Endpoint (COVIDcast)
 nav_order: 1
 ---
-# National Syndromic Surveillance Program Emergency Department Visits
+# National Healthcare Safety Network Respiratory Hospitalizations
 {: .no_toc}
 
 * **Source name:** `nhsn`

--- a/docs/api/covidcast-signals/nhsn.md
+++ b/docs/api/covidcast-signals/nhsn.md
@@ -1,5 +1,5 @@
 ---
-title: NHSN ED Visits
+title: NHSN Respiratory Hospitalizations
 parent: Data Sources and Signals
 grand_parent: Main Endpoint (COVIDcast)
 nav_order: 1


### PR DESCRIPTION
while we figure out the verbiage for the relationship between data from source `hhs` and source `nhsn` in #1581, this fixes just the text that was inherited from the `nssp` documentation, so we can release it to the public site.