### PR TITLE
Added new field to the covidcast_utils/model

### DIFF
--- a/src/server/endpoints/covidcast_utils/model.py
+++ b/src/server/endpoints/covidcast_utils/model.py
@@ -167,6 +167,7 @@ class DataSource:
     license: Optional[str] = None
     link: List[WebLink] = field(default_factory=list)
     dua: Optional[str] = None
+    original_data_provider: Optional[str] = None
 
     signals: List[DataSignal] = field(default_factory=list)
 


### PR DESCRIPTION
Added new field called 'Original Data Provider' to the covidcast_utils/model.py so we can use it in the medatata.

addresses issue(s) #ISSUE <!--list issue(s) associated with this PR -->

### Summary:

<!--
  describe what this PR changes
-->

### Prerequisites:

- [x] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted
