### PR TITLE
COVID reframing

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,15 +1,15 @@
 ---
-title: Other Endpoints (COVID-19 and Other Diseases)
+title: Other Endpoints
 has_children: true
 nav_order: 4
 ---
 
-# Other Endpoints (COVID-19 and Other Diseases)
+# Other Endpoints
 
 This is the home of [Delphi](https://delphi.cmu.edu/)'s epidemiological data
-API for tracking epidemics such as influenza, dengue, and norovirus. Note that
-additional data, including most COVID-19 signals, is available in the
-[main Epidata API (formerly known as COVIDcast)](covidcast.md).
+API for tracking fast-moving contagious diseases such as influenza, dengue,
+and norovirus. Note that additional data, including most COVID-19 signals, is
+available in the [main Epidata API (formerly known as COVIDcast)](covidcast.md).
 
 ## Table of Contents
 {: .no_toc .text-delta}

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -7,7 +7,7 @@ nav_order: 4
 # Other Endpoints
 
 This is the home of [Delphi](https://delphi.cmu.edu/)'s epidemiological data
-API for tracking fast-moving contagious diseases such as influenza, dengue,
+API for tracking infectious diseases such as influenza, dengue,
 and norovirus. Note that additional data, including most COVID-19 signals, is
 available in the [main Epidata API (formerly known as COVIDcast)](covidcast.md).
 

--- a/docs/api/covidcast.md
+++ b/docs/api/covidcast.md
@@ -9,7 +9,7 @@ nav_order: 3
 This endpoint was previously known as COVIDcast.
 
 This is the documentation for accessing Delphi's COVID-19 indicators via the `covidcast` endpoint of [Delphi](https://delphi.cmu.edu/)'s
-epidemiological data API. This API provides data on the spread and impact of the COVID-19 pandemic across the United States, most of which is available at the
+epidemiological data API. This API provides data on the spread and impact of fast-moving contagious diseases, including COVID-19, across the United States, most of which is available at the
 county level and updated daily. This data powers our public [COVIDcast
 map](https://delphi.cmu.edu/covidcast/) which includes testing, cases, and death data,
 as well as unique healthcare and survey data Delphi acquires through its

--- a/docs/api/covidcast.md
+++ b/docs/api/covidcast.md
@@ -6,19 +6,18 @@ nav_order: 3
 
 # Main Epidata API
 
-This endpoint was previously known as COVIDcast.
+This legacy Epidata API endpoint was formerly called COVIDcast.
 
-This is the documentation for accessing Delphi's COVID-19 indicators via the `covidcast` endpoint of [Delphi](https://delphi.cmu.edu/)'s
-epidemiological data API. This API provides data on the spread and impact of fast-moving contagious diseases, including COVID-19, across the United States, most of which is available at the
+This is the documentation for accessing all Delphi's indicators via the `covidcast` endpoint of [Delphi](https://delphi.cmu.edu/)'s
+epidemiological data API. This API provides data on the spread and impact of infectious diseases, including COVID-19, across the United States, most of which is available at the
 county level and updated daily. This data powers our public [COVIDcast
 map](https://delphi.cmu.edu/covidcast/) which includes testing, cases, and death data,
 as well as unique healthcare and survey data Delphi acquires through its
-partners. The API allows users to select specific signals and download data for
-selected geographical areas---counties, states, metropolitan statistical areas,
-and other divisions.
+partners. Many additional data sources and pathogen indicator types are available. The API allows users to select specific signals and download data for
+selected geographical areas. For a comprehensive look at the sources, signals, and geographic regions available through the API, please visit [EpiPortal](https://delphi.cmu.edu/epiportal/?hosted_by_delphi=on).
 
 
-> **Get updates:** Delphi operates a [mailing list](https://lists.andrew.cmu.edu/mailman/listinfo/delphi-covidcast-api) for users of the COVIDcast API. We will use the list to announce API changes, corrections to data, and new features; API users may also use the mailing list to ask general questions about its use. If you use the API, we strongly encourage you to [subscribe](https://lists.andrew.cmu.edu/mailman/listinfo/delphi-covidcast-api).
+> **Get updates:** Delphi operates a [mailing list](https://lists.andrew.cmu.edu/mailman/listinfo/delphi-covidcast-api) for users of the main Epidata API. We will use the list to announce API changes, corrections to data, and new features; API users may also use the mailing list to ask general questions about its use. If you use the API, we strongly encourage you to [subscribe](https://lists.andrew.cmu.edu/mailman/listinfo/delphi-covidcast-api).
 {: .important }
 
 ## Table of contents
@@ -28,7 +27,7 @@ and other divisions.
 {:toc}
 
 ## Licensing
-Like all other Delphi Epidata datasets, our COVIDcast data is freely available to the public. However, our COVID-19 indicators include data from many different sources, with data licensing handled separately for each source. For a summary of the licenses used and a list of the indicators each license applies to, we suggest users visit our [COVIDcast licensing](covidcast_licensing.md) page. Licensing information is also summarized on each indicator's details page.
+Like all other Delphi Epidata datasets, our data is freely available to the public. However, our indicators include data from many different sources, with data licensing handled separately for each source. For a summary of the licenses used and a list of the indicators each license applies to, we suggest users visit our [licensing](covidcast_licensing.md) page. Licensing information is also summarized on each indicator's details page.
 We encourage academic users to [cite](README.md#citing) the data if they
 use it in any publications. Our [data ingestion
 code](https://github.com/cmu-delphi/covidcast-indicators) and [API server
@@ -39,9 +38,9 @@ in the [API overview](README.md).
 ## Accessing the Data
 
 Our [COVIDcast site](https://delphi.cmu.edu/covidcast/) provides an interactive
-visualization of a select set of the data signals available in the COVIDcast
-API, and provides a data export feature to download any data range as a
-CSV file.
+visualization of a select set of the data signals available and relevant
+during the COVID-19 pandemic, and provides a data export feature to download
+any data range as a CSV file.
 
 Several [API clients are available](covidcast_clients.md) for common programming
 languages, so you do not need to construct API calls yourself to obtain
@@ -93,13 +92,13 @@ Alternatively, users can [manually construct URLs and parse responses to access 
 The API provides multiple data sources, each with several signals. Each source
 represents one provider of data, such as a medical testing provider or a symptom
 survey, and each signal represents one quantity computed from data provided by
-that source. Our sources provide detailed data about COVID-related topics,
+that source. Our sources provide detailed data about infectious disease related topics,
 including confirmed cases, symptom-related search queries, hospitalizations,
 outpatient doctor's visits, and other sources. Many of these are publicly
-available *only* through the COVIDcast API.
+available *only* through the main Epidata API.
 
-Delphi's COVID-19 indicators data includes the following data sources.
-Data from most of these sources is typically updated daily. You can use the
+Update cadence varies by source, reflecting what is most relevant for each
+pathogen and context. You can use the
 [`covidcast_meta`](covidcast_meta.md) endpoint to get summary information
 about the ranges of the different attributes for the different data sources.
 

--- a/docs/api/date_formats.md
+++ b/docs/api/date_formats.md
@@ -1,6 +1,6 @@
 ---
 title: Date Formats
-parent: Other Endpoints (COVID-19 and Other Diseases)
+parent: Other Endpoints
 nav_order: 901
 ---
 

--- a/docs/api/epidata_signals.md
+++ b/docs/api/epidata_signals.md
@@ -1,6 +1,6 @@
 ---
 title: Data Sources and Signals
-parent: Other Endpoints (COVID-19 and Other Diseases)
+parent: Other Endpoints
 nav_order: 2
 has_children: true
 

--- a/docs/api/flusurv.md
+++ b/docs/api/flusurv.md
@@ -1,7 +1,7 @@
 ---
 title: Flusurv
 parent: Data Sources and Signals
-grand_parent: Other Endpoints (COVID-19 and Other Diseases)
+grand_parent: Other Endpoints
 nav_order: 3
 ---
 

--- a/docs/api/fluview.md
+++ b/docs/api/fluview.md
@@ -1,7 +1,7 @@
 ---
 title: FluView
 parent: Data Sources and Signals
-grand_parent: Other Endpoints (COVID-19 and Other Diseases)
+grand_parent: Other Endpoints
 nav_order: 1
 ---
 

--- a/docs/api/fluview_clinical.md
+++ b/docs/api/fluview_clinical.md
@@ -1,7 +1,7 @@
 ---
 title: FluView Clinical
 parent: Data Sources and Signals
-grand_parent: Other Endpoints (COVID-19 and Other Diseases)
+grand_parent: Other Endpoints
 nav_order: 2
 ---
 

--- a/docs/api/fluview_meta.md
+++ b/docs/api/fluview_meta.md
@@ -1,7 +1,7 @@
 ---
 title: FluView Metadata
 parent: Data Sources and Signals
-grand_parent: Other Endpoints (COVID-19 and Other Diseases)
+grand_parent: Other Endpoints
 nav_order: 1
 ---
 

--- a/docs/api/geographic_codes.md
+++ b/docs/api/geographic_codes.md
@@ -1,6 +1,6 @@
 ---
 title: Geographic Codes
-parent: Other Endpoints (COVID-19 and Other Diseases)
+parent: Other Endpoints
 nav_order: 900
 ---
 

--- a/docs/api/inactive_other.md
+++ b/docs/api/inactive_other.md
@@ -1,7 +1,7 @@
 ---
 title: Inactive Sources (Other)
 parent: Data Sources and Signals
-grand_parent: Other Endpoints (COVID-19 and Other Diseases)
+grand_parent: Other Endpoints
 nav_order: 99
 has_children: true
 ---

--- a/docs/api/rvdss.md
+++ b/docs/api/rvdss.md
@@ -1,6 +1,6 @@
 ---
 parent: Data Sources and Signals
-grand_parent: Other Endpoints (COVID-19 and Other Diseases)
+grand_parent: Other Endpoints
 title: Respiratory Virus Detections in Canada
 nav_order: 4
 ---

--- a/docs/epidata_development.md
+++ b/docs/epidata_development.md
@@ -182,5 +182,5 @@ Additional internal documentation for Sentry can be found [here](https://booksta
 ## COVIDcast Development Guide
 
 For information on accessing Delphi's COVID-19 indicators via the `covidcast` endpoint of [Delphi](https://delphi.cmu.edu/)'s
-epidemiological data API, please see [COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast.html). This API provides data on the spread and impact of the COVID-19 pandemic across the United States, most of which is available at the
+epidemiological data API, please see [COVIDcast Epidata API](https://cmu-delphi.github.io/delphi-epidata/api/covidcast.html). This API provides data on the spread and impact of fast-moving contagious diseases, including COVID-19, across the United States, most of which is available at the
 county level and updated daily.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,12 +6,13 @@ nav_order: 1
 
 # The Epidata API
 
-Delphi's Epidata API provides real-time access to epidemiological surveillance data.
+Delphi's Epidata API provides real-time access to epidemiological surveillance data
+for tracking fast-moving contagious diseases across the United States.
 It is built and maintained by the Carnegie Mellon University [Delphi research
 group](https://delphi.cmu.edu/). The Epidata API includes:
 
 * The [Delphi V5 API](api/v5.md), serving real-time, high-resolution signals for public health surveillance.
-* The [main endpoint (COVIDcast)](api/covidcast.md), providing daily updates about current COVID-19 and influenza activity across the United States.
+* The [main endpoint (COVIDcast)](api/covidcast.md), providing daily updates about current activity for fast-moving contagious diseases such as COVID-19 and influenza across the United States.
 * A [variety of other endpoints](api/README.md), providing primarily historical data about various diseases including COVID-19, influenza, dengue fever, and norovirus in several countries.
 
 A [full-featured R client](api/client_libraries.md) is available for quick access to all data. While we continue developing a full-featured Python client, the [legacy Python client](api/client_libraries.md#python) remains available. The main endpoint can also be accessed with a [dedicated COVIDcast client](api/covidcast_clients.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,12 +7,12 @@ nav_order: 1
 # The Epidata API
 
 Delphi's Epidata API provides real-time access to epidemiological surveillance data
-for tracking fast-moving contagious diseases across the United States.
+for tracking infectious diseases across the United States.
 It is built and maintained by the Carnegie Mellon University [Delphi research
 group](https://delphi.cmu.edu/). The Epidata API includes:
 
 * The [Delphi V5 API](api/v5.md), serving real-time, high-resolution signals for public health surveillance.
-* The [main endpoint (COVIDcast)](api/covidcast.md), providing daily updates about current activity for fast-moving contagious diseases such as COVID-19 and influenza across the United States.
+* The [main endpoint (COVIDcast)](api/covidcast.md), providing frequent updates about current activity for infectious diseases such as COVID-19 and influenza across the United States.
 * A [variety of other endpoints](api/README.md), providing primarily historical data about various diseases including COVID-19, influenza, dengue fever, and norovirus in several countries.
 
 A [full-featured R client](api/client_libraries.md) is available for quick access to all data. While we continue developing a full-featured Python client, the [legacy Python client](api/client_libraries.md#python) remains available. The main endpoint can also be accessed with a [dedicated COVIDcast client](api/covidcast_clients.md).


### PR DESCRIPTION
### Summary:

This PR updates the documentation to reference the pandemic and COVID-19 in a way that emphasizes tracking rapidly spreading contagious diseases across the US.

I found other references to COVID-19 and the pandemic, but I believe it's best to leave them as they are. E.g.:
- COVID-19 Trends and Impact Survey. It's an archived COVID-specific product.
- docs/api/covidcast*.md, docs/api/covid_hosp*.md, docs/api/covidcast-signals/*.md document the actual COVIDcast and covid_hosp endpoints/signals.
- api/v5.md:32 states that it "emerged from the rapid demands of the COVID-19 response," but I don't think this makes COVID-19 too central.

### Prerequisites:

- [X] Unless it is a documentation hotfix it should be merged against the `dev` branch
- [X] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [X] Build is successful
- [X] Code is cleaned up and formatted
