### PR TITLE
remove pinned version of jinja from requirements

### DIFF
--- a/requirements.api.txt
+++ b/requirements.api.txt
@@ -2,7 +2,6 @@ delphi_utils
 epiweeks==2.1.2
 Flask==2.2.5
 Flask-Limiter==3.3.0
-jinja2==3.1.4
 more_itertools==8.4.0
 mysqlclient==2.1.1
 orjson==3.9.15


### PR DESCRIPTION
Our code doesnt directly use jinja, but Flask does (or at least, it did at one point).  In the past, we pinned jinja to earlier versions to get around an incompatibility with jinja 3.1.0 (in #891 and #877), but dependabot has since taken us well past that (first in #1370 and most recently in #1610).  This PR removes jinja from our enumerated requirements altogether.