### PR TITLE
redis script needs to be self-contained

### DIFF
--- a/src/maintenance/update_last_usage.py
+++ b/src/maintenance/update_last_usage.py
@@ -5,8 +5,6 @@ import delphi.operations.secrets as secrets
 import mysql.connector
 import redis
 
-from src.server.admin.models import default_date_now
-
 REDIS_HOST = os.environ.get("REDIS_HOST", "delphi_redis")
 REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD")
 LAST_USED_KEY_PATTERN = "*LAST_USED*"
@@ -44,7 +42,7 @@ def main():
             date_str = (
                 dtime.strftime(last_time_used, "%Y-%m-%d")
                 if last_time_used
-                else default_date_now()
+                else dtime.strftime(dtime.now(), "%Y-%m-%d")
             )
             redis_cli.set(f"LAST_USED/{api_key}", date_str)
 


### PR DESCRIPTION
### Summary:

[The redis update script isn't running on cronicle because of the src import](https://cronicle-prod-01.delphi.cmu.edu/#JobDetails?id=jmny3f6675v). This drops the src dependence so that doesn't happen.

### Prerequisites:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [ ] Build is successful
- [X] Code is cleaned up and formatted
