### PR TITLE
pluralize 'indicators' in a few places in the api documentation

### DIFF
--- a/docs/api/covidcast-signals/dsew-cpr.md
+++ b/docs/api/covidcast-signals/dsew-cpr.md
@@ -83,5 +83,5 @@ The CPR is prepared with an internal lag of 1-2 days for most signals. The file 
 
 ## Source and Licensing
 
-This indicator mirrors and lightly aggregates data originally published by the Data Strategy and Execution Workgroup via [HealthData.gov](https://healthdata.gov/). As a work of the US government, the original data is in the [public domain](https://www.usa.gov/government-works).
+These indicators mirror and lightly aggregate data originally published by the Data Strategy and Execution Workgroup via [HealthData.gov](https://healthdata.gov/). As a work of the US government, the original data is in the [public domain](https://www.usa.gov/government-works).
 

--- a/docs/api/covidcast-signals/hhs.md
+++ b/docs/api/covidcast-signals/hhs.md
@@ -26,7 +26,7 @@ datasets is mirrored in Epidata at the following endpoint:
 That dataset contains dozens of columns that break down hospital
 resource usage in different ways.
 
-This indicator makes available several commonly-used columns and combinations of
+These indicators make available several commonly-used columns and combinations of
 columns, aggregated geographically. In particular, we include the sum of all
 adult and pediatric COVID-19 hospital admissions. This sum is used as the
 "ground truth" for hospitalizations by the
@@ -116,7 +116,7 @@ is first published.
 
 ## Source and Licensing
 
-This indicator mirrors and lightly aggregates data originally
+These indicators mirror and lightly aggregate data originally
 published by the U.S. Department of Health & Human Services.
 As a work of the US government, the original data is in the
 [public domain](https://www.usa.gov/government-works).

--- a/docs/api/covidcast-signals/youtube-survey.md
+++ b/docs/api/covidcast-signals/youtube-survey.md
@@ -42,7 +42,7 @@ note that values from the same dates differ between the two surveys for
 
 As of late April 2020, the number of Youtube survey responses we received each
 day was 4-7 thousand. This was not enough coverage to report at finer
-geographic levels, so this indicator only reports at the state level. The
+geographic levels, so these indicators only report at the state level. The
 survey ran from April 21, 2020 to June 17, 2020, collecting about 159
 thousand responses in the United States in that time.
 
@@ -122,7 +122,7 @@ available for more locations than the raw signals.
 
 ## Lag and Backfill
 
-This indicator has a lag of 2 days. Reported values can be revised for one
+These indicators have a lag of 2 days. Reported values can be revised for one
 day (corresponding to a lag of 3 days), due to how we receive survey
 responses. However, these tend to be associated with minimal changes in
 value.
@@ -172,5 +172,5 @@ longer time period.
 
 ## Source and Licensing
 
-This indicator aggregates responses from a Delphi-run survey that is hosted on the Youtube platform.
+These indicators aggregate responses from a Delphi-run survey that is hosted on the Youtube platform.
 The data is licensed as [CC BY-NC](../covidcast_licensing.md#creative-commons-attribution-noncommercial).


### PR DESCRIPTION
This brings usage of the term "indicator" more in line with what we have been calling "signal" (as discussed in slack).