### PR TITLE
docs: closes multiple old documentation issues

### DIFF
--- a/docs/api/covid_hosp.md
+++ b/docs/api/covid_hosp.md
@@ -23,6 +23,9 @@ title: COVID-19 Reported Patient Impact and Hospital Capacity by State Timeserie
 
 This dataset provides daily surveys of hospital COVID-19 capacity and patient impact, as reported by US hospitals. Data is acquired from HealthData.gov. It is a mirror of the "COVID-19 Reported Patient Impact and Hospital Capacity by State Timeseries" and "COVID-19 Reported Patient Impact and Hospital Capacity by State" datasets provided by HHS via healthdata.gov. The latter provides more frequent updates, so it is combined with the former to create a single dataset which is as recent as possible.
 
+> **Note:** Administration of this dataset has moved to the National Healthcare Safety Network (NHSN). See [NHSN Respiratory Hospitalizations](covidcast-signals/nhsn.md) for the current data source.
+{: .note }
+
 HHS performs up to four days of forward-fill for missing values in the
 [facility-level data](covid_hosp_facility.md) which are aggregated to make this
 state-level dataset. This sometimes results in repeated values in the state-level data.

--- a/docs/api/covid_hosp_facility.md
+++ b/docs/api/covid_hosp_facility.md
@@ -23,6 +23,9 @@ title: COVID-19 Reported Patient Impact and Hospital Capacity by Facility
 
 This dataset provides facility-level daily surveys of hospital COVID-19 capacity and patient impact. Data is acquired from HealthData.gov. It is a mirror of the "COVID-19 Reported Patient Impact and Hospital Capacity by Facility" dataset provided by HHS via healthdata.gov.
 
+> **Note:** Administration of this dataset has moved to the National Healthcare Safety Network (NHSN). See [NHSN Respiratory Hospitalizations](covidcast-signals/nhsn.md) for the current data source.
+{: .note }
+
 HHS performs up to four days of forward-fill for missing values.
 
 Starting October 1, 2022, some facilities are only required to report annually.

--- a/docs/api/covid_hosp_facility_lookup.md
+++ b/docs/api/covid_hosp_facility_lookup.md
@@ -23,6 +23,10 @@ title: COVID-19 Reported Patient Impact and Hospital Capacity - Facility lookup
 {: .no_toc}
 
 This endpoint is a companion to the [`covid_hosp_facility` endpoint](covid_hosp_facility.md). It provides a way to find unique identifiers and other metadata for facilities of interest.
+
+> **Note:** Administration of this dataset has moved to the National Healthcare Safety Network (NHSN). See [NHSN Respiratory Hospitalizations](covidcast-signals/nhsn.md) for the current data source.
+{: .note }
+
 A total of 4922 facilities are included.
 
 Metadata is derived from the "COVID-19 Reported Patient Impact and Hospital Capacity by Facility" dataset provided by HHS via healthdata.gov.

--- a/docs/api/covidcast-signals/chng.md
+++ b/docs/api/covidcast-signals/chng.md
@@ -48,8 +48,8 @@ commercial purposes.
 | `smoothed_adj_outpatient_covid` | Same, but with systematic day-of-week effects removed; see [details below](#day-of-week-adjustment) <br/> **Earliest date available:** 2020-02-01 |
 | `smoothed_outpatient_cli` | Estimated percentage of outpatient doctor visits primarily about COVID-related symptoms, based on Change Healthcare claims data that has been de-identified in accordance with HIPAA privacy regulations, smoothed in time using a Gaussian linear smoother <br/> **Earliest date available:** 2020-02-01 |
 | `smoothed_adj_outpatient_cli` | Same, but with systematic day-of-week effects removed; see [details below](#day-of-week-adjustment) <br/> **Earliest date available:** 2020-02-01 |
-| `smoothed_outpatient_flu` | Estimated percentage of outpatient doctor visits with confirmed influenza, based on Change Healthcare claims data that has been de-identified in accordance with HIPAA privacy regulations, smoothed in time using a Gaussian linear smoother <br/> **Earliest issue available:** 2021-12-06 <br/> **Earliest date available:** 2020-02-01 |
-| `smoothed_adj_outpatient_flu` | Same, but with systematic day-of-week effects removed; see [details below](#day-of-week-adjustment) <br/> **Earliest issue available:** 2021-12-06 <br/> **Earliest date available:** 2020-02-01 |
+| `smoothed_outpatient_flu` | Estimated percentage of outpatient doctor visits with confirmed influenza, based on Change Healthcare claims data that has been de-identified in accordance with HIPAA privacy regulations, smoothed in time using a Gaussian linear smoother <br/> **Earliest date available:** 2020-02-01 |
+| `smoothed_adj_outpatient_flu` | Same, but with systematic day-of-week effects removed; see [details below](#day-of-week-adjustment) <br/> **Earliest date available:** 2020-02-01 |
 
 ## Table of Contents
 {: .no_toc .text-delta}

--- a/docs/api/covidcast-signals/google-symptoms.md
+++ b/docs/api/covidcast-signals/google-symptoms.md
@@ -13,7 +13,7 @@ title: Google Symptom Search Trends
 | **Data Source** | Google |
 | **Geographic Levels** | National, Department of Health & Human Services (HHS) Regions, State, County, Hospital Referral Region (HRR), Metropolitan Statistical Area (MSA) (see [geography coding docs](../covidcast_geography.md)) |
 | **Temporal Granularity** | Daily (see [date format docs](../covidcast_times.md)) |
-| **Reporting Cadence** | Inactive - No longer updated after November 16th, 2025 |
+| **Reporting Cadence** | Inactive - No longer updated after November 16th, 2025 (see [Symptom sets](#symptom-sets) for details) |
 | **Date of last data revision:** | March 14th, 2025 (see [data revision docs](#changelog)) |
 | **Temporal Scope Start** | February 13th, 2020, with some variation depending on geographic area|
 | **License** | [Google Terms of Service](https://policies.google.com/terms) |
@@ -70,30 +70,30 @@ This symptom set can be used as a negative control.
 
 Until January 20, 2022, we had separate signals for symptoms Anosmia, Ageusia, and their sum.
 
-| Signal | Description |
-| --- | --- |
-| `s01_raw_search` | The average of Google search volume for related searches of symptom set _s01_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
-| `s01_smoothed_search` | The average of Google search volume for related searches of symptom set _s01_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
-| `s02_raw_search` | The average of Google search volume for related searches of symptom set _s02_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
-| `s02_smoothed_search` | The average of Google search volume for related searches of symptom set _s02_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
-| `s03_raw_search` | The average of Google search volume for related searches of symptom set _s03_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
-| `s03_smoothed_search` | The average of Google search volume for related searches of symptom set _s03_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
-| `s04_raw_search` | The average of Google search volume for related searches of symptom set _s04_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
-| `s04_smoothed_search` | The average of Google search volume for related searches of symptom set _s04_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
-| `s05_raw_search` | The average of Google search volume for related searches of symptom set _s05_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
-| `s05_smoothed_search` | The average of Google search volume for related searches of symptom set _s05_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
-| `s06_raw_search` | The average of Google search volume for related searches of symptom set _s06_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
-| `s06_smoothed_search` | The average of Google search volume for related searches of symptom set _s06_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
-| `s07_raw_search` | The average of Google search volume for related searches of symptom set _s07_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
-| `s07_smoothed_search` | The average of Google search volume for related searches of symptom set _s07_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
-| `scontrol_raw_search` | The average of Google search volume for related searches of symptom set _scontrol_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
-| `scontrol_smoothed_search` | The average of Google search volume for related searches of symptom set _scontrol_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
-| `anosmia_raw_search` |  Google search volume for anosmia-related searches, in arbitrary units that are normalized for overall search users. _This signal is no longer updated as of 20 January, 2022._ <br/> **Earliest date available:** 2020-02-13 |
-| `anosmia_smoothed_search` | Google search volume for anosmia-related searches, in arbitrary units that are normalized for overall search users, smoothed by 7-day average. _This signal is no longer updated as of 20 January, 2022._ <br/> **Earliest date available:** 2020-02-20 |
-| `ageusia_raw_search` | Google search volume for ageusia-related searches, in arbitrary units that are normalized for overall search users. _This signal is no longer updated as of 20 January, 2022._ <br/> **Earliest date available:** 2020-02-13 |
-| `ageusia_smoothed_search` |  Google search volume for ageusia-related searches, in arbitrary units that are normalized for overall search users, smoothed by 7-day average. _This signal is no longer updated as of 20 January, 2022._ <br/> **Earliest date available:** 2020-02-20 |
-| `sum_anosmia_ageusia_raw_search` | The sum of Google search volume for anosmia and ageusia related searches, in an arbitrary units that are normalized for overall search users. _This signal is no longer updated as of 20 January, 2022._ <br/> **Earliest date available:** 2020-02-13 |
-| `sum_anosmia_ageusia_smoothed_search` | The sum of Google search volume for anosmia and ageusia related searches, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. _This signal is no longer updated as of 20 January, 2022._ <br/> **Earliest date available:** 2020-02-20 |
+| Signal | Status | Description |
+| --- | --- | --- |
+| `s01_raw_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s01_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
+| `s01_smoothed_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s01_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
+| `s02_raw_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s02_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
+| `s02_smoothed_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s02_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
+| `s03_raw_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s03_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
+| `s03_smoothed_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s03_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
+| `s04_raw_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s04_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
+| `s04_smoothed_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s04_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
+| `s05_raw_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s05_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
+| `s05_smoothed_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s05_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
+| `s06_raw_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s06_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
+| `s06_smoothed_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s06_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
+| `s07_raw_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s07_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
+| `s07_smoothed_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _s07_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
+| `scontrol_raw_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _scontrol_, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2017-08-15 |
+| `scontrol_smoothed_search` | Ended Nov 2025 | The average of Google search volume for related searches of symptom set _scontrol_, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2017-08-21 |
+| `anosmia_raw_search` | Ended Jan 2022 | Google search volume for anosmia-related searches, in arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2020-02-13 |
+| `anosmia_smoothed_search` | Ended Jan 2022 | Google search volume for anosmia-related searches, in arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2020-02-20 |
+| `ageusia_raw_search` | Ended Jan 2022 | Google search volume for ageusia-related searches, in arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2020-02-13 |
+| `ageusia_smoothed_search` | Ended Jan 2022 | Google search volume for ageusia-related searches, in arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2020-02-20 |
+| `sum_anosmia_ageusia_raw_search` | Ended Jan 2022 | The sum of Google search volume for anosmia and ageusia related searches, in an arbitrary units that are normalized for overall search users. <br/> **Earliest date available:** 2020-02-13 |
+| `sum_anosmia_ageusia_smoothed_search` | Ended Jan 2022 | The sum of Google search volume for anosmia and ageusia related searches, in an arbitrary units that are normalized for overall search users, smoothed by 7-day average. <br/> **Earliest date available:** 2020-02-20 |
 
 
 ## Table of Contents

--- a/docs/api/covidcast-signals/hhs.md
+++ b/docs/api/covidcast-signals/hhs.md
@@ -33,8 +33,9 @@ No changes so far.
 
 The U.S. Department of Health & Human Services (HHS) publishes several
 datasets on patient impact and hospital capacity. The data is made available
-to HHS through the CDC’s National Healthcare Safety Network (NHSN). One of these
-datasets is mirrored in Epidata at the following endpoint:
+to HHS through the CDC’s National Healthcare Safety Network (NHSN). 
+See [NHSN Respiratory Hospitalizations](nhsn.md) for the current data source.
+One of these datasets is mirrored in Epidata at the following endpoint:
 
 * [COVID-19 Hospitalization: States](../covid_hosp.md) - daily resolution, state aggregates
 

--- a/docs/api/covidcast-signals/hospital-admissions.md
+++ b/docs/api/covidcast-signals/hospital-admissions.md
@@ -39,8 +39,8 @@ hospital admissions, provided to us by health system partners. We use this
 inpatient data to estimate the percentage of new hospital admissions with a
 COVID-associated diagnosis code in a given location, on a given day.
 
-See also our [Health & Human Services](hhs.md) data source for official COVID
-hospitalization reporting from the Department of Health & Human Services.
+See also our [NHSN Respiratory Hospitalizations](nhsn.md) data source for current official COVID
+hospitalization reporting from the CDC. (Previously this was reported by [Health & Human Services](hhs.md).)
 
 **Active Signals.** These signals are currently updated.
 

--- a/docs/api/covidcast-signals/nchs-mortality.md
+++ b/docs/api/covidcast-signals/nchs-mortality.md
@@ -54,7 +54,7 @@ as additional death certificates from recent weeks are received and tabulated.
 | `deaths_covid_and_pneumonia_notflu_incidence_prop`| Number of weekly new deaths involving COVID-19 and Pneumonia, excluding Influenza, per 100,000 population <br/> **Earliest date available:** Epiweek 05 2020 |
 |`deaths_pneumonia_or_flu_or_covid_incidence_num`| Number of weekly new deaths involving Pneumonia, Influenza, or COVID-19 <br/> **Earliest date available:** Epiweek 05 2020 |
 |`deaths_pneumonia_or_flu_or_covid_incidence_prop`| Number of weekly new deaths involving Pneumonia, Influenza, or COVID-19, per 100,000 population <br/> **Earliest date available:** Epiweek 05 2020 |
-|`deaths_percent_of_expected`| Number of weekly new deaths for all causes in 2020 compared to the average number across the same week in 2017–2019 <br/> **Earliest date available:** Epiweek 05 2020 |
+|`deaths_percent_of_expected`| Number of weekly new deaths for all causes compared to the average number across the same week in 2017–2019 <br/> **Earliest date available:** Epiweek 05 2020 |
 
 ## Table of contents
 {: .no_toc .text-delta}

--- a/docs/api/covidcast-signals/nhsn.md
+++ b/docs/api/covidcast-signals/nhsn.md
@@ -36,6 +36,9 @@ No changes so far.
 [The National Healthcare Safety Network (NHSN)](https://www.cdc.gov/nhsn/index.html) is the nation’s most widely used healthcare-associated infection tracking system.
 This dataset reports preliminary and finalized weekly hospital respiratory data and metrics aggregated to national and state/territory levels reported to the CDC’s National Health Safety Network (NHSN). Values are available for reference dates beginning August 2020.
 
+> **Note:** This data source is the continuation of the [HHS Hospitalizations](hhs.md) data source. In late 2023, the administration of this dataset moved from HHS Protect to the National Healthcare Safety Network (NHSN).
+{: .note }
+
 Each signal below is derived from one of the two following datasets:
 
 - Main: [Weekly Hospital Respiratory Data (HRD) Metrics by Jurisdiction, National Healthcare Safety Network (NHSN)](https://data.cdc.gov/Public-Health-Surveillance/Weekly-Hospital-Respiratory-Data-HRD-Metrics-by-Ju/ua7e-t2fy/about_data)


### PR DESCRIPTION
addresses issue(s) #1624, #1579, #1352, #1528, #1397

### Summary:

This PR aims to close multiple minor documentation issues. In particular: 
* Included a status column in the signals table on google-symptoms.md (fixed #1624)
* Added mutual mentions to NHSN, HHS, and `covid_*` pages (fixed #1579 and #1352)
* Removed "in 2020" wording from NCHS (fixed #1528)
* Removed "earliest issue date" from doc pages signals description table for chng (fixed #1397)

### Prerequisites:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [X] Build is successful
- [X] Code is cleaned up and formatted
