### PR TITLE
/indicator_geo_coverage endpoint

### DIFF
--- a/dev/docker/python/Dockerfile
+++ b/dev/docker/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.8-bookworm
 
 RUN apt-get update && apt-get install -y r-base && Rscript -e "install.packages(c('httr','xml2'))"
 

--- a/integrations/server/test_covidcast_endpoints.py
+++ b/integrations/server/test_covidcast_endpoints.py
@@ -399,13 +399,7 @@ class CovidcastEndpointTests(CovidcastBase):
 
         update_crossref()
 
-        response = requests.get(
-            f"{BASE_URL}/geo_indicator_coverage",
-            params=dict(data_source="src", signals="sig"),
-        )
-        response.raise_for_status()
-        out = response.json()
-
+        out = self._fetch("/geo_indicator_coverage", data_source="src", signals="sig")
         self.assertEqual(len(out["epidata"]), 2)
         self.assertEqual(out["epidata"], ['state:ny', 'state:pa'])
 

--- a/integrations/server/test_covidcast_endpoints.py
+++ b/integrations/server/test_covidcast_endpoints.py
@@ -388,8 +388,8 @@ class CovidcastEndpointTests(CovidcastBase):
             out = self._fetch("/coverage", signal=first.signal_pair(), geo_type="doesnt_exist", format="json")
             self.assertEqual(len(out), 0)
 
-    def test_indicator_geo_coverage(self):
-        """Request a geo_type:geo_value from the /indicator_geo_coverage endpoint."""
+    def test_geo_indicator_coverage(self):
+        """Request a geo_type:geo_value from the /geo_indicator_coverage endpoint."""
 
         self._insert_rows([
             CovidcastTestRow.make_default_row(geo_type="state", geo_value="pa"),
@@ -400,7 +400,7 @@ class CovidcastEndpointTests(CovidcastBase):
         update_crossref()
 
         response = requests.get(
-            f"{BASE_URL}/indicator_geo_coverage",
+            f"{BASE_URL}/geo_indicator_coverage",
             params=dict(data_source="src", signals="sig"),
         )
         response.raise_for_status()

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -565,7 +565,7 @@ def handle_geo_coverage():
 def handle_indicator_geo_coverage():
     source_signal_sets = parse_source_signal_sets()
     source_signal_sets = restrict_by_roles(source_signal_sets)
-    source_signal_sets, alias_mapper = create_source_signal_alias_mapper(source_signal_sets)
+    source_signal_sets, _ = create_source_signal_alias_mapper(source_signal_sets)
 
     q = QueryBuilder("coverage_crossref_v", "c")
     fields_string = ["geo_type", "geo_value"]

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -561,6 +561,26 @@ def handle_geo_coverage():
 
     return execute_query(q.query, q.params, fields_string, [], [])
 
+@bp.route("/indicator_geo_coverage", methods=("GET", "POST"))
+def handle_indicator_geo_coverage():
+    source_signal_sets = parse_source_signal_sets()
+    source_signal_sets = restrict_by_roles(source_signal_sets)
+    source_signal_sets, alias_mapper = create_source_signal_alias_mapper(source_signal_sets)
+
+    q = QueryBuilder("coverage_crossref_v", "c")
+    fields_string = ["geo_type", "geo_value"]
+
+    q.set_fields(fields_string)
+
+    q.apply_source_signal_filters("source", "signal", source_signal_sets)
+    q.set_sort_order("geo_type", "geo_value")
+    q.group_by = ["c." + field for field in fields_string] # this condenses duplicate results, similar to `SELECT DISTINCT`
+
+    def transform_row(row, proxy):
+        return f"{row['geo_type']}:{row['geo_value']}"
+
+    return execute_query(q.query, q.params, fields_string, [], [], transform=transform_row)
+
 @bp.route("/anomalies", methods=("GET", "POST"))
 def handle_anomalies():
     """

--- a/src/server/endpoints/covidcast.py
+++ b/src/server/endpoints/covidcast.py
@@ -561,8 +561,8 @@ def handle_geo_coverage():
 
     return execute_query(q.query, q.params, fields_string, [], [])
 
-@bp.route("/indicator_geo_coverage", methods=("GET", "POST"))
-def handle_indicator_geo_coverage():
+@bp.route("/geo_indicator_coverage", methods=("GET", "POST"))
+def handle_geo_indicator_coverage():
     source_signal_sets = parse_source_signal_sets()
     source_signal_sets = restrict_by_roles(source_signal_sets)
     source_signal_sets, _ = create_source_signal_alias_mapper(source_signal_sets)


### PR DESCRIPTION
### Summary:

Added new /indicator_geo_coverage endpoint.
It accepts source:signals and returns list of available geo_type:geo_value pairs.
This endpoint is needed for the EpiPortal to show the only list of available geos for the selected indicators.

### Prerequisites:

- [ ] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted
