### PR TITLE
docs: fixes the `epidatpy` code samples and improves formatting on the Geographic Codes page

### DIFF
--- a/docs/api/01meta.md
+++ b/docs/api/01meta.md
@@ -129,11 +129,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_meta()
-print(res)
+print(res()['epidata'])
 ```
   </div>
 

--- a/docs/api/cdc.md
+++ b/docs/api/cdc.md
@@ -137,11 +137,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pvt_cdc(auth='auth_token', locations=['nat'], epiweeks=[201501])
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/covid_hosp.md
+++ b/docs/api/covid_hosp.md
@@ -240,11 +240,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
-res = epidata.pub_covid_hosp(states="MA", dates=20200510)
-print(res)
+res = epidata.pub_covid_hosp_state_timeseries(states="MA", dates=20200510)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/covid_hosp_facility.md
+++ b/docs/api/covid_hosp_facility.md
@@ -227,11 +227,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_covid_hosp_facility(hospital_pks="390119", collection_weeks=EpiRange(20201201, 20201207))
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/covid_hosp_facility_lookup.md
+++ b/docs/api/covid_hosp_facility_lookup.md
@@ -145,11 +145,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_covid_hosp_facility_lookup(city="southlake")
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/delphi.md
+++ b/docs/api/delphi.md
@@ -197,11 +197,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
-res = epidata.delphi('ec', 201501)
-print(res['result'], res['message'], len(res['epidata']))
+res = epidata.pub_delphi('ec', 201501)
+print(res()['epidata'])
 ```
   </div>
 

--- a/docs/api/dengue_digital_surveillance.md
+++ b/docs/api/dengue_digital_surveillance.md
@@ -130,11 +130,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
-res = epidata.dengue_sensors('auth_token', ['ght'], ['pr'], [201501])
-print(res['result'], res['message'], len(res['epidata']))
+res = epidata.pvt_dengue_sensors('auth_token', ['ght'], ['pr'], [201501])
+print(res.df())
 ```
   </div>
 

--- a/docs/api/dengue_nowcast.md
+++ b/docs/api/dengue_nowcast.md
@@ -125,11 +125,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
-res = epidata.dengue_nowcast(['pr'], EpiRange(201401, 202301))
-print(res['result'], res['message'], len(res['epidata']))
+res = epidata.pub_dengue_nowcast(['pr'], EpiRange(201401, 202301))
+print(res.df())
 ```
   </div>
 

--- a/docs/api/ecdc_ili.md
+++ b/docs/api/ecdc_ili.md
@@ -125,11 +125,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
-res = epidata.ecdc_ili(['austria'], [202001, 202002])
-print(res['result'], res['message'], len(res['epidata']))
+res = epidata.pub_ecdc_ili(['austria'], [202001, 202002])
+print(res.df())
 ```
   </div>
 

--- a/docs/api/flusurv.md
+++ b/docs/api/flusurv.md
@@ -274,11 +274,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_flusurv(locations="CA", epiweeks=EpiRange(201701, 201801))
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/flusurv.md
+++ b/docs/api/flusurv.md
@@ -292,21 +292,7 @@ print(res)
 ```
   </div>
 
-  <div class="tab-content" data-tab="js" markdown="1">
 
-The JavaScript client is available [here](https://github.com/cmu-delphi/delphi-epidata/blob/main/src/client/delphi_epidata.js).
-
-```html
-<!-- Imports -->
-<script src="delphi_epidata.js"></script>
-<!-- Fetch data -->
-<script>
-  EpidataAsync.flusurv('CA', [EpidataAsync.range(201701, 201801)]).then((res) => {
-    console.log(res.result, res.message, res.epidata != null ? res.epidata.length : 0);
-  });
-</script>
-```
-  </div>
 
 </div>
 

--- a/docs/api/fluview.md
+++ b/docs/api/fluview.md
@@ -182,11 +182,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_fluview(regions="nat", epiweeks=EpiRange(201501, 201510))
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/fluview.md
+++ b/docs/api/fluview.md
@@ -200,17 +200,8 @@ print(res)
 ```
   </div>
 
-  <div class="tab-content" data-tab="js" markdown="1">
-
-The JavaScript client is available [here](https://github.com/cmu-delphi/delphi-epidata/blob/main/src/client/delphi_epidata.js).
-
-```html
-<!-- Imports -->
-<script src="delphi_epidata.js"></script>
-<!-- Fetch data -->
-<script>
-  EpidataAsync.fluview('nat', [EpidataAsync.range(201501, 201510)]).then((res) => {
 </div>
+
 
 ### Legacy Clients
 
@@ -220,6 +211,7 @@ We recommend using the modern client libraries mentioned above. Legacy clients a
   <div class="tab-header">
     <button class="active" data-tab="python">Python</button>
     <button data-tab="r">R</button>
+    <button data-tab="js">JavaScript</button>
   </div>
 
   <div class="tab-content active" data-tab="python" markdown="1">

--- a/docs/api/fluview_clinical.md
+++ b/docs/api/fluview_clinical.md
@@ -149,10 +149,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
-res = Epidata.fluview_clinical(['nat'], [Epidata.range(201601, 201701)])
-print(res['result'], res['message'], len(res['epidata']))
+epidata = EpiDataContext()
+res = epidata.pub_fluview_clinical(regions=['nat'], epiweeks=EpiRange(201601, 201701))
+print(res.df())
 ```
   </div>
 

--- a/docs/api/fluview_meta.md
+++ b/docs/api/fluview_meta.md
@@ -93,7 +93,7 @@ from epidatpy import EpiDataContext
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_fluview_meta()
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/fluview_meta.md
+++ b/docs/api/fluview_meta.md
@@ -108,3 +108,61 @@ print(res)
   </div>
 
 </div>
+
+
+### Legacy Clients
+
+We recommend using the modern client libraries mentioned above. Legacy clients are also available for [Python](https://pypi.org/project/delphi-epidata/), [R](https://github.com/cmu-delphi/delphi-epidata/blob/dev/src/client/delphi_epidata.R), and [JavaScript](https://github.com/cmu-delphi/delphi-epidata/blob/dev/src/client/delphi_epidata.js).
+
+<div class="code-tabs">
+  <div class="tab-header">
+    <button class="active" data-tab="python">Python</button>
+    <button data-tab="r">R</button>
+    <button data-tab="js">JavaScript</button>
+  </div>
+
+  <div class="tab-content active" data-tab="python" markdown="1">
+
+Optionally install the package using pip(env):
+```bash
+pip install delphi-epidata
+```
+
+Otherwise, place `delphi_epidata.py` from this repo next to your python script.
+
+```python
+# Import
+from delphi_epidata import Epidata
+# Fetch data
+res = Epidata.fluview_meta()
+print(res['result'], res['message'], len(res['epidata']))
+```
+  </div>
+
+  <div class="tab-content" data-tab="r" markdown="1">
+
+Place `delphi_epidata.R` from this repo next to your R script.
+
+```R
+source("delphi_epidata.R")
+# Fetch data
+res <- Epidata$fluview_meta()
+print(res$epidata)
+```
+  </div>
+
+  <div class="tab-content" data-tab="js" markdown="1">
+
+```html
+<!-- Imports -->
+<script src="delphi_epidata.js"></script>
+<!-- Fetch data -->
+<script>
+  EpidataAsync.fluview_meta().then((res) => {
+    console.log(res.result, res.message, res.epidata != null ? res.epidata.length : 0);
+  });
+</script>
+```
+  </div>
+
+</div>

--- a/docs/api/geographic_codes.md
+++ b/docs/api/geographic_codes.md
@@ -94,6 +94,9 @@ Multiple endpoints use standard US geographic codes. These include the national 
 |---|---|
 | `nat` | United States (National) |
 
+{: .note}
+> **Note:** All endpoints that contain US data use `nat` to access it, whereas [`ght`](ght.md) and other endpoints that contain data for countries in the Americas use `us`.
+
 ### HHS Regions
 
 The US Department of Health and Human Services divides the country into 10 regions.

--- a/docs/api/geographic_codes.md
+++ b/docs/api/geographic_codes.md
@@ -26,57 +26,57 @@ Multiple endpoints accept ISO 3166-1 alpha-2 country codes for countries and ter
 
 | Code | Name |
 |---|---|
-| AG | Antigua and Barbuda |
-| AI | Anguilla |
-| AR | Argentina |
-| AW | Aruba |
-| BB | Barbados |
-| BL | Saint Barthelemy |
-| BM | Bermuda |
-| BO | Bolivia |
-| BQ | Bonaire, Saint Eustatius and Saba |
-| BR | Brazil |
-| BS | Bahamas |
-| BZ | Belize |
-| CA | Canada |
-| CL | Chile |
-| CO | Colombia |
-| CR | Costa Rica |
-| CU | Cuba |
-| CW | Curaçao |
-| DO | Dominican Republic |
-| EC | Ecuador |
-| GD | Grenada |
-| GF | French Guiana |
-| GP | Guadeloupe |
-| GT | Guatemala |
-| GY | Guyana |
-| HN | Honduras |
-| HT | Haiti |
-| JM | Jamaica |
-| KN | Saint Kitts and Nevis |
-| KY | Cayman Islands |
-| LC | Saint Lucia |
-| MF | Saint Martin (French part) |
-| MQ | Martinique |
-| MS | Montserrat |
-| MX | Mexico |
-| NI | Nicaragua |
-| PA | Panama |
-| PE | Peru |
-| PR | Puerto Rico |
-| PY | Paraguay |
-| SR | Suriname |
-| SV | El Salvador |
-| SX | Sint Maarten (Dutch part) |
-| TC | Turks and Caicos Islands |
-| TT | Trinidad and Tobago |
-| US | United States of America |
-| UY | Uruguay |
-| VC | Saint Vincent and the Grenadines |
-| VE | Venezuela |
-| VG | Virgin Islands (UK) |
-| VI | Virgin Islands (US) |
+| `AG` | Antigua and Barbuda |
+| `AI` | Anguilla |
+| `AR` | Argentina |
+| `AW` | Aruba |
+| `BB` | Barbados |
+| `BL` | Saint Barthelemy |
+| `BM` | Bermuda |
+| `BO` | Bolivia |
+| `BQ` | Bonaire, Saint Eustatius and Saba |
+| `BR` | Brazil |
+| `BS` | Bahamas |
+| `BZ` | Belize |
+| `CA` | Canada |
+| `CL` | Chile |
+| `CO` | Colombia |
+| `CR` | Costa Rica |
+| `CU` | Cuba |
+| `CW` | Curaçao |
+| `DO` | Dominican Republic |
+| `EC` | Ecuador |
+| `GD` | Grenada |
+| `GF` | French Guiana |
+| `GP` | Guadeloupe |
+| `GT` | Guatemala |
+| `GY` | Guyana |
+| `HN` | Honduras |
+| `HT` | Haiti |
+| `JM` | Jamaica |
+| `KN` | Saint Kitts and Nevis |
+| `KY` | Cayman Islands |
+| `LC` | Saint Lucia |
+| `MF` | Saint Martin (French part) |
+| `MQ` | Martinique |
+| `MS` | Montserrat |
+| `MX` | Mexico |
+| `NI` | Nicaragua |
+| `PA` | Panama |
+| `PE` | Peru |
+| `PR` | Puerto Rico |
+| `PY` | Paraguay |
+| `SR` | Suriname |
+| `SV` | El Salvador |
+| `SX` | Sint Maarten (Dutch part) |
+| `TC` | Turks and Caicos Islands |
+| `TT` | Trinidad and Tobago |
+| `US` | United States of America |
+| `UY` | Uruguay |
+| `VC` | Saint Vincent and the Grenadines |
+| `VE` | Venezuela |
+| `VG` | Virgin Islands (UK) |
+| `VI` | Virgin Islands (US) |
 
 <!--- Countries with no responses
 | FK | Falkland Islands |
@@ -92,7 +92,7 @@ Multiple endpoints use standard US geographic codes. These include the national 
 
 | Code | Name |
 |---|---|
-| nat | United States (National) |
+| `nat` | United States (National) |
 
 ### HHS Regions
 
@@ -100,16 +100,16 @@ The US Department of Health and Human Services divides the country into 10 regio
 
 | Code | Region | States |
 |---|---|---|
-| hhs1 | Region 1 | CT, ME, MA, NH, RI, VT |
-| hhs2 | Region 2 | NJ, NY, PR, VI |
-| hhs3 | Region 3 | DE, DC, MD, PA, VA, WV |
-| hhs4 | Region 4 | AL, FL, GA, KY, MS, NC, SC, TN |
-| hhs5 | Region 5 | IL, IN, MI, MN, OH, WI |
-| hhs6 | Region 6 | AR, LA, NM, OK, TX |
-| hhs7 | Region 7 | IA, KS, MO, NE |
-| hhs8 | Region 8 | CO, MT, ND, SD, UT, WY |
-| hhs9 | Region 9 | AZ, CA, HI, NV, AS, GU, MP |
-| hhs10 | Region 10 | AK, ID, OR, WA |
+| `hhs1` | Region 1 | CT, ME, MA, NH, RI, VT |
+| `hhs2` | Region 2 | NJ, NY, PR, VI |
+| `hhs3` | Region 3 | DE, DC, MD, PA, VA, WV |
+| `hhs4` | Region 4 | AL, FL, GA, KY, MS, NC, SC, TN |
+| `hhs5` | Region 5 | IL, IN, MI, MN, OH, WI |
+| `hhs6` | Region 6 | AR, LA, NM, OK, TX |
+| `hhs7` | Region 7 | IA, KS, MO, NE |
+| `hhs8` | Region 8 | CO, MT, ND, SD, UT, WY |
+| `hhs9` | Region 9 | AZ, CA, HI, NV, AS, GU, MP |
+| `hhs10` | Region 10 | AK, ID, OR, WA |
 
 ### Census Divisions
 
@@ -117,15 +117,15 @@ The US Census Bureau divides the country into 9 divisions.
 
 | Code | Division | States |
 |---|---|---|
-| cen1 | New England | CT, ME, MA, NH, RI, VT |
-| cen2 | Mid-Atlantic | NJ, NY, PA |
-| cen3 | East North Central | IL, IN, MI, OH, WI |
-| cen4 | West North Central | IA, KS, MN, MO, NE, ND, SD |
-| cen5 | South Atlantic | DE, DC, FL, GA, MD, NC, SC, VA, WV |
-| cen6 | East South Central | AL, KY, MS, TN |
-| cen7 | West South Central | AR, LA, OK, TX |
-| cen8 | Mountain | AZ, CO, ID, MT, NV, NM, UT, WY |
-| cen9 | Pacific | AK, CA, HI, OR, WA |
+| `cen1` | New England | CT, ME, MA, NH, RI, VT |
+| `cen2` | Mid-Atlantic | NJ, NY, PA |
+| `cen3` | East North Central | IL, IN, MI, OH, WI |
+| `cen4` | West North Central | IA, KS, MN, MO, NE, ND, SD |
+| `cen5` | South Atlantic | DE, DC, FL, GA, MD, NC, SC, VA, WV |
+| `cen6` | East South Central | AL, KY, MS, TN |
+| `cen7` | West South Central | AR, LA, OK, TX |
+| `cen8` | Mountain | AZ, CO, ID, MT, NV, NM, UT, WY |
+| `cen9` | Pacific | AK, CA, HI, OR, WA |
 
 ### US States and Territories
 
@@ -135,182 +135,182 @@ Full list of 51 US states and territories used by multiple endpoints:
 
 | Code | Name |
 |---|---|
-| AK | Alaska |
-| AL | Alabama |
-| AR | Arkansas |
-| AZ | Arizona |
-| CA | California |
-| CO | Colorado |
-| CT | Connecticut |
-| DC | District of Columbia |
-| DE | Delaware |
-| FL | Florida |
-| GA | Georgia |
-| HI | Hawaii |
-| IA | Iowa |
-| ID | Idaho |
-| IL | Illinois |
-| IN | Indiana |
-| KS | Kansas |
-| KY | Kentucky |
-| LA | Louisiana |
-| MA | Massachusetts |
-| MD | Maryland |
-| ME | Maine |
-| MI | Michigan |
-| MN | Minnesota |
-| MO | Missouri |
-| MS | Mississippi |
-| MT | Montana |
-| NC | North Carolina |
-| ND | North Dakota |
-| NE | Nebraska |
-| NH | New Hampshire |
-| NJ | New Jersey |
-| NM | New Mexico |
-| NV | Nevada |
-| NY | New York |
-| OH | Ohio |
-| OK | Oklahoma |
-| OR | Oregon |
-| PA | Pennsylvania |
-| RI | Rhode Island |
-| SC | South Carolina |
-| SD | South Dakota |
-| TN | Tennessee |
-| TX | Texas |
-| UT | Utah |
-| VA | Virginia |
-| VT | Vermont |
-| WA | Washington |
-| WI | Wisconsin |
-| WV | West Virginia |
-| WY | Wyoming |
+| `AK` | Alaska |
+| `AL` | Alabama |
+| `AR` | Arkansas |
+| `AZ` | Arizona |
+| `CA` | California |
+| `CO` | Colorado |
+| `CT` | Connecticut |
+| `DC` | District of Columbia |
+| `DE` | Delaware |
+| `FL` | Florida |
+| `GA` | Georgia |
+| `HI` | Hawaii |
+| `IA` | Iowa |
+| `ID` | Idaho |
+| `IL` | Illinois |
+| `IN` | Indiana |
+| `KS` | Kansas |
+| `KY` | Kentucky |
+| `LA` | Louisiana |
+| `MA` | Massachusetts |
+| `MD` | Maryland |
+| `ME` | Maine |
+| `MI` | Michigan |
+| `MN` | Minnesota |
+| `MO` | Missouri |
+| `MS` | Mississippi |
+| `MT` | Montana |
+| `NC` | North Carolina |
+| `ND` | North Dakota |
+| `NE` | Nebraska |
+| `NH` | New Hampshire |
+| `NJ` | New Jersey |
+| `NM` | New Mexico |
+| `NV` | Nevada |
+| `NY` | New York |
+| `OH` | Ohio |
+| `OK` | Oklahoma |
+| `OR` | Oregon |
+| `PA` | Pennsylvania |
+| `RI` | Rhode Island |
+| `SC` | South Carolina |
+| `SD` | South Dakota |
+| `TN` | Tennessee |
+| `TX` | Texas |
+| `UT` | Utah |
+| `VA` | Virginia |
+| `VT` | Vermont |
+| `WA` | Washington |
+| `WI` | Wisconsin |
+| `WV` | West Virginia |
+| `WY` | Wyoming |
 
 #### US Territories
 
 | Code | Name |
 |---|---|
-| PR | Puerto Rico |
-| VI | Virgin Islands |
-| GU | Guam |
-| AS | American Samoa |
-| MP | Northern Mariana Islands |
-| FM | Federated States of Micronesia |
-| MH | Marshall Islands |
-| PW | Palau |
+| `PR` | Puerto Rico |
+| `VI` | Virgin Islands |
+| `GU` | Guam |
+| `AS` | American Samoa |
+| `MP` | Northern Mariana Islands |
+| `FM` | Federated States of Micronesia |
+| `MH` | Marshall Islands |
+| `PW` | Palau |
 
 ## Selected US cities
 
 Selected US cities used by multiple endpoints.
 
-| Code |
-|---|
-| Abilene_TX |
-| Akron_OH |
-| Albany_NY |
-| Albuquerque_NM |
-| Alexandria_VA |
-| Allentown_PA |
-| Amarillo_TX |
-| Anaheim_CA |
-| Anchorage_AK |
-| Ann_Arbor_MI |
-| Arlington_TX |
-| Arlington_VA |
-| Atlanta_GA |
-| Austin_TX |
-| Bakersfield_CA |
-| Baltimore_MD |
-| Baton_Rouge_LA |
-| Berkeley_CA |
-| Birmingham_AL |
-| Boise_ID |
-| Boston_MA |
-| Boulder_CO |
-| Buffalo_NY |
-| Cary_NC |
-| Charlotte_NC |
-| Chicago_IL |
-| Cleveland_OH |
-| Colorado_Springs_CO |
-| Columbia_SC |
-| Columbus_OH |
-| Dallas_TX |
-| Dayton_OH |
-| Denver_CO |
-| Des_Moines_IA |
-| Durham_NC |
-| Eugene_OR |
-| Fresno_CA |
-| Ft_Worth_TX |
-| Gainesville_FL |
-| Grand_Rapids_MI |
-| Greensboro_NC |
-| Greenville_SC |
-| Honolulu_HI |
-| Houston_TX |
-| Indianapolis_IN |
-| Irvine_CA |
-| Irving_TX |
-| Jacksonville_FL |
-| Jackson_MS |
-| Kansas_City_MO |
-| Knoxville_TN |
-| Las_Vegas_NV |
-| Lexington_KY |
-| Lincoln_NE |
-| Little_Rock_AR |
-| Los_Angeles_CA |
-| Lubbock_TX |
-| Madison_WI |
-| Memphis_TN |
-| Mesa_AZ |
-| Miami_FL |
-| Milwaukee_WI |
-| Nashville_TN |
-| Newark_NJ |
-| New_Orleans_LA |
-| New_York_NY |
-| Norfolk_VA |
-| Oakland_CA |
-| Oklahoma_City_OK |
-| Omaha_NE |
-| Orlando_FL |
-| Philadelphia_PA |
-| Phoenix_AZ |
-| Pittsburgh_PA |
-| Plano_TX |
-| Portland_OR |
-| Providence_RI |
-| Raleigh_NC |
-| Reno_NV |
-| Reston_VA |
-| Richmond_VA |
-| Rochester_NY |
-| Roswell_GA |
-| Sacramento_CA |
-| Salt_Lake_City_UT |
-| Santa_Clara_CA |
-| San_Antonio_TX |
-| San_Diego_CA |
-| San_Francisco_CA |
-| San_Jose_CA |
-| Scottsdale_AZ |
-| Seattle_WA |
-| Somerville_MA |
-| Spokane_WA |
-| Springfield_MO |
-| State_College_PA |
-| St_Louis_MO |
-| St_Paul_MN |
-| Sunnyvale_CA |
-| Tampa_FL |
-| Tempe_AZ |
-| Tucson_AZ |
-| Tulsa_OK |
-| Washington_DC |
-| Wichita_KS |
+| Code | Name |
+|---|---|
+| `Abilene_TX` | Abilene, TX |
+| `Akron_OH` | Akron, OH |
+| `Albany_NY` | Albany, NY |
+| `Albuquerque_NM` | Albuquerque, NM |
+| `Alexandria_VA` | Alexandria, VA |
+| `Allentown_PA` | Allentown, PA |
+| `Amarillo_TX` | Amarillo, TX |
+| `Anaheim_CA` | Anaheim, CA |
+| `Anchorage_AK` | Anchorage, AK |
+| `Ann_Arbor_MI` | Ann Arbor, MI |
+| `Arlington_TX` | Arlington, TX |
+| `Arlington_VA` | Arlington, VA |
+| `Atlanta_GA` | Atlanta, GA |
+| `Austin_TX` | Austin, TX |
+| `Bakersfield_CA` | Bakersfield, CA |
+| `Baltimore_MD` | Baltimore, MD |
+| `Baton_Rouge_LA` | Baton Rouge, LA |
+| `Berkeley_CA` | Berkeley, CA |
+| `Birmingham_AL` | Birmingham, AL |
+| `Boise_ID` | Boise, ID |
+| `Boston_MA` | Boston, MA |
+| `Boulder_CO` | Boulder, CO |
+| `Buffalo_NY` | Buffalo, NY |
+| `Cary_NC` | Cary, NC |
+| `Charlotte_NC` | Charlotte, NC |
+| `Chicago_IL` | Chicago, IL |
+| `Cleveland_OH` | Cleveland, OH |
+| `Colorado_Springs_CO` | Colorado Springs, CO |
+| `Columbia_SC` | Columbia, SC |
+| `Columbus_OH` | Columbus, OH |
+| `Dallas_TX` | Dallas, TX |
+| `Dayton_OH` | Dayton, OH |
+| `Denver_CO` | Denver, CO |
+| `Des_Moines_IA` | Des Moines, IA |
+| `Durham_NC` | Durham, NC |
+| `Eugene_OR` | Eugene, OR |
+| `Fresno_CA` | Fresno, CA |
+| `Ft_Worth_TX` | Ft Worth, TX |
+| `Gainesville_FL` | Gainesville, FL |
+| `Grand_Rapids_MI` | Grand Rapids, MI |
+| `Greensboro_NC` | Greensboro, NC |
+| `Greenville_SC` | Greenville, SC |
+| `Honolulu_HI` | Honolulu, HI |
+| `Houston_TX` | Houston, TX |
+| `Indianapolis_IN` | Indianapolis, IN |
+| `Irvine_CA` | Irvine, CA |
+| `Irving_TX` | Irving, TX |
+| `Jacksonville_FL` | Jacksonville, FL |
+| `Jackson_MS` | Jackson, MS |
+| `Kansas_City_MO` | Kansas City, MO |
+| `Knoxville_TN` | Knoxville, TN |
+| `Las_Vegas_NV` | Las Vegas, NV |
+| `Lexington_KY` | Lexington, KY |
+| `Lincoln_NE` | Lincoln, NE |
+| `Little_Rock_AR` | Little Rock, AR |
+| `Los_Angeles_CA` | Los Angeles, CA |
+| `Lubbock_TX` | Lubbock, TX |
+| `Madison_WI` | Madison, WI |
+| `Memphis_TN` | Memphis, TN |
+| `Mesa_AZ` | Mesa, AZ |
+| `Miami_FL` | Miami, FL |
+| `Milwaukee_WI` | Milwaukee, WI |
+| `Nashville_TN` | Nashville, TN |
+| `Newark_NJ` | Newark, NJ |
+| `New_Orleans_LA` | New Orleans, LA |
+| `New_York_NY` | New York, NY |
+| `Norfolk_VA` | Norfolk, VA |
+| `Oakland_CA` | Oakland, CA |
+| `Oklahoma_City_OK` | Oklahoma City, OK |
+| `Omaha_NE` | Omaha, NE |
+| `Orlando_FL` | Orlando, FL |
+| `Philadelphia_PA` | Philadelphia, PA |
+| `Phoenix_AZ` | Phoenix, AZ |
+| `Pittsburgh_PA` | Pittsburgh, PA |
+| `Plano_TX` | Plano, TX |
+| `Portland_OR` | Portland, OR |
+| `Providence_RI` | Providence, RI |
+| `Raleigh_NC` | Raleigh, NC |
+| `Reno_NV` | Reno, NV |
+| `Reston_VA` | Reston, VA |
+| `Richmond_VA` | Richmond, VA |
+| `Rochester_NY` | Rochester, NY |
+| `Roswell_GA` | Roswell, GA |
+| `Sacramento_CA` | Sacramento, CA |
+| `Salt_Lake_City_UT` | Salt Lake City, UT |
+| `Santa_Clara_CA` | Santa Clara, CA |
+| `San_Antonio_TX` | San Antonio, TX |
+| `San_Diego_CA` | San Diego, CA |
+| `San_Francisco_CA` | San Francisco, CA |
+| `San_Jose_CA` | San Jose, CA |
+| `Scottsdale_AZ` | Scottsdale, AZ |
+| `Seattle_WA` | Seattle, WA |
+| `Somerville_MA` | Somerville, MA |
+| `Spokane_WA` | Spokane, WA |
+| `Springfield_MO` | Springfield, MO |
+| `State_College_PA` | State College, PA |
+| `St_Louis_MO` | St Louis, MO |
+| `St_Paul_MN` | St Paul, MN |
+| `Sunnyvale_CA` | Sunnyvale, CA |
+| `Tampa_FL` | Tampa, FL |
+| `Tempe_AZ` | Tempe, AZ |
+| `Tucson_AZ` | Tucson, AZ |
+| `Tulsa_OK` | Tulsa, OK |
+| `Washington_DC` | Washington, DC |
+| `Wichita_KS` | Wichita, KS |
 
 ## NIDSS
 
@@ -320,96 +320,96 @@ Geographic codes used by [NIDSS Flu](nidss_flu.html) and [NIDSS Dengue](nidss_de
 
 Regions of Taiwan.
 
-| Code |
-|---|
-| nationwide |
-| central |
-| eastern |
-| kaoping |
-| northern |
-| southern |
-| taipei |
+| Code | Name |
+|---|---|
+| `nationwide` | Nationwide |
+| `central` | Central |
+| `eastern` | Eastern |
+| `kaoping` | Kaoping |
+| `northern` | Northern |
+| `southern` | Southern |
+| `taipei` | Taipei |
 
 ### Taiwan Cities and Counties
 
 Administrative divisions of Taiwan.
 
-| Code |
-|---|
-| changhua_county |
-| chiayi_city |
-| chiayi_county |
-| hsinchu_city |
-| hsinchu_county |
-| hualien_county |
-| kaohsiung_city |
-| keelung_city |
-| kinmen_county |
-| lienchiang_county |
-| miaoli_county |
-| nantou_county |
-| new_taipei_city |
-| penghu_county |
-| pingtung_county |
-| taichung_city |
-| tainan_city |
-| taipei_city |
-| taitung_county |
-| taoyuan_city |
-| yilan_county |
-| yunlin_county |
+| Code | Name |
+|---|---|
+| `changhua_county` | Changhua County |
+| `chiayi_city` | Chiayi City |
+| `chiayi_county` | Chiayi County |
+| `hsinchu_city` | Hsinchu City |
+| `hsinchu_county` | Hsinchu County |
+| `hualien_county` | Hualien County |
+| `kaohsiung_city` | Kaohsiung City |
+| `keelung_city` | Keelung City |
+| `kinmen_county` | Kinmen County |
+| `lienchiang_county` | Lienchiang County |
+| `miaoli_county` | Miaoli County |
+| `nantou_county` | Nantou County |
+| `new_taipei_city` | New Taipei City |
+| `penghu_county` | Penghu County |
+| `pingtung_county` | Pingtung County |
+| `taichung_city` | Taichung City |
+| `tainan_city` | Tainan City |
+| `taipei_city` | Taipei City |
+| `taitung_county` | Taitung County |
+| `taoyuan_city` | Taoyuan City |
+| `yilan_county` | Yilan County |
+| `yunlin_county` | Yunlin County |
 
 ## European Countries
 
 European countries and regions used by the [ECDC ILI](ecdc_ili.html) endpoint.
 
-| Name |
-|---|
-| Armenia |
-| Austria |
-| Azerbaijan |
-| Belarus |
-| Belgium |
-| Czech Republic |
-| Denmark |
-| Estonia |
-| Finland |
-| France |
-| Georgia |
-| Iceland |
-| Ireland |
-| Israel |
-| Italy |
-| Kazakhstan |
-| Kosovo* |
-| Kyrgyzstan |
-| Latvia |
-| Lithuania |
-| Luxembourg |
-| Malta |
-| Moldova |
-| Montenegro |
-| Netherlands |
-| North Macedonia |
-| Norway |
-| Poland |
-| Portugal |
-| Romania |
-| Russia |
-| Serbia |
-| Slovakia |
-| Slovenia |
-| Spain |
-| Switzerland |
-| Tajikistan |
-| Turkey |
-| Turkmenistan |
-| Ukraine |
-| United Kingdom - England |
-| United Kingdom - Northern Irel |
-| United Kingdom - Scotland |
-| United Kingdom - Wales |
-| Uzbekistan |
+| Code | Name |
+|---|---|
+| `armenia` | Armenia |
+| `austria` | Austria |
+| `azerbaijan` | Azerbaijan |
+| `belarus` | Belarus |
+| `belgium` | Belgium |
+| `czech republic` | Czech Republic |
+| `denmark` | Denmark |
+| `estonia` | Estonia |
+| `finland` | Finland |
+| `france` | France |
+| `georgia` | Georgia |
+| `iceland` | Iceland |
+| `ireland` | Ireland |
+| `israel` | Israel |
+| `italy` | Italy |
+| `kazakhstan` | Kazakhstan |
+| `kosovo*` | Kosovo* |
+| `kyrgyzstan` | Kyrgyzstan |
+| `latvia` | Latvia |
+| `lithuania` | Lithuania |
+| `luxembourg` | Luxembourg |
+| `malta` | Malta |
+| `moldova` | Moldova |
+| `montenegro` | Montenegro |
+| `netherlands` | Netherlands |
+| `north macedonia` | North Macedonia |
+| `norway` | Norway |
+| `poland` | Poland |
+| `portugal` | Portugal |
+| `romania` | Romania |
+| `russia` | Russia |
+| `serbia` | Serbia |
+| `slovakia` | Slovakia |
+| `slovenia` | Slovenia |
+| `spain` | Spain |
+| `switzerland` | Switzerland |
+| `tajikistan` | Tajikistan |
+| `turkey` | Turkey |
+| `turkmenistan` | Turkmenistan |
+| `ukraine` | Ukraine |
+| `united kingdom - england` | United Kingdom - England |
+| `united kingdom - northern irel` | United Kingdom - Northern Irel |
+| `united kingdom - scotland` | United Kingdom - Scotland |
+| `united kingdom - wales` | United Kingdom - Wales |
+| `uzbekistan` | Uzbekistan |
 
 ## FluSurv Locations
 
@@ -417,28 +417,28 @@ Locations used by the [FluSurv](flusurv.html) endpoint.
 
 | Code | Description |
 |---|---|
-| CA | California |
-| CO | Colorado |
-| CT | Connecticut |
-| GA | Georgia |
-| IA | Iowa |
-| ID | Idaho |
-| MD | Maryland |
-| MI | Michigan |
-| MN | Minnesota |
-| NM | New Mexico |
-| NY_albany | New York (Albany) |
-| NY_rochester | New York (Rochester) |
-| OH | Ohio |
-| OK | Oklahoma |
-| OR | Oregon |
-| RI | Rhode Island |
-| SD | South Dakota |
-| TN | Tennessee |
-| UT | Utah |
-| network_all | All Networks |
-| network_eip | Emerging Infections Program |
-| network_ihsp | Influenza Hospitalization Surveillance Project |
+| `CA` | California |
+| `CO` | Colorado |
+| `CT` | Connecticut |
+| `GA` | Georgia |
+| `IA` | Iowa |
+| `ID` | Idaho |
+| `MD` | Maryland |
+| `MI` | Michigan |
+| `MN` | Minnesota |
+| `NM` | New Mexico |
+| `NY_albany` | New York (Albany) |
+| `NY_rochester` | New York (Rochester) |
+| `OH` | Ohio |
+| `OK` | Oklahoma |
+| `OR` | Oregon |
+| `RI` | Rhode Island |
+| `SD` | South Dakota |
+| `TN` | Tennessee |
+| `UT` | Utah |
+| `network_all` | All Networks |
+| `network_eip` | Emerging Infections Program |
+| `network_ihsp` | Influenza Hospitalization Surveillance Project |
 
 ## Republic of Korea
 
@@ -446,7 +446,7 @@ Geographic codes used by the [KCDC ILI](kcdc_ili.html) endpoint.
 
 | Code | Name |
 |---|---|
-| ROK | Republic of Korea |
+| `ROK` | Republic of Korea |
 
 
 ## FluView Cities
@@ -455,9 +455,9 @@ Specific cities used by the [FluView](fluview.html) endpoint.
 
 | City | Code |
 |---|---|
-| Chicago | ord |
-| Los Angeles | lax |
-| New York City | jfk |
+| Chicago | `ord` |
+| Los Angeles | `lax` |
+| New York City | `jfk` |
 
 ### Note on New York
 

--- a/docs/api/geographic_codes.md
+++ b/docs/api/geographic_codes.md
@@ -95,7 +95,7 @@ Multiple endpoints use standard US geographic codes. These include the national 
 | `nat` | United States (National) |
 
 {: .note}
-> **Note:** All endpoints that contain US data use `nat` to access it, whereas [`ght`](ght.md) and other endpoints that contain data for countries in the Americas use `us`.
+> **Note:** All endpoints that contain US-only data use `nat` to access national-level data, whereas [`ght`](ght.md) and other endpoints that contain data for multiple countries use `us`.
 
 ### HHS Regions
 

--- a/docs/api/gft.md
+++ b/docs/api/gft.md
@@ -104,11 +104,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_gft(locations='nat', epiweeks=EpiRange(201501, 201510))
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/ght.md
+++ b/docs/api/ght.md
@@ -229,11 +229,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext
 # Fetch data
 epidata = EpiDataContext()
-res = epidata.ght('auth_token', ['US'], [201501], 'how to get over the flu')
-print(res['result'], res['message'], len(res['epidata']))
+res = epidata.pvt_ght('auth_token', ['US'], [201501], 'how to get over the flu')
+print(res.df())
 ```
   </div>
 

--- a/docs/api/ili_nearby_nowcast.md
+++ b/docs/api/ili_nearby_nowcast.md
@@ -130,11 +130,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_nowcast(locations=['nat'], epiweeks=EpiRange(202001, 202010))
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/kcdc_ili.md
+++ b/docs/api/kcdc_ili.md
@@ -133,11 +133,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_kcdc_ili(regions=['ROK'], epiweeks=[202001, 202002])
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/nidss_dengue.md
+++ b/docs/api/nidss_dengue.md
@@ -116,11 +116,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_nidss_dengue(locations=['nationwide'], epiweeks=EpiRange(201501, 201510))
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/nidss_flu.md
+++ b/docs/api/nidss_flu.md
@@ -148,11 +148,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_nidss_flu(regions=['nationwide'], epiweeks=EpiRange(201501, 201510))
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/norostat.md
+++ b/docs/api/norostat.md
@@ -120,11 +120,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pvt_norostat(auth='auth_token', locations=['Minnesota, Ohio, Oregon, Tennessee, and Wisconsin'], epiweeks=[201501])
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/norostat_meta.md
+++ b/docs/api/norostat_meta.md
@@ -118,11 +118,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pvt_meta_norostat(auth='auth_token')
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/paho_dengue.md
+++ b/docs/api/paho_dengue.md
@@ -138,11 +138,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_paho_dengue(regions=['ca'], epiweeks=[201501])
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/quidel.md
+++ b/docs/api/quidel.md
@@ -118,11 +118,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pvt_quidel(auth='auth_token', locations=['hhs1'], epiweeks=EpiRange(201535, 202001))
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/twitter.md
+++ b/docs/api/twitter.md
@@ -141,11 +141,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pvt_twitter(auth='auth_token', locations=['nat'], time_type="week", time_values=[201501])
-print(res)
+print(res.df())
 ```
   </div>
 

--- a/docs/api/wiki.md
+++ b/docs/api/wiki.md
@@ -285,11 +285,11 @@ pip install -e "git+https://github.com/cmu-delphi/epidatpy.git#egg=epidatpy"
 
 ```python
 # Import
-from epidatpy import CovidcastEpidata, EpiDataContext, EpiRange
+from epidatpy import EpiDataContext, EpiRange
 # Fetch data
 epidata = EpiDataContext()
 res = epidata.pub_wiki(articles=['influenza'], time_values=EpiRange(202001, 202010), time_type='week', language='en', hours=[0, 12])
-print(res)
+print(res.df())
 ```
   </div>
 


### PR DESCRIPTION
### Summary:

This PR makes minor fixes to the `epidatpy` code samples for the other endpoints and improves the formatting of the Geographic Codes page. In particular, it prints the df in the code samples and corrects a couple of typos. 

### Prerequisites:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [X] Build is successful
- [X] Code is cleaned up and formatted
